### PR TITLE
fix: support object typed data payload in validation

### DIFF
--- a/src/background/controller/provider/controller.ts
+++ b/src/background/controller/provider/controller.ts
@@ -137,7 +137,7 @@ const signTypedDataVlidation = ({
 }: ProviderRequest) => {
   let jsonData;
   try {
-    jsonData = JSON.parse(data);
+    jsonData = typeof data === 'string' ? JSON.parse(data) : data;
   } catch (e) {
     throw ethErrors.rpc.invalidParams('data is not a validate JSON string');
   }


### PR DESCRIPTION
## Motivation

Some dapps/providers pass EIP-712 typed data as an object rather than a JSON string. The current validation logic assumes data is always a string and unconditionally calls JSON.parse(data), which throws for object inputs and causes signing requests to fail with invalidParams.

## Solution

Update signTypedDataVlidation to only JSON.parse when data is a string; otherwise use the object payload directly. This preserves existing behavior for string inputs while preventing runtime errors for object inputs.