### PR TITLE
feat: tooltip within an approval page will appear in a container with padding

### DIFF
--- a/src/ui/component/Tooltip/TooltipWithMagnetArrow.tsx
+++ b/src/ui/component/Tooltip/TooltipWithMagnetArrow.tsx
@@ -41,13 +41,15 @@ const TooltipWrapStyled = styled(TooltipWrap)`
  *
  * New feature:
  * - viewportOffset: [top, right, bottom, left], offset of the tooltip to the viewport
+ * - inApproval: if in approval page, the tooltip will have a viewportOffset of [0, -16, 0, 16]
  */
 export const TooltipWithMagnetArrow = React.forwardRef<
   any,
   TooltipProps & {
     viewportOffset?: [number, number, number, number];
+    inApproval?: boolean;
   }
->(({ viewportOffset = [0, 0, 0, 0], ...props }, ref) => {
+>(({ viewportOffset, inApproval, ...props }, ref) => {
   const [left, setLeft] = React.useState(0);
 
   const getPopupContainer = (trigger) => {
@@ -80,11 +82,19 @@ export const TooltipWithMagnetArrow = React.forwardRef<
 
   const tooltipRef = React.useRef(null);
 
+  const currentViewportOffset = React.useMemo(() => {
+    if (!viewportOffset) {
+      return inApproval ? [0, -16, 0, 16] : [0, 0, 0, 0];
+    }
+
+    return viewportOffset;
+  }, [viewportOffset]);
+
   return (
     <TooltipWrapStyled
       align={
         {
-          viewportOffset,
+          viewportOffset: currentViewportOffset,
         } as any
       }
       {...props}

--- a/src/ui/views/Approval/components/Actions/ContractCall.tsx
+++ b/src/ui/views/Approval/components/Actions/ContractCall.tsx
@@ -159,6 +159,7 @@ const ContractCall = ({
                 {requireData.call.func || '-'}
               </span>
               <TooltipWithMagnetArrow
+                inApproval
                 overlayClassName="rectangle w-[max-content]"
                 title={
                   requireData.call.func

--- a/src/ui/views/Approval/components/Actions/components/SubTable.tsx
+++ b/src/ui/views/Approval/components/Actions/components/SubTable.tsx
@@ -148,6 +148,7 @@ export const SubRow = ({
       {children}
       {tip && (
         <TooltipWithMagnetArrow
+          inApproval
           title={tip}
           overlayClassName="rectangle w-[max-content] max-w-[355px]"
         >

--- a/src/ui/views/Approval/components/Actions/components/Table.tsx
+++ b/src/ui/views/Approval/components/Actions/components/Table.tsx
@@ -137,6 +137,7 @@ const Row = ({
       {children}
       {tip && (
         <TooltipWithMagnetArrow
+          inApproval
           title={tip}
           overlayClassName="rectangle w-[max-content] max-w-[355px]"
         >

--- a/src/ui/views/Approval/components/Actions/components/Values.tsx
+++ b/src/ui/views/Approval/components/Actions/components/Values.tsx
@@ -274,6 +274,7 @@ const TokenLabel = ({
     >
       {isFake && (
         <TooltipWithMagnetArrow
+          inApproval
           overlayClassName="rectangle w-[max-content]"
           title={t('page.signTx.fakeTokenAlert')}
         >
@@ -282,6 +283,7 @@ const TokenLabel = ({
       )}
       {isScam && (
         <TooltipWithMagnetArrow
+          inApproval
           overlayClassName="rectangle w-[max-content]"
           title={t('page.signTx.scamTokenAlert')}
         >
@@ -329,6 +331,7 @@ const Address = ({
   return (
     <AddressWrapper className="value-address relative">
       <TooltipWithMagnetArrow
+        inApproval
         title={address}
         className="rectangle w-[max-content]"
       >
@@ -368,6 +371,7 @@ const AddressWithCopy = ({
   return (
     <AddressWrapper className="value-address relative" id={id}>
       <TooltipWithMagnetArrow
+        inApproval
         title={address}
         className="rectangle w-[max-content]"
       >

--- a/src/ui/views/Approval/components/Actions/index.tsx
+++ b/src/ui/views/Approval/components/Actions/index.tsx
@@ -150,6 +150,7 @@ const Actions = ({
             <div className="left">
               {isSpeedUp && (
                 <TooltipWithMagnetArrow
+                  inApproval
                   placement="bottom"
                   overlayClassName="rectangle w-[max-content]"
                   title={t('page.signTx.speedUpTooltip')}
@@ -164,6 +165,7 @@ const Actions = ({
               <span>{actionName}</span>
               {isUnknown && (
                 <TooltipWithMagnetArrow
+                  inApproval
                   placement="bottom"
                   overlayClassName="rectangle w-[max-content] decode-tooltip"
                   title={

--- a/src/ui/views/Approval/components/AddAsset.tsx
+++ b/src/ui/views/Approval/components/AddAsset.tsx
@@ -414,6 +414,7 @@ const AddAsset = ({ params }: { params: AddAssetProps }) => {
               {t('global.cancelButton')}
             </Button>
             <TooltipWithMagnetArrow
+              inApproval
               overlayClassName="rectangle w-[max-content]"
               title={addButtonStatus.reason}
             >

--- a/src/ui/views/Approval/components/BroadcastMode/index.tsx
+++ b/src/ui/views/Approval/components/BroadcastMode/index.tsx
@@ -377,6 +377,7 @@ export const BroadcastMode = ({
         <OptionList>
           {options.map((option) => (
             <TooltipWithMagnetArrow
+              inApproval
               title={option.tips || ''}
               className="rectangle w-[max-content]"
               align={{

--- a/src/ui/views/Approval/components/FooterBar/GasLessComponents.tsx
+++ b/src/ui/views/Approval/components/FooterBar/GasLessComponents.tsx
@@ -54,6 +54,7 @@ export function GasLessNotEnough({
 
         {gasLessFailedReason ? (
           <TooltipWithMagnetArrow
+            inApproval
             visible={hoverGasLessFailedReason}
             title={gasLessFailedReason}
             className="rectangle w-[max-content]"

--- a/src/ui/views/Approval/components/FooterBar/ProcessActions.tsx
+++ b/src/ui/views/Approval/components/FooterBar/ProcessActions.tsx
@@ -19,6 +19,7 @@ export const ProcessActions: React.FC<Props> = ({
   return (
     <ActionsContainer onCancel={onCancel}>
       <TooltipWithMagnetArrow
+        inApproval
         overlayClassName="rectangle sign-tx-forbidden-tooltip"
         title={tooltipContent}
         viewportOffset={[20, -20, -20, 20]}

--- a/src/ui/views/Approval/components/OriginInfo.tsx
+++ b/src/ui/views/Approval/components/OriginInfo.tsx
@@ -137,6 +137,7 @@ export const OriginInfo: React.FC<Props> = ({
             height="24px"
           />
           <TooltipWithMagnetArrow
+            inApproval
             className="rectangle w-[max-content]"
             title={currentChain.name}
           >

--- a/src/ui/views/Approval/components/SecurityEngine/RuleDrawer.backup.tsx
+++ b/src/ui/views/Approval/components/SecurityEngine/RuleDrawer.backup.tsx
@@ -520,6 +520,7 @@ const RuleDrawer = ({
               {selectRule.ruleConfig.valueDescription}
               {valueTooltip ? (
                 <TooltipWithMagnetArrow
+                  inApproval
                   className="rectangle w-[max-content] max-w-[355px]"
                   title={valueTooltip}
                 >

--- a/src/ui/views/Approval/components/SecurityEngine/RuleDrawer.tsx
+++ b/src/ui/views/Approval/components/SecurityEngine/RuleDrawer.tsx
@@ -294,6 +294,7 @@ const RuleDrawer = ({
             {currentDescription}
             {valueTooltip ? (
               <TooltipWithMagnetArrow
+                inApproval
                 className="rectangle w-[max-content] max-w-[355px]"
                 title={valueTooltip}
               >

--- a/src/ui/views/Approval/components/SignTestnetTx/components/TestnetActions.tsx
+++ b/src/ui/views/Approval/components/SignTestnetTx/components/TestnetActions.tsx
@@ -101,6 +101,7 @@ export const TestnetActions = ({
             <div className="left">
               {isSpeedUp && (
                 <TooltipWithMagnetArrow
+                  inApproval
                   placement="bottom"
                   overlayClassName="rectangle w-[max-content]"
                   title={t('page.signTx.speedUpTooltip')}
@@ -115,6 +116,7 @@ export const TestnetActions = ({
               <span>{actionName}</span>
               {isUnknown && (
                 <TooltipWithMagnetArrow
+                  inApproval
                   placement="bottom"
                   overlayClassName="rectangle w-[max-content] decode-tooltip"
                   title={

--- a/src/ui/views/Approval/components/TextActions/index.tsx
+++ b/src/ui/views/Approval/components/TextActions/index.tsx
@@ -144,6 +144,7 @@ const Actions = ({
               <span>{actionName}</span>
               {isUnknown && (
                 <TooltipWithMagnetArrow
+                  inApproval
                   placement="bottom"
                   overlayClassName="rectangle w-[max-content] decode-tooltip"
                   title={

--- a/src/ui/views/Approval/components/TxComponents/GasSelecter.tsx
+++ b/src/ui/views/Approval/components/TxComponents/GasSelecter.tsx
@@ -681,6 +681,7 @@ const GasSelector = ({
                       !CAN_ESTIMATE_L1_FEE_CHAINS.includes(chain.enum) && (
                         <span className="relative ml-6">
                           <TooltipWithMagnetArrow
+                            inApproval
                             title={t('page.signTx.l2GasEstimateTooltip')}
                             className="rectangle w-[max-content]"
                           >

--- a/src/ui/views/Approval/components/TxComponents/GasSelectorHeader.tsx
+++ b/src/ui/views/Approval/components/TxComponents/GasSelectorHeader.tsx
@@ -765,6 +765,7 @@ const GasSelectorHeader = ({
                     !CAN_ESTIMATE_L1_FEE_CHAINS.includes(chain.enum) && (
                       <span className="relative ml-6">
                         <TooltipWithMagnetArrow
+                          inApproval
                           title={t('page.signTx.l2GasEstimateTooltip')}
                           className="rectangle w-[max-content]"
                         >

--- a/src/ui/views/Approval/components/TypedDataActions/ContractCall.tsx
+++ b/src/ui/views/Approval/components/TypedDataActions/ContractCall.tsx
@@ -165,6 +165,7 @@ const ContractCall = ({
                 {operation || '-'}
               </span>
               <TooltipWithMagnetArrow
+                inApproval
                 overlayClassName="rectangle w-[max-content]"
                 title={
                   operation

--- a/src/ui/views/Approval/components/TypedDataActions/index.tsx
+++ b/src/ui/views/Approval/components/TypedDataActions/index.tsx
@@ -113,6 +113,7 @@ const Actions = ({
               <span>{actionName}</span>
               {isUnknown && (
                 <TooltipWithMagnetArrow
+                  inApproval
                   placement="bottom"
                   overlayClassName="rectangle w-[max-content] decode-tooltip"
                   title={


### PR DESCRIPTION
before
<img width="370" alt="截屏2024-07-11 11 19 43" src="https://github.com/RabbyHub/Rabby/assets/110591045/5188874b-07d9-4ff2-a8e6-4b1834087f1e">

after:
<img width="392" alt="截屏2024-07-11 11 17 58" src="https://github.com/RabbyHub/Rabby/assets/110591045/1861b13b-516e-488a-8ba5-43b31c3609b9">
