### PR TITLE
bitbox02: bump bitbox-api to v0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ahooks": "3.7.8",
     "antd": "4.15.3",
     "bignumber.js": "9.0.1",
-    "bitbox-api": "0.3.1",
+    "bitbox-api": "0.3.2",
     "browserify-zlib": "0.2.0",
     "buffer": "6.0.3",
     "clipboard": "2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6802,10 +6802,10 @@ bip66@^1.1.5:
   dependencies:
     safe-buffer "^5.0.1"
 
-bitbox-api@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/bitbox-api/-/bitbox-api-0.3.1.tgz#4954289233bc69513ac027ec04e93aaad1726511"
-  integrity sha512-9ZXcNZj0hbRle1jPycPmOGuht3HaolD9aXYddfN3rUAaPhQuHnHSs4Jr+rPhVYutHgOMCvT6NVdIotqNQ3QX1g==
+bitbox-api@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/bitbox-api/-/bitbox-api-0.3.2.tgz#cc0acf3170400d203cc2c3618a13c928da00e263"
+  integrity sha512-w85zT4FFtMhaK3bNGQH7PVpOPvO0VDv8ZQxhgqqElqaGVGhv+ql+pE091/+St8R869Wot8HOEwMMd36osArnDQ==
 
 bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
It fixes a parsing bug when signing typed messages that contain "0x1" or other uneven hex strings for uints.