### PR TITLE
fix: typo

### DIFF
--- a/_raw/locales/index.json
+++ b/_raw/locales/index.json
@@ -13,5 +13,5 @@
   { "code": "pt", "name": "Português" },
   { "code": "vi", "name": "Tiếng Việt" },
   { "code": "id", "name": "Bahasa Indonesia" },
-  { "code": "ko", "name": "한국인" }
+  { "code": "ko", "name": "한국어" }
 ]


### PR DESCRIPTION
This PR fixes a typo in the list of supported languages. The existing term `한국인` means "Korean people," so `한국어` ("Korean language") is more appropriate here.