### PR TITLE
fix: gas limit issue in testnet

### DIFF
--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -172,7 +172,8 @@ export async function calcGasLimit({
   let recommendGasLimit = needRatio
     ? gas.times(ratio).toFixed(0)
     : gas.toFixed(0);
-  if (block && new BigNumber(recommendGasLimit).gt(block.gasLimit)) {
+  const blockGasRatio = SAFE_GAS_LIMIT_BUFFER[chain.id] || 1;
+  if (block && new BigNumber(block.gasLimit).times(blockGasRatio).lt(recommendGasLimit)) {
     const buffer = SAFE_GAS_LIMIT_BUFFER[chain.id] || DEFAULT_GAS_LIMIT_BUFFER;
     recommendGasLimit = new BigNumber(block.gasLimit).times(buffer).toFixed(0);
   }


### PR DESCRIPTION
The problem in #2710 still exists after new release, so I've double checked the changes introduced in #2726 and noticed that the safe buffer only applies when the recommended gas limit is strictly greater than the block gas limit. However, there can be scenarios—such as an estimated gas limit of 59M against a block limit of 60M—where the buffer isn't applied, even though it might still be necessary. For example, Bifrost chain allows only 86% of the block gas limit for a single transaction, meaning a 59M gas estimate could actually fail if the block limit is 60M. It might be beneficial to adjust the logic to account for this by checking whether the recommended gas limit exceeds the (block gas limit * safe buffer ratio) instead.