### PR TITLE
fix: make defaultLocale as english no matter what language is accepted

### DIFF
--- a/src/background/service/preference.ts
+++ b/src/background/service/preference.ts
@@ -33,11 +33,7 @@ class PreferenceService {
   hasOtherProvider = false;
 
   init = async () => {
-    let defaultLang = 'en';
-    const acceptLangs = await this.getAcceptLanguages();
-    if (acceptLangs.length > 0) {
-      defaultLang = acceptLangs[0];
-    }
+    const defaultLang = 'en';
     this.store = await createPersistStore<PreferenceStore>({
       name: 'preference',
       template: {


### PR DESCRIPTION
To avoid a non-chinese user use Chinese as default locale since some wired config

FYI #349 