### PR TITLE
swap order of event subscriptions in keystone keyring constructor

### DIFF
--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -2561,7 +2561,7 @@ export class WalletController extends BaseController {
     const keyringType = KEYRING_CLASS.HARDWARE.KEYSTONE;
     const keyring: KeystoneKeyring = this._getKeyringByType(keyringType);
     if (keyring) {
-      keyring.getInteraction().on(MemStoreDataReady, (request) => {
+      keyring.getInteraction().once(MemStoreDataReady, (request) => {
         eventBus.emit(EVENTS.broadcastToUI, {
           method: EVENTS.QRHARDWARE.ACQUIRE_MEMSTORE_SUCCEED,
           params: {


### PR DESCRIPTION
calling 'getMemStore().subscribe' before the AcquireMemeStoreData event is fired caused the 'request' variable to be stale

fixes #2203