### PR TITLE
feat: support EIP-7524 PLUME signatures

### DIFF
--- a/_raw/locales/en/messages.json
+++ b/_raw/locales/en/messages.json
@@ -1476,6 +1476,14 @@
         "description": "Description"
       }
     },
+    "signPlume": {
+      "title": "Sign PLUME",
+      "message": "Message",
+      "createKey": {
+        "interactDapp": "Interact Dapp",
+        "description": "Description"
+      }
+    },
     "securityEngine": {
       "yes": "Yes",
       "no": "No",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@rabby-wallet/eth-gnosis-keyring": "0.0.1",
     "@rabby-wallet/eth-hd-keyring": "4.1.0",
     "@rabby-wallet/eth-lattice-keyring": "1.0.5",
-    "@rabby-wallet/eth-simple-keyring": "5.0.1",
+    "@rabby-wallet/eth-simple-keyring": "5.1.0",
     "@rabby-wallet/eth-trezor-keyring": "2.3.0",
     "@rabby-wallet/eth-walletconnect-keyring": "2.0.4",
     "@rabby-wallet/eth-watch-keyring": "1.0.0",

--- a/src/background/controller/provider/rpcFlow.ts
+++ b/src/background/controller/provider/rpcFlow.ts
@@ -15,7 +15,7 @@ import stats from '@/stats';
 import { addHexPrefix, stripHexPrefix } from 'ethereumjs-util';
 
 const isSignApproval = (type: string) => {
-  const SIGN_APPROVALS = ['SignText', 'SignTypedData', 'SignTx'];
+  const SIGN_APPROVALS = ['SignText', 'SignTypedData', 'SignTx', 'SignPlume'];
   return SIGN_APPROVALS.includes(type);
 };
 

--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -2665,6 +2665,28 @@ export class WalletController extends BaseController {
     return res;
   };
 
+  signPlumeMessage = async (
+    type: string,
+    from: string,
+    data: string,
+    options?: any
+  ) => {
+    const keyring = await keyringService.getKeyringForAccount(from, type);
+    const res = await keyringService.signPlumeMessage(
+      keyring,
+      { from, data },
+      options
+    );
+    eventBus.emit(EVENTS.broadcastToUI, {
+      method: EVENTS.SIGN_FINISHED,
+      params: {
+        success: true,
+        data: res,
+      },
+    });
+    return res;
+  };
+
   signTransaction = async (
     type: string,
     from: string,

--- a/src/background/service/keyring/index.ts
+++ b/src/background/service/keyring/index.ts
@@ -679,6 +679,21 @@ export class KeyringService extends EventEmitter {
   }
 
   /**
+   * Sign PLUME Message
+   * (EIP 7524 https://github.com/ethereum/ERCs/pull/37/files?short_path=d698c69#diff-d698c694be4189f928935d8c63c0df0a03e5cca1521c388a97949dc0436dc4ca)
+   *
+   * Attempts to sign the message using the keyring of given address. The
+   * message data should be utf8 encoded.
+   *
+   * @param {Object} msgParams - The message parameters.
+   * @returns {Promise<Object>} The raw signature components.
+   */
+  signPlumeMessage(keyring, msgParams, opts = {}) {
+    const address = normalizeAddress(msgParams.from);
+    return keyring.signPlumeMessage(address, msgParams.data, opts);
+  }
+
+  /**
    * Get encryption public key
    *
    * Get encryption public key for using in encrypt/decrypt process.

--- a/src/background/service/notification.ts
+++ b/src/background/service/notification.ts
@@ -41,6 +41,7 @@ const QUEUE_APPROVAL_COMPONENTS_WHITELIST = [
   'SignTx',
   'SignText',
   'SignTypedData',
+  'SignPlume',
   'LedgerHardwareWaiting',
   'QRHardWareWaiting',
   'WatchAddressWaiting',

--- a/src/background/service/signTextHistory.ts
+++ b/src/background/service/signTextHistory.ts
@@ -13,7 +13,8 @@ export interface SignTextHistoryItem {
     | 'ethSignTypedData'
     | 'ethSignTypedDataV1'
     | 'ethSignTypedDataV3'
-    | 'ethSignTypedDataV4';
+    | 'ethSignTypedDataV4'
+    | 'ethGetPlumeSignature';
 }
 
 interface SignTextHistoryStore {

--- a/src/ui/views/Approval/components/SignPlume.tsx
+++ b/src/ui/views/Approval/components/SignPlume.tsx
@@ -1,0 +1,407 @@
+import { Account } from 'background/service/preference';
+import React, { ReactNode, useEffect, useState, useRef, useMemo } from 'react';
+import { useScroll, useAsync } from 'react-use';
+import { Skeleton } from 'antd';
+import { useSize } from 'ahooks';
+import { useTranslation } from 'react-i18next';
+import { Result } from '@rabby-wallet/rabby-security-engine';
+import { Level } from '@rabby-wallet/rabby-security-engine/dist/rules';
+import {
+  INTERNAL_REQUEST_ORIGIN,
+  KEYRING_CLASS,
+  KEYRING_TYPE,
+  CHAINS,
+  REJECT_SIGN_TEXT_KEYRINGS,
+} from 'consts';
+import { hex2Text, useApproval, useCommonPopupView, useWallet } from 'ui/utils';
+import { getKRCategoryByType } from '@/utils/transaction';
+import { matomoRequestEvent } from '@/utils/matomo-request';
+import { useLedgerDeviceConnected } from '@/utils/ledger';
+import { FooterBar } from './FooterBar/FooterBar';
+import {
+  parseAction,
+  formatSecurityEngineCtx,
+  TextActionData,
+} from './TextActions/utils';
+import { useSecurityEngine } from 'ui/utils/securityEngine';
+import RuleDrawer from './SecurityEngine/RuleDrawer';
+import { useRabbyDispatch, useRabbySelector } from '@/ui/store';
+import IconGnosis from 'ui/assets/walletlogo/safe.svg';
+import Actions from './TextActions';
+import { ParseTextResponse } from '@rabby-wallet/rabby-api/dist/types';
+import { isTestnetChainId } from '@/utils/chain';
+import { useSignPermissionCheck } from '../hooks/useSignPermissionCheck';
+import { useTestnetCheck } from '../hooks/useTestnetCheck';
+import { WaitingSignMessageComponent } from './map';
+import { useEnterPassphraseModal } from '@/ui/hooks/useEnterPassphraseModal';
+
+interface SignPlumeProps {
+  data: string[];
+  session: {
+    origin: string;
+    icon: string;
+    name: string;
+  };
+  isGnosis?: boolean;
+  account?: Account;
+  method?: string;
+}
+
+const SignPlume = ({ params }: { params: SignPlumeProps }) => {
+  const [, resolveApproval, rejectApproval] = useApproval();
+  const wallet = useWallet();
+  const { t } = useTranslation();
+  const { data, session, isGnosis = false } = params;
+  const [msg, from] = data;
+  const message = hex2Text(msg);
+  const [isWatch, setIsWatch] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLedger, setIsLedger] = useState(false);
+  const [useLedgerLive, setUseLedgerLive] = useState(false);
+  const hasConnectedLedgerHID = useLedgerDeviceConnected();
+  const [
+    cantProcessReason,
+    setCantProcessReason,
+  ] = useState<ReactNode | null>();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollRefSize = useSize(scrollRef);
+  const scrollInfo = useScroll(scrollRef);
+  const [footerShowShadow, setFooterShowShadow] = useState(false);
+  const [engineResults, setEngineResults] = useState<Result[]>([]);
+  const [
+    parsedActionData,
+    setParsedActionData,
+  ] = useState<TextActionData | null>(null);
+  const { executeEngine } = useSecurityEngine();
+  const dispatch = useRabbyDispatch();
+  const { userData, rules, currentTx } = useRabbySelector((s) => ({
+    userData: s.securityEngine.userData,
+    rules: s.securityEngine.rules,
+    currentTx: s.securityEngine.currentTx,
+  }));
+  const [chainId, setChainId] = useState<number | undefined>(undefined);
+
+  const securityLevel = useMemo(() => {
+    const enableResults = engineResults.filter((result) => {
+      return result.enable && !currentTx.processedRules.includes(result.id);
+    });
+    if (enableResults.some((result) => result.level === Level.FORBIDDEN))
+      return Level.FORBIDDEN;
+    if (enableResults.some((result) => result.level === Level.DANGER))
+      return Level.DANGER;
+    if (enableResults.some((result) => result.level === Level.WARNING))
+      return Level.WARNING;
+    return undefined;
+  }, [engineResults, currentTx]);
+
+  const hasUnProcessSecurityResult = useMemo(() => {
+    const { processedRules } = currentTx;
+    const enableResults = engineResults.filter((item) => item.enable);
+    const hasForbidden = enableResults.find(
+      (result) => result.level === Level.FORBIDDEN
+    );
+    const hasSafe = !!enableResults.find(
+      (result) => result.level === Level.SAFE
+    );
+    const needProcess = enableResults.filter(
+      (result) =>
+        (result.level === Level.DANGER || result.level === Level.WARNING) &&
+        !processedRules.includes(result.id)
+    );
+    if (hasForbidden) return true;
+    if (needProcess.length > 0) {
+      return !hasSafe;
+    } else {
+      return false;
+    }
+  }, [engineResults, currentTx]);
+
+  const { value: textActionData, loading, error } = useAsync(async () => {
+    const currentAccount = await wallet.getCurrentAccount();
+    let chainId = 1; // ETH as default
+    if (params.session.origin !== INTERNAL_REQUEST_ORIGIN) {
+      const site = await wallet.getConnectedSite(params.session.origin);
+      if (site) {
+        chainId = CHAINS[site.chain].id;
+      }
+    }
+    setChainId(chainId);
+
+    const apiProvider = isTestnetChainId(chainId)
+      ? wallet.testnetOpenapi
+      : wallet.openapi;
+
+    return await apiProvider.parseText({
+      text: message,
+      address: currentAccount!.address,
+      origin: session.origin,
+    });
+  }, [message, session]);
+
+  useSignPermissionCheck({
+    origin: params.session.origin,
+    chainId,
+    onOk: () => {
+      handleCancel();
+    },
+    onDisconnect: () => {
+      handleCancel();
+    },
+  });
+
+  useTestnetCheck({
+    chainId,
+    onOk: () => {
+      handleCancel();
+    },
+  });
+
+  const report = async (
+    action:
+      | 'createSignPlume'
+      | 'startSignPlume'
+      | 'cancelSignPlume'
+      | 'completeSignPlume',
+    extra?: Record<string, any>
+  ) => {
+    const currentAccount = isGnosis
+      ? params.account
+      : await wallet.getCurrentAccount<Account>();
+    if (!currentAccount) {
+      return;
+    }
+    matomoRequestEvent({
+      category: 'SignPlume',
+      action: action,
+      label: [
+        getKRCategoryByType(currentAccount.type),
+        currentAccount.brandName,
+      ].join('|'),
+      transport: 'beacon',
+    });
+    await wallet.reportStats(action, {
+      type: currentAccount.brandName,
+      category: getKRCategoryByType(currentAccount.type),
+      method: 'ethGetPlumeSignature',
+      ...extra,
+    });
+  };
+
+  const handleCancel = () => {
+    report('cancelSignPlume');
+    rejectApproval('User rejected the request.');
+  };
+
+  const { activeApprovalPopup } = useCommonPopupView();
+  const invokeEnterPassphrase = useEnterPassphraseModal('address');
+
+  const handleAllow = async () => {
+    if (activeApprovalPopup()) {
+      return;
+    }
+    const currentAccount = await wallet.getCurrentAccount();
+
+    if (currentAccount?.type === KEYRING_TYPE.HdKeyring) {
+      await invokeEnterPassphrase(currentAccount.address);
+    }
+
+    if (
+      currentAccount?.type &&
+      WaitingSignMessageComponent[currentAccount?.type]
+    ) {
+      resolveApproval({
+        uiRequestComponent: WaitingSignMessageComponent[currentAccount?.type],
+        type: currentAccount.type,
+        address: currentAccount.address,
+        extra: {
+          brandName: currentAccount.brandName,
+          signTextMethod: 'ethGetPlumeSignature',
+        },
+      });
+
+      return;
+    }
+    report('startSignPlume');
+    resolveApproval({});
+  };
+
+  const executeSecurityEngine = async () => {
+    const ctx = formatSecurityEngineCtx({
+      actionData: parsedActionData!,
+      origin: session.origin,
+    });
+    const result = await executeEngine(ctx);
+    setEngineResults(result);
+  };
+
+  const handleIgnoreAllRules = () => {
+    dispatch.securityEngine.processAllRules(
+      engineResults.map((result) => result.id)
+    );
+  };
+
+  const handleIgnoreRule = (id: string) => {
+    dispatch.securityEngine.processRule(id);
+    dispatch.securityEngine.closeRuleDrawer();
+  };
+
+  const handleUndoIgnore = (id: string) => {
+    dispatch.securityEngine.unProcessRule(id);
+    dispatch.securityEngine.closeRuleDrawer();
+  };
+
+  const handleRuleEnableStatusChange = async (id: string, value: boolean) => {
+    if (currentTx.processedRules.includes(id)) {
+      dispatch.securityEngine.unProcessRule(id);
+    }
+    await wallet.ruleEnableStatusChange(id, value);
+    dispatch.securityEngine.init();
+  };
+
+  const handleRuleDrawerClose = (update: boolean) => {
+    if (update) {
+      executeSecurityEngine();
+    }
+    dispatch.securityEngine.closeRuleDrawer();
+  };
+
+  const checkWachMode = async () => {
+    const currentAccount = await wallet.getCurrentAccount();
+    const accountType =
+      isGnosis && params.account ? params.account.type : currentAccount?.type;
+    setIsLedger(accountType === KEYRING_CLASS.HARDWARE.LEDGER);
+    setUseLedgerLive(await wallet.isUseLedgerLive());
+    if (accountType === KEYRING_TYPE.WatchAddressKeyring) {
+      setIsWatch(true);
+      setCantProcessReason(
+        <div>You can only use imported addresses to sign</div>
+      );
+    }
+    if (accountType === KEYRING_TYPE.GnosisKeyring && !params.account) {
+      setIsWatch(true);
+      setCantProcessReason(
+        <div className="flex items-center gap-6">
+          <img src={IconGnosis} alt="" className="w-[24px] flex-shrink-0" />
+          {t(
+            'This is a Gnosis Safe address, and it cannot be used to sign PLUMEs.'
+          )}
+        </div>
+      );
+    }
+  };
+
+  const init = async (
+    textActionData: ParseTextResponse,
+    message: string,
+    sender: string
+  ) => {
+    const currentAccount = await wallet.getCurrentAccount();
+    if (
+      currentAccount?.type &&
+      REJECT_SIGN_TEXT_KEYRINGS.includes(currentAccount.type as any)
+    ) {
+      rejectApproval('This address can not sign PLUME messages', false, true);
+    }
+    const parsed = parseAction(textActionData, message, sender);
+    setParsedActionData(parsed);
+    const ctx = formatSecurityEngineCtx({
+      actionData: parsed,
+      origin: params.session.origin,
+    });
+    const result = await executeEngine(ctx);
+    setEngineResults(result);
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    if (!loading) {
+      if (textActionData) {
+        init(textActionData, message, from);
+      } else {
+        setIsLoading(false);
+      }
+    }
+  }, [loading, message, textActionData, params, from]);
+
+  useEffect(() => {
+    if (scrollRef.current && scrollInfo && scrollRefSize) {
+      const avaliableHeight =
+        scrollRef.current.scrollHeight - scrollRefSize.height;
+      if (avaliableHeight <= 0) {
+        setFooterShowShadow(false);
+      } else {
+        setFooterShowShadow(avaliableHeight - 20 > scrollInfo.y);
+      }
+    }
+  }, [scrollInfo, scrollRefSize]);
+
+  useEffect(() => {
+    executeSecurityEngine();
+  }, [rules]);
+
+  useEffect(() => {
+    checkWachMode();
+  }, []);
+
+  useEffect(() => {
+    report('createSignPlume');
+  }, []);
+
+  return (
+    <>
+      <div className="approval-text">
+        {isLoading && (
+          <Skeleton.Input
+            active
+            style={{
+              width: 358,
+              height: 400,
+            }}
+          />
+        )}
+        {!isLoading && (
+          <Actions
+            data={parsedActionData}
+            engineResults={engineResults}
+            raw={msg}
+            message={message}
+            origin={params.session.origin}
+            plume={true}
+          />
+        )}
+      </div>
+
+      <footer className="approval-text__footer">
+        <FooterBar
+          hasShadow={footerShowShadow}
+          securityLevel={securityLevel}
+          hasUnProcessSecurityResult={hasUnProcessSecurityResult}
+          origin={params.session.origin}
+          originLogo={params.session.icon}
+          gnosisAccount={isGnosis ? params.account : undefined}
+          enableTooltip={isWatch}
+          tooltipContent={cantProcessReason}
+          onCancel={handleCancel}
+          onSubmit={() => handleAllow()}
+          disabledProcess={
+            (isLedger && !useLedgerLive && !hasConnectedLedgerHID) ||
+            isWatch ||
+            hasUnProcessSecurityResult
+          }
+          engineResults={engineResults}
+          onIgnoreAllRules={handleIgnoreAllRules}
+        />
+      </footer>
+      <RuleDrawer
+        selectRule={currentTx.ruleDrawer.selectRule}
+        visible={currentTx.ruleDrawer.visible}
+        onIgnore={handleIgnoreRule}
+        onUndo={handleUndoIgnore}
+        onRuleEnableStatusChange={handleRuleEnableStatusChange}
+        onClose={handleRuleDrawerClose}
+      />
+    </>
+  );
+};
+
+export default SignPlume;

--- a/src/ui/views/Approval/components/TextActions/index.tsx
+++ b/src/ui/views/Approval/components/TextActions/index.tsx
@@ -104,12 +104,14 @@ const Actions = ({
   raw,
   message,
   origin,
+  plume,
 }: {
   data: TextActionData | null;
   engineResults: Result[];
   raw: string;
   message: string;
   origin: string;
+  plume?: boolean;
 }) => {
   const actionName = useMemo(() => {
     return getActionTypeText(data);
@@ -139,7 +141,9 @@ const Actions = ({
   return (
     <>
       <SignTitle>
-        <div className="left relative">{t('page.signText.title')}</div>
+        <div className="left relative">
+          {t(plume ? 'page.signPlume.title' : 'page.signText.title')}
+        </div>
         <div
           className="float-right text-12 cursor-pointer flex items-center view-raw"
           onClick={handleViewRawClick}

--- a/src/ui/views/Approval/components/index.ts
+++ b/src/ui/views/Approval/components/index.ts
@@ -1,6 +1,7 @@
 export { default as SignText } from './SignText';
 export { default as SignTx } from './SignTx';
 export { default as SignTypedData } from './SignTypedData';
+export { default as SignPlume } from './SignPlume';
 export { default as Connect } from './Connect';
 export { default as WatchAddressWaiting } from './WatchAddressWaiting';
 export { default as CoinbaseWaiting } from './CoinbaseWaiting';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1304,6 +1304,11 @@
     stream-browserify "^3.0.0"
     util "^0.12.4"
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@ctrl/tinycolor@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz#c3c5ae543c897caa9c2a68630bed355be5f9990f"
@@ -3724,7 +3729,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
   integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
 
-"@noble/secp256k1@1.7.1", "@noble/secp256k1@~1.7.0":
+"@noble/secp256k1@1.7.1", "@noble/secp256k1@^1.7.0", "@noble/secp256k1@~1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
   integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
@@ -3941,7 +3946,22 @@
     rlp "^3.0.0"
     secp256k1 "4.0.2"
 
-"@rabby-wallet/eth-simple-keyring@5.0.1", "@rabby-wallet/eth-simple-keyring@^5.0.1":
+"@rabby-wallet/eth-simple-keyring@../eth-simple-keyring/":
+  version "5.0.1"
+  dependencies:
+    "@ethereumjs/util" "^9.0.0"
+    "@metamask/eth-sig-util" "5.1.0"
+    "@metamask/utils" "^8.1.0"
+    chai "^4.3.4"
+    eth-sig-util "^3.0.1"
+    ethereum-cryptography "^2.1.2"
+    ethereumjs-tx "^2.1.2"
+    ethereumjs-util "^7.0.9"
+    ethereumjs-wallet "^1.0.2"
+    plume-sig "^2.0.3"
+    randombytes "^2.1.0"
+
+"@rabby-wallet/eth-simple-keyring@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@rabby-wallet/eth-simple-keyring/-/eth-simple-keyring-5.0.1.tgz#aecdc8f82703741570d6759f8599909b5ccb6850"
   integrity sha512-5KYpR5gI5Hlo4E6uXKY3Iv+rleij0kelsESX07kgPEqInBHkvYiYmxFauY1Uz7gUotnejI9mgv5ijmsOC+q70w==
@@ -6190,6 +6210,13 @@ ajv@^8.0.0, ajv@^8.8.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+amcl-js@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/amcl-js/-/amcl-js-3.1.0.tgz#96ed3c7b18f91bf9ac991843ec9dff45a1ced744"
+  integrity sha512-36dd2w+cqK2NPww9w3ATPqbUeFgDHyTgeyXAk9jd7PXQh3uqSIdjiVCiqijIyAMDCzlkXdotkr8Sv0nmd1/UMQ==
+  dependencies:
+    prompt "^1.0.0"
+
 ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
@@ -6451,7 +6478,12 @@ async-validator@^3.0.3:
   resolved "https://registry.yarnpkg.com/async-validator/-/async-validator-3.5.1.tgz#cd62b9688b2465f48420e27adb47760ab1b5559f"
   integrity sha512-DDmKA7sdSAJtTVeNZHrnr2yojfFaoeW8MfQN8CeuXg8DDQHTqKk9Fdv38dSvnesHoO8MUwMI2HphOeSyIF+wmQ==
 
-async@^2.6.2:
+async@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
+
+async@^2.6.2, async@^2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
   integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
@@ -7499,6 +7531,11 @@ colorette@^2.0.10, colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+colors@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
+  integrity sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==
+
 combined-stream@^1.0.6, combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -7940,6 +7977,11 @@ csstype@^3.0.2, csstype@^3.0.6:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
   integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
+
+cycle@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
+  integrity sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==
 
 "d3-array@2 - 3", "d3-array@2.10.0 - 3", d3-array@^3.1.6:
   version "3.2.4"
@@ -9389,7 +9431,7 @@ extend@^3.0.0:
   resolved "https://r.cnpmjs.org/extend/download/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=
 
-eyes@^0.1.8:
+eyes@0.1.x, eyes@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
@@ -10707,6 +10749,11 @@ isomorphic-ws@^4.0.1:
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
   integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
 
+isstream@0.1.x:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
+
 istanbul-lib-coverage@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
@@ -11199,6 +11246,11 @@ js-cookie@^2.2.1, js-cookie@^2.x.x:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
+js-sha256@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.10.1.tgz#b40104ba1368e823fdd5f41b66b104b15a0da60d"
+  integrity sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==
 
 js-sha3@0.5.7:
   version "0.5.7"
@@ -12329,6 +12381,11 @@ multiformats@^9.4.2:
   resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.9.0.tgz#c68354e7d21037a8f1f8833c8ccd68618e8f1d37"
   integrity sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==
 
+mute-stream@~0.0.4:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
 nan@^2.13.2:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
@@ -13075,6 +13132,15 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+plume-sig@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/plume-sig/-/plume-sig-2.0.3.tgz#579a0c16551b317b7877a769791ce1c8ee75c8dd"
+  integrity sha512-RHe5Cfa3ZRUQcJoQRWfkMWHKoTsB00vcWKt44LWb5VHTvLILpTiZg666klGNEser0J+z3k01mN5GUw9bwhCYHw==
+  dependencies:
+    "@noble/secp256k1" "^1.7.0"
+    amcl-js "^3.1.0"
+    js-sha256 "^0.10.1"
+
 pony-cause@^2.1.10:
   version "2.1.10"
   resolved "https://registry.yarnpkg.com/pony-cause/-/pony-cause-2.1.10.tgz#828457ad6f13be401a075dbf14107a9057945174"
@@ -13319,6 +13385,17 @@ progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+prompt@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/prompt/-/prompt-1.3.0.tgz#b1f6d47cb1b6beed4f0660b470f5d3ec157ad7ce"
+  integrity sha512-ZkaRWtaLBZl7KKAKndKYUL8WqNT+cQHKRZnT4RYYms48jQkFw3rrBL+/N5K/KtdEveHkxs982MX2BkDKub2ZMg==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    async "3.2.3"
+    read "1.0.x"
+    revalidator "0.1.x"
+    winston "2.x"
 
 prompts@^2.0.1:
   version "2.4.1"
@@ -14116,6 +14193,13 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+read@1.0.x:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
+  integrity sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==
+  dependencies:
+    mute-stream "~0.0.4"
+
 readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.5, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
@@ -14412,6 +14496,11 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+revalidator@0.1.x:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/revalidator/-/revalidator-0.1.8.tgz#fece61bfa0c1b52a206bd6b18198184bdd523a3b"
+  integrity sha512-xcBILK2pA9oh4SiinPEZfhP8HfrB/ha+a2fTMyl7Om2WjlDVrOQy99N2MXXlUHqGJz4qEu2duXxHJjDWuK/0xg==
 
 rimraf@^2.6.3:
   version "2.7.1"
@@ -15134,6 +15223,11 @@ stack-generator@^2.0.5:
   integrity sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==
   dependencies:
     stackframe "^1.1.1"
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
 
 stack-utils@^2.0.3:
   version "2.0.5"
@@ -16762,6 +16856,18 @@ wildcard@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
+
+winston@2.x:
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.7.tgz#5791fe08ea7e90db090f1cb31ef98f32531062f1"
+  integrity sha512-vLB4BqzCKDnnZH9PHGoS2ycawueX4HLqENXQitvFHczhgW2vFpSOn31LZtVr1KU8YTw7DS4tM+cqyovxo8taVg==
+  dependencies:
+    async "^2.6.4"
+    colors "1.0.x"
+    cycle "1.0.x"
+    eyes "0.1.x"
+    isstream "0.1.x"
+    stack-trace "0.0.x"
 
 word-wrap@^1.2.3:
   version "1.2.4"


### PR DESCRIPTION
## Explanation

This PR adds a new `eth_getPlumeSignature` RPC method that implements a [novel ECDSA nullifier scheme](https://aayushg.com/thesis.pdf) as [described](https://blog.aayushg.com/posts/nullifier) in [EIP-7524](https://github.com/ethereum/ERCs/pull/37/files#diff-d698c694be4189f928935d8c63c0df0a03e5cca1521c388a97949dc0436dc4ca).

The `eth_getPlumeSignature` method takes in two parameters, a message and an address, then generates a deterministic signature (PLUME) and several other inputs. The plume can be used as a nullifier to prevent double-spending in an anonymity set. This capability unlocks novel on-chain behavior, such as private DAO voting, [fair, non-doxxing airdrops](https://github.com/stealthdrop/stealthdrop), and more.

## Screenshot

![plume_rabby](https://github.com/RabbyHub/Rabby/assets/22937570/83e16fa7-05bd-4732-a36b-2befe763e5d0)

## Manual Testing Steps

After building and running Rabby locally, enter this into the browser console:

```js
await window.ethereum.request({
  "method": "eth_requestAccounts",
  "params": []
});

accountAddress = (await window.ethereum.request({
  "method": "eth_accounts",
  "params": []
}))[0];

await window.ethereum.request({
  "method": "eth_getPlumeSignature",
  "params": [
    "this is a test message",
    accountAddress
  ]
});
```

A confirmation screen should open up. After clicking "Sign", you will see the plume and other signals outputted into the console.



Needs https://github.com/RabbyHub/eth-simple-keyring/pull/3