### PR TITLE
fix: address duplication in address list

### DIFF
--- a/src/ui/component/AddressList/index.tsx
+++ b/src/ui/component/AddressList/index.tsx
@@ -10,6 +10,7 @@ import React, {
 import clsx from 'clsx';
 import { findIndex } from 'lodash';
 import { FixedSizeList, areEqual } from 'react-window';
+import { sortBy, unionBy } from 'lodash';
 import { DisplayedKeryring } from 'background/service/keyring';
 import { KEYRING_TYPE } from 'consts';
 import AddressItem, { AddressItemProps } from './AddressItem';
@@ -101,18 +102,18 @@ const AddressList: any = forwardRef(
     useImperativeHandle(ref, () => ({
       updateAllBalance,
     }));
-    const combinedList = list
-      .sort((a, b) => {
-        return SORT_WEIGHT[a.type] - SORT_WEIGHT[b.type];
-      })
-      .map((group) => {
-        const templist = group.accounts.map(
-          (item) =>
-            (item = { ...item, type: group.type, keyring: group.keyring })
-        );
-        return templist;
-      })
-      .flat(1);
+    const combinedList = unionBy(
+      sortBy(list, (item) => SORT_WEIGHT[item.type])
+        .map((group) => {
+          const templist = group.accounts.map(
+            (item) =>
+              (item = { ...item, type: group.type, keyring: group.keyring })
+          );
+          return templist;
+        })
+        .flat(1),
+      (item) => `${item.keyring.type}-${item.address.toLowerCase()}`
+    );
     const itemKey = useCallback(
       (index: number, data: any) =>
         data.combinedList[index].address + data.combinedList[index].brandName,


### PR DESCRIPTION
1. Sometimes when import Ledger address will create 2 duplicate keyrings, this will make address duplication
![image](https://user-images.githubusercontent.com/86296331/142801368-9c30be2c-518e-4c5c-b8b3-bdabfad00e0d.png)


2. Private keyring is independent means when we import via pk will create new keyring every time which will cause order issue
![image](https://user-images.githubusercontent.com/86296331/142801458-5a9c7a82-2198-49fd-abb6-4b6aaaab969f.png)
