### PR TITLE
bitbox02: add support for signing EIP-712 typed data

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "axios-rate-limit": "^1.3.0",
     "bignumber.js": "^9.0.1",
     "bip39": "^3.0.3",
-    "bitbox02-api": "0.14.0",
+    "bitbox02-api": "0.15.0",
     "browser-passworder": "^2.0.3",
     "buffer": "^6.0.3",
     "clipboard": "^2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4886,10 +4886,10 @@ bip66@^1.1.5:
   dependencies:
     safe-buffer "^5.0.1"
 
-bitbox02-api@0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/bitbox02-api/-/bitbox02-api-0.14.0.tgz#1032b3dcc2478c06d72ebb8a291b91904f6daf1a"
-  integrity sha512-VJt8RKizXK4HRDuh3dNL5Rsl0TNtYkND2IN+ZtVz5SIwAh8TLrjsKTYEGJKPVb4d/FXzEyI1OZMv35MpVyi4zQ==
+bitbox02-api@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/bitbox02-api/-/bitbox02-api-0.15.0.tgz#29d5b61d366f0568b2761a9efeec308e2c59ab62"
+  integrity sha512-/jiL+Q85On9v0Q+jDkaSOi59wSp41wsjie1ogIW9roCZ1kTTuD0+PqPZJiMAghmXbmYkgmL696jv07KE0fFQLA==
 
 bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
BitBox02 firmware v9.12.0 is needed.
