### PR TITLE
fix: handle protocol-less URLs in getOriginFromUrl

### DIFF
--- a/__tests__/utils/getOriginFromUrl.test.ts
+++ b/__tests__/utils/getOriginFromUrl.test.ts
@@ -1,0 +1,23 @@
+import { getOriginFromUrl } from '@/utils';
+
+declare const describe: any;
+declare const it: any;
+declare const expect: any;
+
+describe('getOriginFromUrl', () => {
+  it('returns origin for full URL', () => {
+    expect(getOriginFromUrl('https://example.com/path')).toBe(
+      'https://example.com'
+    );
+  });
+
+  it('handles URL without protocol', () => {
+    expect(getOriginFromUrl('exchange.pancakeswap.finance/blabla')).toBe(
+      'https://exchange.pancakeswap.finance'
+    );
+  });
+
+  it('returns empty string for invalid input', () => {
+    expect(getOriginFromUrl('not a url')).toBe('');
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,8 +25,17 @@ export const getChain = (chainId?: string) => {
 };
 
 export const getOriginFromUrl = (url: string) => {
-  const urlObj = new URL(url);
-  return urlObj.origin;
+  try {
+    const urlObj = new URL(url);
+    return urlObj.origin;
+  } catch (e) {
+    try {
+      const urlObj = new URL(`https://${url}`);
+      return urlObj.origin;
+    } catch (e) {
+      return '';
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
## Motivation
getOriginFromUrl currently relies on new URL(url) and throws for inputs without a protocol (e.g. exchange.pancakeswap.finance/blabla). However, the surrounding utilities (getMainDomain) explicitly accept URLs in this format. This can lead to unexpected runtime errors and empty domain extraction.

## Solution
Make getOriginFromUrl resilient by:

- parsing normally when a protocol is present
- falling back to https:// when protocol is missing
- returning an empty string for invalid inputs
- **Add unit tests** covering protocol URLs, protocol-less URLs, and invalid strings.