### PR TITLE
feat: add preconf networks support

### DIFF
--- a/_raw/locales/en/messages.json
+++ b/_raw/locales/en/messages.json
@@ -2171,7 +2171,8 @@
         "rpcUrlRequired": "Please input RPC URL",
         "nativeTokenSymbol": "Currency symbol",
         "nativeTokenSymbolRequired": "Please input currency symbol",
-        "blockExplorerUrl": "Block explorer URL (Optional)"
+        "blockExplorerUrl": "Block explorer URL (Optional)",
+        "hasPreconfs": "This network supports preconfirmations"
       },
       "AddFromChainList": {
         "title": "Quick add from Chainlist",

--- a/_raw/locales/es/messages.json
+++ b/_raw/locales/es/messages.json
@@ -2166,7 +2166,8 @@
         "rpcUrl": "RPC URL",
         "id": "Chain ID",
         "name": "Nombre de la red",
-        "idRequired": "Por favor, introduzca el id de la cadena"
+        "idRequired": "Por favor, introduzca el id de la cadena",
+        "hasPreconfs": "Esta red soporta preconfirmaciones"
       },
       "AddFromChainList": {
         "tips": {

--- a/src/background/service/customTestnet.ts
+++ b/src/background/service/customTestnet.ts
@@ -30,6 +30,7 @@ export interface TestnetChainBase {
   nativeTokenSymbol: string;
   rpcUrl: string;
   scanLink?: string;
+  hasPreconfs?: boolean;
 }
 
 export interface TestnetChain extends TestnetChainBase {

--- a/src/ui/views/Approval/components/AddChain/AddChain.tsx
+++ b/src/ui/views/Approval/components/AddChain/AddChain.tsx
@@ -35,6 +35,7 @@ const AddChain = ({ params }: { params: AddChainProps }) => {
       rpcUrl: addChainParams.rpcUrls?.[0],
       nativeTokenSymbol: addChainParams.nativeCurrency?.symbol,
       scanLink: addChainParams.blockExplorerUrls?.[0],
+      hasPreconfs: addChainParams.hasPreconfs,
     });
   }, [form, addChainParams]);
 

--- a/src/ui/views/Approval/components/AddChain/type.ts
+++ b/src/ui/views/Approval/components/AddChain/type.ts
@@ -8,4 +8,5 @@ export interface AddEthereumChainParams {
   };
   rpcUrls: string[];
   blockExplorerUrls: string[];
+  hasPreconfs: boolean;
 }

--- a/src/ui/views/CustomTestnet/components/CustomTestnetForm.tsx
+++ b/src/ui/views/CustomTestnet/components/CustomTestnetForm.tsx
@@ -1,5 +1,5 @@
 import { TestnetChainBase } from '@/background/service/customTestnet';
-import { Form, FormInstance, Input } from 'antd';
+import { Checkbox, Form, FormInstance, Input } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMount } from 'ahooks';
@@ -9,7 +9,8 @@ const Warper = styled.div`
   .ant-form-item {
     margin-bottom: 16px;
   }
-  .ant-form-item-label > label {
+  .ant-form-item-label > label,
+  .ant-checkbox-wrapper {
     color: var(--r-neutral-body, #3e495e);
     font-size: 13px;
     line-height: 16px;
@@ -146,6 +147,11 @@ export const CustomTestnetForm = ({
           name="scanLink"
         >
           <Input autoComplete="off" disabled={disabled} />
+        </Form.Item>
+        <Form.Item name="hasPreconfs" valuePropName="checked">
+          <Checkbox disabled={disabled}>
+            {t('page.customTestnet.CustomTestnetForm.hasPreconfs')}
+          </Checkbox>
         </Form.Item>
       </Form>
     </Warper>


### PR DESCRIPTION
This PR enhances support for preconf networks by optimizing receipt polling intervals. To maintain efficiency and backwards compatibility in standard networks, the default interval remains at 5 seconds. However, when a preconf network has a pending transaction, the system accelerates receipt requests to a 200ms interval.

Users can now specify whether a network supports preconf when adding or editing it.

![image](https://github.com/user-attachments/assets/0bc4d25d-d1c5-42b6-b4f6-f8e3437b5cf1)
