### PR TITLE
package.json: bump the bitbox02 dep to v0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "axios-rate-limit": "^1.3.0",
     "bignumber.js": "^9.0.1",
     "bip39": "^3.0.3",
-    "bitbox02-api": "0.11.0",
+    "bitbox02-api": "0.14.0",
     "browser-passworder": "^2.0.3",
     "buffer": "^6.0.3",
     "clipboard": "^2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4382,10 +4382,10 @@ bip66@^1.1.5:
   dependencies:
     safe-buffer "^5.0.1"
 
-bitbox02-api@0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/bitbox02-api/-/bitbox02-api-0.11.0.tgz#9b11e3be8665a616372ba5bbeddc9c76eb355fba"
-  integrity sha512-/eiSRKtLgfkbrl43ZhQXaoQpUzu5WJ/W3WPYyV2X2XPFIXUFohdLEOlubeI62bUTuMfe85TS8/nz0tZ97hhRYA==
+bitbox02-api@0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/bitbox02-api/-/bitbox02-api-0.14.0.tgz#1032b3dcc2478c06d72ebb8a291b91904f6daf1a"
+  integrity sha512-VJt8RKizXK4HRDuh3dNL5Rsl0TNtYkND2IN+ZtVz5SIwAh8TLrjsKTYEGJKPVb4d/FXzEyI1OZMv35MpVyi4zQ==
 
 bitwise@^2.0.4:
   version "2.1.0"


### PR DESCRIPTION
This allows the BitBox02 to directly accept a network chain ID, which
allows future network additions to happen without changes to the JS
library.

BitBox02 v9.10.0 (out soon) will add support for Binance Smart Chain, Optimism, Polygon and Arbitrum One.