### PR TITLE
Cache BitBox02 wallet paths upon import.

### DIFF
--- a/src/background/service/keyring/eth-bitbox02-keyring.ts
+++ b/src/background/service/keyring/eth-bitbox02-keyring.ts
@@ -18,7 +18,6 @@ import {
 const hdPathString = "m/44'/60'/0'/0";
 const keyringType = 'BitBox02 Hardware';
 const pathBase = 'm';
-const MAX_INDEX = 100;
 
 class BitBox02Keyring extends EventEmitter {
   static type = keyringType;
@@ -131,6 +130,12 @@ class BitBox02Keyring extends EventEmitter {
         if (!this.accounts.includes(address)) {
           this.accounts.push(address);
         }
+
+        // Cache available address paths
+        if (typeof this.paths[address] === 'undefined') {
+          this.paths[address] = i;
+        }
+
         this.page = 0;
       }
       return this.accounts;
@@ -334,17 +339,11 @@ class BitBox02Keyring extends EventEmitter {
   _pathFromAddress(address: string): string {
     const checksummedAddress = ethUtil.toChecksumAddress(address);
     let index = this.paths[checksummedAddress];
-    if (typeof index === 'undefined') {
-      for (let i = 0; i < MAX_INDEX; i++) {
-        if (checksummedAddress === this._addressFromIndex(pathBase, i)) {
-          index = i;
-          break;
-        }
-      }
-    }
 
     if (typeof index === 'undefined') {
-      throw new Error('Unknown address');
+      throw new Error(
+        'Address not be found. Please resync this wallet with your device!'
+      );
     }
     return `${this.hdPath}/${index}`;
   }


### PR DESCRIPTION
This is mainly related to the issue described in #1026, but from what I can see, any hardware wallet is limited to a specific `MAX_INDEX` of wallets it can import/use.

I'm not sure what was the design choice to move forward with this, and actually would appreciate some context on why caching the hardware wallet lookups/index might not be good.

This should as well make faster the lookups for a wallet upon use.

Appreciate reviewing this :bowing_man: 

/cc @jadzeidan  @benma