### PR TITLE
bitbox02: switch to new bitbox client library

### DIFF
--- a/build/webpack.common.config.js
+++ b/build/webpack.common.config.js
@@ -255,6 +255,7 @@ const config = {
     },
   },
   experiments: {
+    asyncWebAssembly: true,
     topLevelAwait: true,
   },
 };

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ahooks": "3.7.8",
     "antd": "4.15.3",
     "bignumber.js": "9.0.1",
-    "bitbox02-api": "0.15.1",
+    "bitbox-api": "0.3.1",
     "browserify-zlib": "0.2.0",
     "buffer": "6.0.3",
     "clipboard": "2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6802,10 +6802,10 @@ bip66@^1.1.5:
   dependencies:
     safe-buffer "^5.0.1"
 
-bitbox02-api@0.15.1:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/bitbox02-api/-/bitbox02-api-0.15.1.tgz#9fff84c761a11fb7b423153ec05aa5f38274a8db"
-  integrity sha512-zeuHVF3kAQsJsa2q1fCtktVFiJV/G8nMuKonwMMsCx1RY0mzqc33RGlayTrvLrgs3fj30wLkWmXrgPmQCIJxmg==
+bitbox-api@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/bitbox-api/-/bitbox-api-0.3.1.tgz#4954289233bc69513ac027ec04e93aaad1726511"
+  integrity sha512-9ZXcNZj0hbRle1jPycPmOGuht3HaolD9aXYddfN3rUAaPhQuHnHSs4Jr+rPhVYutHgOMCvT6NVdIotqNQ3QX1g==
 
 bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
The previous one (bitbox02-api) is being deprecated.

The new one is much smaller in size, comes with complete TypeScript, and is a proper ES6 module. It is based on WASM, which is why `asyncWebAssembly: true` needs to be set.