### PR TITLE
kill walletconnect connector when removing address

### DIFF
--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -2229,6 +2229,8 @@ export class WalletController extends BaseController {
     brand?: string,
     removeEmptyKeyrings?: boolean
   ) => {
+    await this.killWalletConnectConnector(address, brand || type, true, true);
+    
     if (removeEmptyKeyrings) {
       const keyring = await keyringService.getKeyringForAccount(address, type);
       this.removeMnemonicKeyringFromStash(keyring);


### PR DESCRIPTION
When removing an address/account, the walletconnect connector needs to be killed.