### PR TITLE
Named AirGap Vaults

### DIFF
--- a/src/background/service/keyring/index.ts
+++ b/src/background/service/keyring/index.ts
@@ -517,6 +517,7 @@ export class KeyringService extends EventEmitter {
         const alias = generateAliasName({
           brandName,
           keyringType: keyring.type,
+          keyringName: keyring.getName ? keyring.getName() : undefined,
           addressCount,
         });
         contactBook.addAlias({

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -12,11 +12,13 @@ import { t } from 'i18next';
 export function generateAliasName({
   keyringType,
   brandName,
+  keyringName,
   keyringCount = 0,
   addressCount = 0,
 }: {
   keyringType: string;
   brandName?: string;
+  keyringName?: string;
   keyringCount?: number;
   addressCount?: number;
 }) {
@@ -33,6 +35,12 @@ export function generateAliasName({
     ) {
       return `${t('background.alias.watchAddressKeyring')} ${addressCount + 1}`;
     }
+
+    // The name the keyring itself suggests should be used
+    if (keyringName) {
+      return `${keyringName} ${addressCount + 1}`;
+    }
+
     if (brandName) {
       return `${BRAND_ALIAN_TYPE_TEXT[brandName] || brandName} ${
         addressCount + 1


### PR DESCRIPTION
Seed phrases in AirGap Vault can have names. These names are transmitted to and stored in Rabby, but they are not used. However, when using multiple AirGap Vaults it is helpful to know which one is already connected before switching.

This change tries to use the keyring's name if there is one present to generate an alias suggestion when adding a vault and its addresses.

I only have AirGap Vault and a Trezor to test with. So it might be worth testing with other devices as well.

