### PR TITLE
fix: eth_accounts no need permission

### DIFF
--- a/src/background/controller/provider/controller.ts
+++ b/src/background/controller/provider/controller.ts
@@ -178,8 +178,9 @@ class ProviderController extends BaseController {
     return account;
   };
 
+  @Reflect.metadata('SAFE', true)
   ethAccounts = async ({ session: { origin } }) => {
-    if (!permissionService.hasPermission(origin)) {
+    if (!permissionService.hasPermission(origin) || !Wallet.isUnlocked()) {
       return [];
     }
 


### PR DESCRIPTION
Wallet no need to unlock before eth_accounts requested, but will response an empty account list