### PR TITLE
fix: overflow issue of chain selector modal

### DIFF
--- a/src/ui/component/ChainCard/index.tsx
+++ b/src/ui/component/ChainCard/index.tsx
@@ -15,6 +15,7 @@ const ChainCard = ({
   saveToPin,
   removeFromPin,
   className,
+  onClick,
 }: {
   plus: boolean;
   showIcon: boolean;
@@ -22,6 +23,7 @@ const ChainCard = ({
   saveToPin?(chain: string): void;
   removeFromPin?(chain: string): void;
   className?: string;
+  onClick?(): void;
 }) => {
   const [isHovering, hoverProps] = useHover();
 
@@ -60,6 +62,7 @@ const ChainCard = ({
       ref={setNodeRef}
       {...attributes}
       style={style}
+      onClick={onClick}
     >
       {!plus ? (
         <div className={clsx('chain-card', 'cursor-pointer')} {...listeners}>

--- a/src/ui/component/ChainSelector/Modal.tsx
+++ b/src/ui/component/ChainSelector/Modal.tsx
@@ -94,22 +94,20 @@ const ChainSelectorModal = ({
         {savedChainsData.length > 0 && (
           <ul className="chain-selector-options">
             {savedChainsData.map((chain) => (
-              <div onClick={() => handleChange(chain.enum as CHAINS_ENUM)}>
-                <ChainCard
-                  chain={chain}
-                  key={chain.id}
-                  showIcon={false}
-                  plus={false}
-                  className="w-[176px] h-[56px]"
-                />
-              </div>
+              <ChainCard
+                chain={chain}
+                key={chain.id}
+                showIcon={false}
+                plus={false}
+                className="w-[176px] h-[56px]"
+                onClick={() => handleChange(chain.enum as CHAINS_ENUM)}
+              />
             ))}
           </ul>
         )}
-        <div
-          className="all-chais"
-          onClick={goToChainManagement}
-        >{`All chains >`}</div>
+        <div className="all-chais" onClick={goToChainManagement}>
+          {'All chains >'}
+        </div>
       </>
     </Drawer>
   );

--- a/src/ui/component/ChainSelector/style.less
+++ b/src/ui/component/ChainSelector/style.less
@@ -32,7 +32,7 @@
 }
 
 .chain-selector-options {
-  width: 400px;
+  width: 100%;
   max-height: 376px;
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Found that when scrolling right in the chain selector modal there is a useless gap and try to fix it

![image](https://user-images.githubusercontent.com/86296331/148345431-0ebf234b-f352-4106-8b3f-12cc3be460b9.png)
