### PR TITLE
feat: still use react window, add load locker

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-ga": "^3.3.0",
-    "react-infinite-scroll-component": "^6.1.0",
     "react-markdown": "^7.1.0",
     "react-router-dom": "^5.2.0",
     "react-use": "^17.2.4",

--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -633,6 +633,15 @@ export class WalletController extends BaseController {
       keyring.useWebUSB(isWebUSB);
     }
 
+    if (
+      type === KEYRING_CLASS.HARDWARE.LEDGER &&
+      !isWebUSB &&
+      stashKeyringId !== null
+    ) {
+      keyring.updateTransportMethod &&
+        (await keyring.updateTransportMethod(true));
+    }
+
     return stashKeyringId;
   };
 

--- a/src/ui/component/AddressList/AddressItem.tsx
+++ b/src/ui/component/AddressList/AddressItem.tsx
@@ -51,6 +51,7 @@ export interface AddressItemProps {
   importedLength?: number;
   canEditing?(editing: boolean): void;
   stopEditing?: boolean;
+  retriveAlianName?(): void;
 }
 
 const formatChain = (item: ChainWithBalance): DisplayChainWithWhiteLogo => {
@@ -133,13 +134,13 @@ const AddressItem = memo(
     importedLength = 0,
     canEditing,
     stopEditing = false,
+    retriveAlianName,
   }: AddressItemProps) => {
     if (!account) {
       return null;
     }
     const { t } = useTranslation();
     const wallet = useWallet();
-
     const [alianName, setAlianName] = useState<string>(
       account?.alianName || ''
     );
@@ -183,6 +184,7 @@ const AddressItem = memo(
     };
     const updateAlianName = async (alianName) => {
       await wallet.updateAlianName(account?.address?.toLowerCase(), alianName);
+      retriveAlianName && retriveAlianName();
     };
     const changeName = async () => {
       if (!alianName) {
@@ -226,6 +228,9 @@ const AddressItem = memo(
             'flex items-center relative',
             isDisabled && 'opacity-40'
           )}
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
         >
           {showImportIcon && (
             <Tooltip

--- a/src/ui/component/AddressList/index.tsx
+++ b/src/ui/component/AddressList/index.tsx
@@ -72,7 +72,6 @@ const Row: React.FC<RowProps> = memo((props) => {
           currentAccount={currentAccount}
           canEditing={setStopEditing}
           stopEditing={stopEditing || editIndex !== index}
-          editIndex={setEditIndex}
           index={index}
           showAssets
           className="h-[56px] pl-16"

--- a/src/ui/component/AddressViewer/index.tsx
+++ b/src/ui/component/AddressViewer/index.tsx
@@ -29,9 +29,16 @@ export default ({
       onClick={onClick}
       style={{ cursor: onClick ? 'pointer' : 'inherit' }}
     >
-      <div className={cx('address-viewer-text', className)} title={address}>
+      <div
+        className={cx('address-viewer-text', className)}
+        title={address?.toLowerCase()}
+      >
         {showIndex && index > 0 && <div className="number-index">{index}</div>}
-        {ellipsis ? `${address.slice(0, 6)}...${address.slice(-4)}` : address}
+        {ellipsis
+          ? `${address
+              ?.toLowerCase()
+              .slice(0, 6)}...${address?.toLowerCase().slice(-4)}`
+          : address?.toLowerCase()}
       </div>
       {showArrow && (
         <SvgIconArrowDown className="ml-1 cursor-pointer fill-current text-white opacity-80" />

--- a/src/ui/component/MultiSelectAddressList.tsx
+++ b/src/ui/component/MultiSelectAddressList.tsx
@@ -28,7 +28,7 @@ const Row = (props) => {
   const { data, index, style } = props;
   const { accounts, others } = data;
   const { importedAccounts, _value, loading, isPopup, handleToggle } = others;
-  //console.log(accounts, 88);
+
   const { t } = useTranslation();
   const imported =
     (accounts.length > 0 &&

--- a/src/ui/component/MultiSelectAddressList.tsx
+++ b/src/ui/component/MultiSelectAddressList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { FixedSizeList, areEqual } from 'react-window';
+import { FixedSizeList } from 'react-window';
 import { Skeleton } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { FieldCheckbox } from 'ui/component';
@@ -24,7 +24,74 @@ interface MultiSelectAddressListArgs {
   loading?: boolean;
   isPopup?: boolean;
 }
-
+const Row = (props) => {
+  const { data, index, style } = props;
+  const { accounts, others } = data;
+  const { importedAccounts, _value, loading, isPopup, handleToggle } = others;
+  //console.log(accounts, 88);
+  const { t } = useTranslation();
+  const imported =
+    (accounts.length > 0 &&
+      importedAccounts &&
+      importedAccounts.length > 0 &&
+      importedAccounts
+        ?.map((address) => address.toLowerCase())
+        .includes(accounts[index].address.toLowerCase())) ||
+    0;
+  const selected = _value.includes(index + 1);
+  return !loading && accounts[index] ? (
+    <div
+      style={style}
+      key={index}
+      className={isPopup ? 'addresses' : 'hard-address'}
+    >
+      <FieldCheckbox
+        checked={selected}
+        onChange={() => handleToggle(index)}
+        disable={
+          imported && (
+            <span
+              className={clsx(
+                'rounded-full bg-gray-bg text-gray-comment text-12 px-[5px] py-[3px]'
+              )}
+            >
+              {t('Imported')}
+            </span>
+          )
+        }
+      >
+        <AddressItem
+          account={{
+            address: accounts[index].address,
+            type: accounts[index].type,
+            brandName: BRAND_ALIAN_TYPE_TEXT[accounts[index].type],
+          }}
+          noNeedBalance={!imported}
+          showAssets={imported}
+          className="select-address-item"
+          editing={false}
+          showImportIcon={false}
+          index={accounts[index].index}
+          showIndex={true}
+        />
+      </FieldCheckbox>
+    </div>
+  ) : (
+    <div
+      style={style}
+      key={index}
+      className={isPopup ? 'addresses' : 'hard-address'}
+    >
+      <div className={clsx('skeleton items-center', { 'w-[460px]': !isPopup })}>
+        <Skeleton.Input
+          active
+          className="items-center"
+          style={{ width: index % 2 ? 140 : 160 }}
+        />
+      </div>
+    </div>
+  );
+};
 const MultiSelectAddressList = ({
   accounts,
   onChange,
@@ -38,7 +105,6 @@ const MultiSelectAddressList = ({
   loading,
   isPopup,
 }: MultiSelectAddressListArgs) => {
-  const { t } = useTranslation();
   const fixedList = useRef<FixedSizeList>();
   const [_value, , , handleToggle] = useSelectOption<number>({
     onChange,
@@ -53,73 +119,6 @@ const MultiSelectAddressList = ({
       fixedList.current?.scrollToItem(end, 'center');
     }
   }, [loadLength, end]);
-  const Row = (props) => {
-    const { data, index, style, isScrolling } = props;
-    const { accounts } = data;
-    //console.log(accounts, 88);
-    const imported =
-      importedAccounts &&
-      importedAccounts.length > 0 &&
-      importedAccounts
-        ?.map((address) => address.toLowerCase())
-        .includes(accounts[index].address.toLowerCase());
-    const selected = _value.includes(index + 1);
-    //console.log(accounts, 99999);
-    return !loading && accounts[index] ? (
-      <div
-        style={style}
-        key={index}
-        className={isPopup ? 'addresses' : 'hard-address'}
-      >
-        <FieldCheckbox
-          checked={selected}
-          onChange={() => handleToggle(index)}
-          disable={
-            imported && (
-              <span
-                className={clsx(
-                  'rounded-full bg-gray-bg text-gray-comment text-12 px-[5px] py-[3px]'
-                )}
-              >
-                {t('Imported')}
-              </span>
-            )
-          }
-        >
-          <AddressItem
-            account={{
-              address: accounts[index].address,
-              type,
-              brandName: BRAND_ALIAN_TYPE_TEXT[type],
-            }}
-            noNeedBalance={!imported}
-            showAssets={imported}
-            className="select-address-item"
-            editing={false}
-            showImportIcon={false}
-            index={accounts[index].index}
-            showIndex={true}
-          />
-        </FieldCheckbox>
-      </div>
-    ) : (
-      <div
-        style={style}
-        key={index}
-        className={isPopup ? 'addresses' : 'hard-address'}
-      >
-        <div
-          className={clsx('skeleton items-center', { 'w-[460px]': !isPopup })}
-        >
-          <Skeleton.Input
-            active
-            className="items-center"
-            style={{ width: index % 2 ? 140 : 160 }}
-          />
-        </div>
-      </div>
-    );
-  };
   const onItemsRendered = ({ overscanStartIndex, overscanStopIndex }) => {
     if (overscanStopIndex + 5 > accounts.length) {
       loadMoreItems && loadMoreItems();
@@ -130,7 +129,14 @@ const MultiSelectAddressList = ({
       height={isPopup ? 500 : 340}
       width={isPopup ? 360 : 460}
       itemData={{
-        accounts,
+        accounts: accounts,
+        others: {
+          importedAccounts,
+          _value,
+          loading,
+          isPopup,
+          handleToggle,
+        },
       }}
       itemCount={accounts.length}
       itemSize={60}

--- a/src/ui/component/MultiSelectAddressList.tsx
+++ b/src/ui/component/MultiSelectAddressList.tsx
@@ -1,12 +1,5 @@
-import React, {
-  useEffect,
-  useRef,
-  forwardRef,
-  useImperativeHandle,
-  memo,
-} from 'react';
-import { chunk } from 'lodash';
-import InfiniteScroll from 'react-infinite-scroll-component';
+import React, { useEffect, useRef } from 'react';
+import { FixedSizeList, areEqual } from 'react-window';
 import { Skeleton } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { FieldCheckbox } from 'ui/component';
@@ -15,7 +8,6 @@ import { useSelectOption } from 'ui/utils';
 import { BRAND_ALIAN_TYPE_TEXT } from 'consts';
 import './index.less';
 import clsx from 'clsx';
-
 interface MultiSelectAddressListArgs {
   accounts: Array<{
     address: string;
@@ -27,215 +19,129 @@ interface MultiSelectAddressListArgs {
   importedAccounts?: string[];
   changeSelectedNumbers?(arg: number): void;
   end?: number;
-  loadMoreItems?(page: number): void;
+  loadMoreItems?(): void;
   loadLength?: number;
+  loading?: boolean;
   isPopup?: boolean;
-  onLoadPage?(page: number): Promise<void>;
 }
 
-const Row = ({
-  account,
-  index,
-  importedAccounts,
+const MultiSelectAddressList = ({
+  accounts,
+  onChange,
   value,
-  isPopup,
+  importedAccounts,
   type,
-  handleToggle,
-}: {
-  account: string;
-  type: string;
-  index: number;
-  importedAccounts?: string[];
-  value: number[];
-  isPopup?: boolean;
-  handleToggle(index: number): void;
-}) => {
-  const imported =
-    importedAccounts &&
-    importedAccounts.length > 0 &&
-    importedAccounts
-      ?.map((address) => address.toLowerCase())
-      .includes(account.toLowerCase());
-  const selected = value.includes(index + 1);
-  const loading = !account;
+  end,
+  changeSelectedNumbers,
+  loadMoreItems,
+  loadLength,
+  loading,
+  isPopup,
+}: MultiSelectAddressListArgs) => {
   const { t } = useTranslation();
-
-  return !loading ? (
-    <div key={index} className={isPopup ? 'address' : 'hard-address'}>
-      <FieldCheckbox
-        checked={selected}
-        onChange={() => handleToggle(index)}
-        disable={
-          imported && (
-            <span
-              className={clsx(
-                'rounded-full bg-gray-bg text-gray-comment text-12 px-[5px] py-[3px]'
-              )}
-            >
-              {t('Imported')}
-            </span>
-          )
-        }
+  const fixedList = useRef<FixedSizeList>();
+  const [_value, , , handleToggle] = useSelectOption<number>({
+    onChange,
+    value,
+    options: accounts.map((x) => x.index),
+  });
+  useEffect(() => {
+    changeSelectedNumbers && changeSelectedNumbers(_value.length);
+  }, [_value]);
+  useEffect(() => {
+    if (end) {
+      fixedList.current?.scrollToItem(end, 'center');
+    }
+  }, [loadLength, end]);
+  const Row = (props) => {
+    const { data, index, style, isScrolling } = props;
+    const { accounts } = data;
+    //console.log(accounts, 88);
+    const imported =
+      importedAccounts &&
+      importedAccounts.length > 0 &&
+      importedAccounts
+        ?.map((address) => address.toLowerCase())
+        .includes(accounts[index].address.toLowerCase());
+    const selected = _value.includes(index + 1);
+    //console.log(accounts, 99999);
+    return !loading && accounts[index] ? (
+      <div
+        style={style}
+        key={index}
+        className={isPopup ? 'addresses' : 'hard-address'}
       >
-        <AddressItem
-          account={{
-            address: account,
-            type,
-            brandName: BRAND_ALIAN_TYPE_TEXT[type],
-          }}
-          noNeedBalance={!imported}
-          showAssets={imported}
-          className="select-address-item"
-          editing={false}
-          showImportIcon={false}
-          index={index}
-          showIndex={true}
-        />
-      </FieldCheckbox>
-    </div>
-  ) : (
-    <div key={index} className={isPopup ? 'address' : 'hard-address'}>
-      <div className={clsx('skeleton items-center', { 'w-[460px]': !isPopup })}>
-        <Skeleton.Input
-          active
-          className="items-center"
-          style={{ width: index % 2 ? 140 : 160 }}
-        />
+        <FieldCheckbox
+          checked={selected}
+          onChange={() => handleToggle(index)}
+          disable={
+            imported && (
+              <span
+                className={clsx(
+                  'rounded-full bg-gray-bg text-gray-comment text-12 px-[5px] py-[3px]'
+                )}
+              >
+                {t('Imported')}
+              </span>
+            )
+          }
+        >
+          <AddressItem
+            account={{
+              address: accounts[index].address,
+              type,
+              brandName: BRAND_ALIAN_TYPE_TEXT[type],
+            }}
+            noNeedBalance={!imported}
+            showAssets={imported}
+            className="select-address-item"
+            editing={false}
+            showImportIcon={false}
+            index={accounts[index].index}
+            showIndex={true}
+          />
+        </FieldCheckbox>
       </div>
-    </div>
+    ) : (
+      <div
+        style={style}
+        key={index}
+        className={isPopup ? 'addresses' : 'hard-address'}
+      >
+        <div
+          className={clsx('skeleton items-center', { 'w-[460px]': !isPopup })}
+        >
+          <Skeleton.Input
+            active
+            className="items-center"
+            style={{ width: index % 2 ? 140 : 160 }}
+          />
+        </div>
+      </div>
+    );
+  };
+  const onItemsRendered = ({ overscanStartIndex, overscanStopIndex }) => {
+    if (overscanStopIndex + 5 > accounts.length) {
+      loadMoreItems && loadMoreItems();
+    }
+  };
+  return (
+    <FixedSizeList
+      height={isPopup ? 500 : 340}
+      width={isPopup ? 360 : 460}
+      itemData={{
+        accounts,
+      }}
+      itemCount={accounts.length}
+      itemSize={60}
+      ref={fixedList}
+      useIsScrolling
+      onItemsRendered={onItemsRendered}
+      className="no-scrollbars"
+    >
+      {Row}
+    </FixedSizeList>
   );
 };
-
-const Group = memo(
-  ({
-    addresses,
-    index,
-    groupCount = 10,
-    importedAccounts,
-    value,
-    type,
-    isPopup,
-    handleToggle,
-    onLoadPage,
-  }: {
-    addresses: { address: string; index: number }[];
-    index: number;
-    groupCount: number;
-    importedAccounts?: string[];
-    value: number[];
-    type: string;
-    isPopup?: boolean;
-    handleToggle(index: number): void;
-    onLoadPage?(page: number): Promise<void>;
-  }) => {
-    const groupEl = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-      const intersectionObserver = new IntersectionObserver(function (entries) {
-        if (entries[0].intersectionRatio <= 0) return;
-        onLoadPage && onLoadPage(index + 1);
-      });
-      intersectionObserver.observe(groupEl.current!);
-      return () => {
-        intersectionObserver.disconnect();
-      };
-    }, []);
-
-    return (
-      <div ref={groupEl}>
-        {addresses.map((account) => (
-          <Row
-            account={account.address}
-            index={account.index}
-            importedAccounts={importedAccounts}
-            value={value}
-            type={type}
-            isPopup={isPopup}
-            handleToggle={handleToggle}
-          />
-        ))}
-      </div>
-    );
-  }
-);
-
-const MultiSelectAddressList = forwardRef(
-  (
-    {
-      accounts,
-      onChange,
-      value,
-      importedAccounts,
-      type,
-      changeSelectedNumbers,
-      loadMoreItems,
-      isPopup,
-      onLoadPage,
-    }: MultiSelectAddressListArgs,
-    ref
-  ) => {
-    const [_value, , , handleToggle] = useSelectOption<number>({
-      onChange,
-      value,
-      options: accounts.map((x) => x.index),
-    });
-    const scrollEl = useRef<HTMLDivElement>(null);
-
-    const handleLoadMore = () => {
-      const nextPage = accounts.length / 10 + 1;
-      loadMoreItems && loadMoreItems(nextPage);
-    };
-
-    useEffect(() => {
-      changeSelectedNumbers && changeSelectedNumbers(_value.length);
-    }, [_value]);
-
-    useImperativeHandle(ref, () => ({
-      scrollTo: (index: number) => {
-        const PER_HEIGHT = 60;
-        if (scrollEl.current) {
-          scrollEl.current.scrollTo({
-            top: PER_HEIGHT * index,
-          });
-        }
-      },
-    }));
-
-    return (
-      <div
-        id="scrollableDiv"
-        style={{
-          height: (isPopup ? 360 : 340) + 'px',
-          width: (isPopup ? 360 : 460) + 'px',
-          overflow: 'auto',
-        }}
-        ref={scrollEl}
-      >
-        <InfiniteScroll
-          hasMore={true}
-          next={handleLoadMore}
-          dataLength={accounts.length}
-          loader={<></>}
-          className="no-scrollbars"
-          scrollableTarget="scrollableDiv"
-        >
-          {chunk(accounts, 10).map((group, groupIndex) => (
-            <Group
-              addresses={group}
-              index={groupIndex}
-              groupCount={10}
-              importedAccounts={importedAccounts}
-              value={_value}
-              type={type}
-              handleToggle={handleToggle}
-              isPopup={isPopup}
-              onLoadPage={onLoadPage}
-            />
-          ))}
-        </InfiniteScroll>
-      </div>
-    );
-  }
-);
 
 export default MultiSelectAddressList;

--- a/src/ui/views/AddressManagement/index.tsx
+++ b/src/ui/views/AddressManagement/index.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory } from 'react-router-dom';
 import { Menu, Dropdown, message } from 'antd';
+import { FixedSizeList } from 'react-window';
 import { KEYRING_TYPE, HARDWARE_KEYRING_TYPES } from 'consts';
 import { useWallet } from 'ui/utils';
 import {
@@ -11,6 +12,7 @@ import {
   Modal,
   StrayFooter,
 } from 'ui/component';
+import AddressItem from 'ui/component/AddressList/AddressItem';
 import { DisplayedKeryring } from 'background/service/keyring';
 import { Account } from 'background/service/preference';
 import DisplayKeyring from 'background/service/keyring/display';
@@ -18,15 +20,26 @@ import { SvgIconPlusPrimary } from 'ui/assets';
 import IconHint from 'ui/assets/hint.png';
 import IconSuccess from 'ui/assets/success.svg';
 import './style.less';
-
+import clsx from 'clsx';
+const SORT_WEIGHT = {
+  [KEYRING_TYPE.HdKeyring]: 1,
+  [KEYRING_TYPE.SimpleKeyring]: 2,
+  [KEYRING_TYPE.HardwareKeyring]: 3,
+  [KEYRING_TYPE.WalletConnectKeyring]: 4,
+  [KEYRING_TYPE.WatchAddressKeyring]: 5,
+};
 const { Nav: StrayFooterNav } = StrayFooter;
 
 const AddressManagement = () => {
   const wallet = useWallet();
   const { t } = useTranslation();
   const [accounts, setAccounts] = useState<DisplayedKeryring[]>([]);
+  const [displayList, setDisplayList] = useState([]);
+
   const [alianNames, setAlianNames] = useState<[]>([]);
   const [noAccount, setNoAccount] = useState(false);
+  const [stopEditing, setStopEditing] = useState(true);
+  const [editIndex, setEditIndex] = useState(0);
   const [hiddenAddresses, setHiddenAddresses] = useState<
     { type: string; address: string }[]
   >([]);
@@ -52,9 +65,28 @@ const AddressManagement = () => {
   const getAllKeyrings = async () => {
     const _accounts = await wallet.getAllClassAccounts();
     const allAlianNames = await wallet.getAllAlianName();
-
     setAccounts(_accounts);
     setAlianNames(allAlianNames);
+    const list = _accounts
+      .sort((a, b) => {
+        return SORT_WEIGHT[a.type] - SORT_WEIGHT[b.type];
+      })
+      .map((group) => {
+        const templist = group.accounts.map(
+          (item) =>
+            (item = {
+              ...item,
+              alianName: allAlianNames[item.address.toLowerCase()],
+              type: group.type,
+              keyring: group.keyring,
+            })
+        );
+        return templist;
+      })
+      .flat(1);
+    if (list.length > 0) {
+      setDisplayList(list);
+    }
   };
 
   const handleViewMnemonics = async () => {
@@ -221,7 +253,7 @@ const AddressManagement = () => {
       </div>
     );
   };
-
+  const fixedList = useRef<FixedSizeList>();
   useEffect(() => {
     getAllKeyrings();
   }, []);
@@ -243,22 +275,68 @@ const AddressManagement = () => {
       </Link>
     </div>
   );
-
+  const Row = (props) => {
+    const { data, index, style } = props;
+    const account = data[index];
+    const [canEdit, setCanEdit] = useState(!stopEditing && index === editIndex);
+    const startEdit = (editing: boolean) => {
+      setCanEdit(editing);
+      if (editing) {
+        setEditIndex(index);
+        setStopEditing(false);
+      } else {
+        setStopEditing(true);
+      }
+    };
+    return (
+      <li className="address-wrap-with-padding" style={style}>
+        <ul className="addresses">
+          <AddressItem
+            key={account.address + account.brandName}
+            account={{ ...account, type: account.type }}
+            keyring={account.keyring}
+            ActionButton={AddressActionButton}
+            hiddenAddresses={hiddenAddresses}
+            index={index}
+            stopEditing={!canEdit}
+            canEditing={startEdit}
+            className="h-[56px] pl-16"
+          />
+        </ul>
+      </li>
+    );
+  };
   return (
-    <div className="address-management">
+    <div
+      className="address-management"
+      onClick={(e) => {
+        e.stopPropagation();
+        setStopEditing(true);
+      }}
+    >
       <PageHeader>{t('Address Management')}</PageHeader>
       {noAccount ? (
         NoAddressUI
       ) : (
         <>
-          <AddressList
-            list={accounts}
-            action="management"
-            ActionButton={AddressActionButton}
-            hiddenAddresses={hiddenAddresses}
-            onShowMnemonics={handleViewMnemonics}
-            alianNames={alianNames}
-          />
+          <ul
+            className={'address-group-list management'}
+            onClick={(e) => {
+              e.stopPropagation();
+              setStopEditing(true);
+            }}
+          >
+            <FixedSizeList
+              height={500}
+              width="100%"
+              itemData={displayList}
+              itemCount={displayList.length}
+              itemSize={64}
+              ref={fixedList}
+            >
+              {Row}
+            </FixedSizeList>
+          </ul>
           <StrayFooterNav
             hasDivider
             onNextClick={() => {

--- a/src/ui/views/AddressManagement/index.tsx
+++ b/src/ui/views/AddressManagement/index.tsx
@@ -37,6 +37,7 @@ const AddressManagement = () => {
   const [displayList, setDisplayList] = useState([]);
 
   const [alianNames, setAlianNames] = useState<[]>([]);
+  const [retrive, setRetrive] = useState(false);
   const [noAccount, setNoAccount] = useState(false);
   const [stopEditing, setStopEditing] = useState(true);
   const [editIndex, setEditIndex] = useState(0);
@@ -256,7 +257,8 @@ const AddressManagement = () => {
   const fixedList = useRef<FixedSizeList>();
   useEffect(() => {
     getAllKeyrings();
-  }, []);
+    setRetrive(false);
+  }, [retrive]);
 
   const NoAddressUI = (
     <div className="no-address">
@@ -288,6 +290,9 @@ const AddressManagement = () => {
         setStopEditing(true);
       }
     };
+    const retriveAlianName = () => {
+      setRetrive(true);
+    };
     return (
       <li className="address-wrap-with-padding" style={style}>
         <ul className="addresses">
@@ -300,6 +305,7 @@ const AddressManagement = () => {
             index={index}
             stopEditing={!canEdit}
             canEditing={startEdit}
+            retriveAlianName={retriveAlianName}
             className="h-[56px] pl-16"
           />
         </ul>

--- a/src/ui/views/Approval/components/WatchAdrressWaiting.tsx
+++ b/src/ui/views/Approval/components/WatchAdrressWaiting.tsx
@@ -291,7 +291,7 @@ const Process = ({
 const WatchAddressWaiting = ({ params }: { params: ApprovalParams }) => {
   const wallet = useWallet();
   const [connectStatus, setConnectStatus] = useState(
-    WALLETCONNECT_STATUS_MAP.PENDING
+    WALLETCONNECT_STATUS_MAP.WAITING
   );
   const [connectError, setConnectError] = useState<null | {
     code?: number;
@@ -414,7 +414,7 @@ const WatchAddressWaiting = ({ params }: { params: ApprovalParams }) => {
         <img src={Mask} className="mask" />
       </div>
       <div className="watchaddress-operation">
-        {connectStatus === WALLETCONNECT_STATUS_MAP.PENDING ? (
+        {connectStatus === WALLETCONNECT_STATUS_MAP.PENDING && qrcodeContent ? (
           <Scan
             uri={qrcodeContent}
             chain={chain}

--- a/src/ui/views/Approval/style.less
+++ b/src/ui/views/Approval/style.less
@@ -143,7 +143,7 @@
   }
 
   .approval-tx {
-    padding: 24px 20px;
+    padding: 20px;
     padding-bottom: 130px;
     display: flex;
     flex-direction: column;
@@ -162,12 +162,12 @@
     .cancel,
     .cancel-tx {
       .balance-change {
-        margin-bottom: 24px;
+        margin-bottom: 20px;
       }
       .common-detail-block {
         min-height: 120px;
         padding: 24px 16px;
-        margin-bottom: 22px;
+        margin-bottom: 20px;
         .title {
           color: #525966;
           font-size: 20px;
@@ -180,7 +180,7 @@
         }
         .block-field {
           display: flex;
-          margin-bottom: 18px;
+          margin-bottom: 16px;
           .label {
             color: #818a99;
             font-size: 14px;
@@ -342,11 +342,11 @@
     .sign {
       .common-detail-block {
         padding: 21px 16px;
-        margin-bottom: 22px;
+        margin-bottom: 20px;
         position: relative;
         .block-field {
           display: flex;
-          margin-bottom: 18px;
+          margin-bottom: 16px;
           .label {
             color: #818a99;
             font-size: 14px;
@@ -366,7 +366,7 @@
           &.contract {
             margin-bottom: 0;
             border-top: 0.5px solid rgba(180, 189, 204, 0.6);
-            padding-top: 20px;
+            padding-top: 16px;
             .value {
               display: flex;
               align-items: center;
@@ -395,7 +395,7 @@
         }
       }
       .balance-change {
-        margin-bottom: 22px;
+        margin-bottom: 20px;
       }
     }
     .balance-change {

--- a/src/ui/views/Dashboard/index.tsx
+++ b/src/ui/views/Dashboard/index.tsx
@@ -200,79 +200,6 @@ const Dashboard = () => {
   useEffect(() => {
     checkIfFirstLogin();
   }, []);
-  const hoverContent = () => (
-    <>
-      <div
-        className="click-content-modar"
-        onClick={(e) => {
-          e.stopPropagation();
-          setHovered(false);
-        }}
-      ></div>
-      <div className="flex flex-col" onClick={() => setStartEdit(false)}>
-        <div className="flex items-center">
-          {currentAccount && (
-            <img
-              className="icon icon-account-type w-[32px] h-[32px]"
-              src={
-                KEYRING_ICONS[currentAccount.type] ||
-                WALLET_BRAND_CONTENT[currentAccount.brandName]?.image
-              }
-            />
-          )}
-          <div className="brand-name">
-            {startEdit ? (
-              <Input
-                value={alianName}
-                defaultValue={alianName}
-                onChange={handleAlianNameChange}
-                onPressEnter={alianNameConfirm}
-                autoFocus={startEdit}
-                onClick={(e) => e.stopPropagation()}
-                maxLength={20}
-                min={0}
-                style={{ zIndex: 10 }}
-              />
-            ) : (
-              displayName
-            )}
-          </div>
-          {!startEdit && (
-            <img
-              className="edit-name"
-              src={IconEditPen}
-              onClick={(e) => {
-                e.stopPropagation();
-                setStartEdit(true);
-              }}
-            />
-          )}
-          {startEdit && (
-            <img
-              className="edit-name w-[16px] h-[16px]"
-              src={IconCorrect}
-              onClick={(e) => {
-                e.stopPropagation();
-                alianNameConfirm(e);
-              }}
-            />
-          )}
-        </div>
-        <div className="flex text-12 mt-12">
-          <div className="mr-8 pt-2 lh-14">{currentAccount?.address}</div>
-          <IconCopy
-            onClick={handleCopyCurrentAddress}
-            className={clsx('icon icon-copy ml-7 mb-2 copy-icon', {
-              success: copySuccess,
-            })}
-          />
-        </div>
-        <div className="qrcode-container">
-          <QRCode value={currentAccount?.address} size={85} />
-        </div>
-      </div>
-    </>
-  );
   const Row = (props) => {
     const { data, index, style } = props;
     const account = data[index];
@@ -495,7 +422,7 @@ const Dashboard = () => {
         width="344px"
       >
         <div className="flex flex-col" onClick={() => setStartEdit(false)}>
-          <div className="flex items-center">
+          <div className="flex items-center h-[32px]">
             {currentAccount && (
               <img
                 className="icon icon-account-type w-[32px] h-[32px]"

--- a/src/ui/views/Dashboard/style.less
+++ b/src/ui/views/Dashboard/style.less
@@ -400,9 +400,9 @@
   .click-content-modar {
     position: absolute;
     left: 200px;
-    top:-300px;
-    width: 300px;
-    height: 800px;
+    top: -300px;
+    width: 200px;
+    height: 1000px;
     background: transparent;
   }
   .ant-popover-arrow {

--- a/src/ui/views/Dashboard/style.less
+++ b/src/ui/views/Dashboard/style.less
@@ -380,7 +380,7 @@
   .qrcode-container {
     width: 100px;
     height: 100px;
-    margin: 14px 0 16px 0;
+    margin: 23px 0 0 0;
     border: 1px solid #d8dfeb;
     box-sizing: border-box;
     border-radius: 8px;

--- a/src/ui/views/Dashboard/style.less
+++ b/src/ui/views/Dashboard/style.less
@@ -666,3 +666,6 @@
 .pointer{
   cursor: pointer;
 }
+.ant-modal-mask {
+  background-color: rgba(0, 0, 0, 0) !important;
+}

--- a/src/ui/views/ImportSuccess/index.tsx
+++ b/src/ui/views/ImportSuccess/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useTranslation, Trans } from 'react-i18next';
 import { sortBy } from 'lodash';
@@ -46,6 +46,17 @@ const ImportSuccess = ({ isPopup = false }: { isPopup?: boolean }) => {
   const importedIcon =
     KEYRING_ICONS[accounts[0].type] ||
     WALLET_BRAND_CONTENT[accounts[0].brandName]?.image;
+  const [stopEditing, setStopEditing] = useState(true);
+  const [editIndex, setEditIndex] = useState(0);
+  const startEdit = (editing: boolean, index: number) => {
+    if (editing) {
+      setEditIndex(index);
+      setStopEditing(false);
+    } else {
+      setStopEditing(true);
+    }
+  };
+
   return (
     <StrayPageWithButton
       hasDivider={hasDivider}
@@ -73,6 +84,10 @@ const ImportSuccess = ({ isPopup = false }: { isPopup?: boolean }) => {
         </header>
       )}
       <div
+        onClick={(e) => {
+          e.stopPropagation();
+          setStopEditing(true);
+        }}
         className={clsx(
           'flex flex-col lg:justify-center text-center h-[472px] lg:h-auto',
           {
@@ -115,6 +130,8 @@ const ImportSuccess = ({ isPopup = false }: { isPopup?: boolean }) => {
               isMnemonics={isMnemonics}
               currentImportLength={accounts.length}
               importedLength={importedLength}
+              stopEditing={stopEditing || index !== editIndex}
+              canEditing={(editing) => startEdit(editing, index)}
             />
           ))}
         </div>

--- a/src/ui/views/SelectAddress/index.tsx
+++ b/src/ui/views/SelectAddress/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
-import { Form, Input } from 'antd';
+import { Form, Input, message } from 'antd';
 import { StrayPageWithButton, MultiSelectAddressList } from 'ui/component';
 import { useWallet, useWalletRequest } from 'ui/utils';
 import { HARDWARE_KEYRING_TYPES } from 'consts';
@@ -77,6 +77,7 @@ const SelectAddress = ({ isPopup = false }: { isPopup?: boolean }) => {
       },
       onError(err) {
         console.log('get hardware account error', err);
+        message.error('Please check the connection with your wallet');
       },
     }
   );

--- a/src/ui/views/SelectAddress/index.tsx
+++ b/src/ui/views/SelectAddress/index.tsx
@@ -146,11 +146,13 @@ const SelectAddress = ({ isPopup = false }: { isPopup?: boolean }) => {
         editing: isPopup,
         showImportIcon: false,
         isMnemonics,
+        importedAccount: true,
+        importedLength: importedAccounts && importedAccounts?.length,
       },
     });
   };
   const startNumberConfirm = (e) => {
-    e.stopPropagation();
+    e.preventDefault();
     if (end > 1000) {
       setErrorMsg(t('Max 1000'));
     } else if (accounts.length <= end && canLoad) {
@@ -158,6 +160,7 @@ const SelectAddress = ({ isPopup = false }: { isPopup?: boolean }) => {
     }
   };
   const toSpecificNumber = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.stopPropagation();
     const currentNumber = parseInt(e.target.value);
     if (!currentNumber) {
       setErrorMsg(t('Invalid Number'));
@@ -192,6 +195,7 @@ const SelectAddress = ({ isPopup = false }: { isPopup?: boolean }) => {
         form={form}
         footerFixed={false}
         noPadding={isPopup}
+        disableKeyDownEvent
         isScrollContainer={isPopup}
       >
         {isPopup && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -10616,13 +10616,6 @@ react-i18next@^11.11.0:
     "@babel/runtime" "^7.14.5"
     html-parse-stringify "^3.0.1"
 
-react-infinite-scroll-component@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz#7e511e7aa0f728ac3e51f64a38a6079ac522407f"
-  integrity sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==
-  dependencies:
-    throttle-debounce "^2.1.0"
-
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -12171,11 +12164,6 @@ throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
-
-throttle-debounce@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.3.0.tgz#fd31865e66502071e411817e241465b3e9c372e2"
-  integrity sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==
 
 throttle-debounce@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
By using the infinity loader, there are several problems may difficult to solve:
1. Can not exactly point to specific number, as the list get longer, the  position to the right number may much higher.
2. By input number or scroll the select address page, there may some lag for user experience.
3. If already to a specific number, scrolling back, the loading skeleton is still there, and  other bad user experience.

Therefore, I prefer to use react-window here.
Demo:

https://user-images.githubusercontent.com/12989352/144710059-a114f62b-623c-432c-ba24-c20b15d47a44.mov


Need discuss :
Previously, I found through ledger live, no addresses can see, it's an exist problem in production,  which is iframe been blocked.  AKA, we may need some words or reminder for users if their ledger needs passwords or iframe blocked or port been occupied, etcs.
