### PR TITLE
fix: bitbox2 supports up to 100 accounts close #1048, close #1026

### DIFF
--- a/src/background/service/keyring/eth-bitbox02-keyring.ts
+++ b/src/background/service/keyring/eth-bitbox02-keyring.ts
@@ -164,6 +164,10 @@ class BitBox02Keyring extends EventEmitter {
       const accounts: any[] = [];
 
       for (let i = from; i < to; i++) {
+        if (i >= MAX_INDEX) {
+          return accounts;
+        }
+
         const address = this._addressFromIndex(pathBase, i);
         accounts.push({
           address,
@@ -181,6 +185,10 @@ class BitBox02Keyring extends EventEmitter {
     const accounts: any[] = [];
     return await this.withDevice(async () => {
       for (let i = from; i < to; i++) {
+        if (i >= MAX_INDEX) {
+          return accounts;
+        }
+
         const address = this._addressFromIndex(pathBase, i);
         accounts.push({
           address,


### PR DESCRIPTION
The bitbox2 only supports up to 100 accounts. We don't need to store the keypath, just prevent importing accounts that exceed the index. 

https://github.com/digitalbitbox/bitbox02-firmware/blob/d37474e37f6715de42094b78396677c1264da10e/src/rust/bitbox02-rust/src/hww/api/ethereum/keypath.rs#L21

https://github.com/digitalbitbox/bitbox02-firmware/blob/d37474e37f6715de42094b78396677c1264da10e/src/rust/bitbox02-rust/src/hww/api/ethereum/keypath.rs#L68-L80