### PR TITLE
feat: add support for XDC chain in types and utilities

### DIFF
--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -125,6 +125,7 @@ export enum CHAINS_ENUM {
   TIOTX = 'TIOTX',
   TPLS = 'TPLS',
   HETH = 'HETH',
+  XDC = 'XDC',
   BKLAY = 'BKLAY',
   CSGB = 'CSGB',
   TKAVA = 'TKAVA',

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -454,6 +454,7 @@ export function supportedChainToChain(item: SupportedChain): Chain {
     frax: 'FRAX',
     aze: 'AZE',
     karak: 'KARAK',
+    xdc: 'XDC',
   };
   return {
     id: item.community_id,


### PR DESCRIPTION
feat: add support for XDC chain in types and utilities

This PR adds support for the XDC Network (XinFin) to the Rabby wallet by:

1. Adding XDC chain mapping in chainServerIdEnumDict in src/utils/chain.ts
2. Including XDC in the CHAINS_ENUM in src/types/chain.ts

The XDC Network is an enterprise-ready hybrid blockchain that combines the best of public and private blockchains with interoperable smart contracts. This addition will allow Rabby wallet users to interact with dApps on the XDC Network.

Chain details:
- Chain ID: 50
- Network Name: XDC Network
- Native Token: XDC
- RPC URL: https://erpc.xinfin.network
- Explorer: https://explorer.xinfin.network