### PR TITLE
chore: fix typos

### DIFF
--- a/src/background/service/customTestnet.ts
+++ b/src/background/service/customTestnet.ts
@@ -1,5 +1,5 @@
 import { customTestnetTokenToTokenItem } from '@/ui/utils/token';
-import { findChain, isSameTesnetToken, updateChainStore } from '@/utils/chain';
+import { findChain, isSameTestnetToken, updateChainStore } from '@/utils/chain';
 import { CHAINS_ENUM } from '@debank/common';
 import { GasLevel, Tx } from 'background/service/openapi';
 import { createPersistStore } from 'background/utils';
@@ -405,13 +405,13 @@ class CustomTestnetService {
 
   removeToken = (params: CustomTestnetTokenBase) => {
     this.store.customTokenList = this.store.customTokenList.filter((item) => {
-      return !isSameTesnetToken(item, params);
+      return !isSameTestnetToken(item, params);
     });
   };
 
   hasToken = (params: Pick<CustomTestnetTokenBase, 'id' | 'chainId'>) => {
     return !!this.store.customTokenList.find((item) => {
-      return isSameTesnetToken(params, item);
+      return isSameTestnetToken(params, item);
     });
   };
 
@@ -504,7 +504,7 @@ class CustomTestnetService {
     }
 
     const local = this.store.customTokenList?.find((item) => {
-      return isSameTesnetToken(item, {
+      return isSameTestnetToken(item, {
         id: tokenId,
         chainId,
       });

--- a/src/ui/views/CommonPopup/AssetList/CustomTestnetAssetList/CustomTestnetAssetListContainer.tsx
+++ b/src/ui/views/CommonPopup/AssetList/CustomTestnetAssetList/CustomTestnetAssetListContainer.tsx
@@ -15,7 +15,7 @@ import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { EditCustomTestnetModal } from '@/ui/views/CustomTestnet/components/EditTestnetModal';
 import { useThemeMode } from '@/ui/hooks/usePreference';
-import { isSameTesnetToken } from '@/utils/chain';
+import { isSameTestnetToken } from '@/utils/chain';
 
 interface Props {
   className?: string;
@@ -169,7 +169,7 @@ export const CustomTestnetAssetListContainer: React.FC<Props> = ({
               if (!search) {
                 mutate((prev) => {
                   return (prev || []).find((item) => {
-                    return isSameTesnetToken(item, token);
+                    return isSameTestnetToken(item, token);
                   })
                     ? prev
                     : [...(prev || []), token];
@@ -180,7 +180,7 @@ export const CustomTestnetAssetListContainer: React.FC<Props> = ({
               if (!search) {
                 mutate((prev) => {
                   return (prev || []).filter((item) => {
-                    return !isSameTesnetToken(item, token);
+                    return !isSameTestnetToken(item, token);
                   });
                 });
               }

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -474,7 +474,7 @@ export function supportedChainToChain(item: SupportedChain): Chain {
   };
 }
 
-export const isSameTesnetToken = <
+export const isSameTestnetToken = <
   T1 extends Pick<CustomTestnetToken, 'id' | 'chainId'>,
   T2 extends Pick<CustomTestnetToken, 'id' | 'chainId'>
 >(


### PR DESCRIPTION
fix a typo: `isSameTesnetToken` -> `isSameTestnetToken`