### PR TITLE
feat: allow copying wallet PK without displaying it

### DIFF
--- a/src/ui/views/AddressBackup/PrivateKey.tsx
+++ b/src/ui/views/AddressBackup/PrivateKey.tsx
@@ -68,11 +68,9 @@ const AddressBackup = () => {
             {t('page.backupPrivateKey.clickToShow')}
           </div>
         ) : (
-          <>
-            {data}
-            <Copy icon={IconCopy} data={data} className="icon-copy"></Copy>
-          </>
+          <p className="private-key-text">{data}</p>
         )}
+        <Copy icon={IconCopy} data={data} className="icon-copy"></Copy>
       </div>
 
       <div className="footer pb-[20px]">

--- a/src/ui/views/AddressBackup/style.less
+++ b/src/ui/views/AddressBackup/style.less
@@ -61,6 +61,11 @@
       width: 16px;
       height: 16px;
     }
+
+    &-text {
+      padding-right: 18px;
+    }
+
     &-mask {
       height: 100%;
       svg {
@@ -74,6 +79,8 @@
       font-size: 14px;
       line-height: 18px;
       text-align: center;
+      margin-right: 48px;
+      margin-left: 48px;
 
       display: flex;
       align-items: center;


### PR DESCRIPTION

This PR enables copying a wallet's private key without revealing it on screen. Useful for handling keys discreetly.

The copy button is now always visible. The width of the "Click to show" area has been reduced to remove overlap, to avoid accidental key exposure when clicking the copy button.

<img width="25%" src="https://github.com/user-attachments/assets/b348314f-4ed5-4295-a002-faccd282c3c5" />
