### PR TITLE
fix(ui): center multiline text inside DashBoard panel component

### DIFF
--- a/src/ui/views/Dashboard/components/DashboardPanel/index.tsx
+++ b/src/ui/views/Dashboard/components/DashboardPanel/index.tsx
@@ -110,6 +110,7 @@ const Container = styled.div`
       font-size: 13px;
       line-height: 16px;
       color: var(--r-neutral-title-1, rgba(25, 41, 69, 1));
+      text-align: center;
     }
 
     @keyframes icn-spin {


### PR DESCRIPTION
Text inside a div was only centered when it was a single line. 
When the text wrapped to multiple lines, it appeared left-aligned.

### Solution
Added `text-align: center` to the container's CSS rule to ensure multiline text stays centered.

### Testing
- Verified with long text that wraps to multiple lines.
- Confirmed alignment remains centered in both single and multiline cases.

### Impact
Minor visual fix only; no functional or structural changes.


<img width="402" height="397" alt="bug" src="https://github.com/user-attachments/assets/82df25b4-66dd-40da-9b1e-2a198e32697c" />

<img width="395" height="402" alt="fixed" src="https://github.com/user-attachments/assets/d4e66f61-a937-46ec-9f27-9126a3af7838" />

