### PR TITLE
Decreased UR density

### DIFF
--- a/src/ui/views/Approval/components/QRHardWareWaiting/Player.tsx
+++ b/src/ui/views/Approval/components/QRHardWareWaiting/Player.tsx
@@ -23,7 +23,8 @@ const Player = ({
   layoutStyle = 'compact',
 }: IProps) => {
   const urEncoder = useMemo(
-    () => new UREncoder(new UR(Buffer.from(cbor, 'hex'), type), 400),
+    // For NGRAVE ZERO support please keep to a maximum fragment size of 200
+    () => new UREncoder(new UR(Buffer.from(cbor, 'hex'), type), 200),
     [cbor, type]
   );
   const [currentQRCode, setCurrentQRCode] = useState(urEncoder.nextPart());


### PR DESCRIPTION
Hi Rabby Team!

This PR introduces a change to the density of the animated QR codes so that they can be scanned by the ZERO hardware wallet from NGRAVE.

This MR is the same change as implemented in MetaMask: https://github.com/MetaMask/metamask-extension/pull/22135


