### PR TITLE
fix Moonriver and Moonbase Alpha gas limit Issue

### DIFF
--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -1064,6 +1064,8 @@ export const DEFAULT_GAS_LIMIT_RATIO = 1.5;
 
 export const SAFE_GAS_LIMIT_RATIO = {
   '1284': 2,
+  '1285': 2,
+  '1287': 2,
 };
 export const GAS_TOP_UP_ADDRESS = '0x7559e1bbe06e94aeed8000d5671ed424397d25b5';
 export const GAS_TOP_UP_PAY_ADDRESS =


### PR DESCRIPTION
Rabby's Gas Estimation logic uses a buffer of 1.5x on all networks except for Moonbeam where it uses a buffer of 2 as a SAFE_GAS_LIMIT_RATIO. Moonriver network is architecturally identical to Moonriver network (it is the sister network of Moonbeam) so it should also use this same safe gas limit ratio. 

We noticed this issue because a user reported an issue where certain revoke staking transactions were failing due to low gas limits. This error was not faced in MetaMask, and it was not faced when using Rabbi on the Moonbeam Network. As a matter of good practice I am including Moonbase Alpha (the testnet for both Moonriver and Moonbeam) in this PR, however it may not be strictly necessary. I did not notice the same issue on Moonbase Alpha but logically it makes sense to keep this SAFE_GAS_LIMIT_RATIO the same across these 3 networks. 

Here is an example of the failed transaction in Moonriver using Rabby Wallet: https://moonriver.moonscan.io/tx/0xf227f2475d219396bf94dcc67b5d52655ba8476e6b1475b74cb67dcb475be24a

And a successful one in Moonbeam (using Rabby Wallet):
https://moonbeam.moonscan.io/tx/0x5804fd176dfb4b23c1957b10a48061f1fd8d8585de0eddb0a99c348cf69be392

Let me know if you have any questions! 

