### PR TITLE
Adding github action for automated submission

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,26 @@
+# Submit the extension to browser marketplace
+
+name: Submit
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to submit, i.e v1.0.0'
+        required: true
+
+jobs:
+  # Prepare node modules. Reuse cache if available
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Github Release Assets
+        uses: plasmo-corp/download-release-asset@v1.0.0
+        with:
+          files: Rabby_*
+          tag: ${{ github.event.inputs.tag }}
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          artifact: "Rabby_${{ github.event.inputs.tag }}.zip"
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .yarn
 .DS_Store
 yarn-error
+keys.json


### PR DESCRIPTION
Hi friends -

Cool extension! I was looking for ways to contribute, and thought adding a bit more ci might help. This PR introduces a new github action workflow that download a release archive then submit it to extension stores. The action is set to run manually from the github action tab, but we can tweak it to run as frequent as needed! The only thing you would need to create is a `SUBMIT_KEYS` github repository secret.

This secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/main/keys.schema.json).

Here's a sample key for you:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/main/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "refreshToken": "789",
    "extId": "abcd"
  }
}
```

You can find instructions on how to get the keys in the schema, or in this [doc](https://github.com/plasmo-corp/bms/blob/main/tokens.md). If you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)

---

Side notes: [bpp](https://browser.market) is an open source action, together with its dependencies. You can audit the source 
 as well as providing any issue/feedback here:
- [Browser Plugin Publisher](https://github.com/plasmo-corp/bpp)
- [Browser Market Submit](https://github.com/plasmo-corp/bms)
- [Mozilla Webstore Upload](https://github.com/plasmo-corp/mwu)
- [Chrome Webstore Upload](https://github.com/plasmo-corp/cwu)