### PR TITLE
Update defunct, potentially risky QR dependency & Increase QR size

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "patch-package": "6.4.7",
     "postinstall-postinstall": "2.1.0",
     "process": "0.11.10",
-    "qrcode.react": "1.0.1",
+    "qrcode.react": "3.1.0",
     "raw-loader": "4.0.2",
     "react": "17.0.2",
     "react-countup": "6.5.0",

--- a/src/ui/views/Approval/components/QRHardWareWaiting/Player.tsx
+++ b/src/ui/views/Approval/components/QRHardWareWaiting/Player.tsx
@@ -41,7 +41,7 @@ const Player = ({
   return (
     <div className="flex flex-col items-center">
       <div className="p-[5px] border border-gray-divider rounded-[8px] bg-white">
-        <QRCode value={currentQRCode.toUpperCase()} size={playerSize ?? 250} />
+        <QRCode value={currentQRCode.toUpperCase()} size={playerSize ?? 180} />
       </div>
       <p
         className={clsx(

--- a/src/ui/views/Approval/components/QRHardWareWaiting/Player.tsx
+++ b/src/ui/views/Approval/components/QRHardWareWaiting/Player.tsx
@@ -41,7 +41,7 @@ const Player = ({
   return (
     <div className="flex flex-col items-center">
       <div className="p-[5px] border border-gray-divider rounded-[8px] bg-white">
-        <QRCode value={currentQRCode.toUpperCase()} size={playerSize ?? 180} />
+        <QRCode value={currentQRCode.toUpperCase()} size={playerSize ?? 250} />
       </div>
       <p
         className={clsx(


### PR DESCRIPTION
Hi Team, 

This PR is a copy of one recently merged for MetaMask: https://github.com/MetaMask/metamask-extension/pull/24952

We noticed differences in density, i.e. QR version number, between the animated QR codes generated by the MetaMask extension and the MetaMask mobile app.

In essence, we discovered several issues with a subdependency in the currently used version of `qrcode.react`: `qr.js` which is used to generate the QR images. Please see the above linked PR at MetaMask for full details. 

To address the potential security risk and the irregular QR codes generated by the defunct dependency, it suffices to increase the version number of qrcode.react to the latest version.

Additionally, We also propose to increase the QR code image size to 250px, reflecting the size used with MetaMask and that we have been able to test most thoroughly with the updated dependency. 
