### PR TITLE
fix: harden typed data message parsing

### DIFF
--- a/__tests__/ui/parseSignTypedDataMessage.test.ts
+++ b/__tests__/ui/parseSignTypedDataMessage.test.ts
@@ -1,0 +1,57 @@
+import {
+  filterPrimaryType,
+  parseSignTypedDataMessage,
+} from '@/ui/views/Approval/components/SignTypedDataExplain/parseSignTypedDataMessage';
+
+declare const describe: any;
+declare const it: any;
+declare const expect: any;
+
+describe('parseSignTypedDataMessage', () => {
+  it('returns raw string when JSON is invalid', () => {
+    const raw = '{not-json';
+    expect(parseSignTypedDataMessage(raw)).toBe(raw);
+  });
+
+  it('returns message when primaryType is missing', () => {
+    const raw = {
+      message: { hello: 'world' },
+    };
+    expect(parseSignTypedDataMessage(raw)).toEqual({ hello: 'world' });
+  });
+
+  it('returns filtered message for valid typed data payload', () => {
+    const raw = {
+      primaryType: 'Mail',
+      types: {
+        Mail: [
+          { name: 'from', type: 'address' },
+          { name: 'to', type: 'address' },
+        ],
+      },
+      message: {
+        from: '0x1111111111111111111111111111111111111111',
+        to: '0x2222222222222222222222222222222222222222',
+        extra: 'ignored',
+      },
+    };
+
+    expect(parseSignTypedDataMessage(raw)).toEqual({
+      from: '0x1111111111111111111111111111111111111111',
+      to: '0x2222222222222222222222222222222222222222',
+    });
+  });
+});
+
+describe('filterPrimaryType', () => {
+  it('falls back to message when types[primaryType] is missing', () => {
+    const message = { a: 1 };
+    expect(
+      filterPrimaryType({
+        primaryType: 'Mail',
+        types: {},
+        message,
+      })
+    ).toEqual(message);
+  });
+});

--- a/src/ui/views/Approval/components/SignTypedDataExplain/parseSignTypedDataMessage.ts
+++ b/src/ui/views/Approval/components/SignTypedDataExplain/parseSignTypedDataMessage.ts
@@ -1,5 +1,12 @@
 export const parseSignTypedDataMessage = (raw: string | object) => {
-  const data = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  let data: any = raw;
+  if (typeof raw === 'string') {
+    try {
+      data = JSON.parse(raw);
+    } catch (e) {
+      return raw;
+    }
+  }
 
   if (!data.primaryType) {
     return data.message;
@@ -20,6 +27,10 @@ export const filterPrimaryType = ({
 }) => {
   const keys = types[primaryType];
   const filteredMessage: Record<string, string> = {};
+
+  if (!Array.isArray(keys)) {
+    return message;
+  }
 
   keys.forEach((key: { name: string; type: string }) => {
     filteredMessage[key.name] = message[key.name];


### PR DESCRIPTION
## Motivation

The typed data approval UI assumes the incoming payload is valid JSON and that types[primaryType] exists. In practice, some dapps/providers can send malformed typed data (invalid JSON) or incomplete schemas, which can cause a runtime exception (JSON.parse throw / forEach on undefined) and break the approval screen.

## Solution

Harden parseSignTypedDataMessage and filterPrimaryType with safe guards:

- Wrap JSON parsing in try/catch and fall back to the raw input when parsing fails.
- Validate types[primaryType] is an array before iterating; otherwise fall back to returning message.
- **Add unit tests** covering invalid JSON, missing primaryType, missing schema for primaryType, and a valid filtering case.