### PR TITLE
fix: guard SIWE origin URL parsing

### DIFF
--- a/__tests__/ui/siweDomain.test.ts
+++ b/__tests__/ui/siweDomain.test.ts
@@ -1,0 +1,17 @@
+import { checkSIWEDomain } from '@/ui/utils/siwe';
+
+declare const describe: any;
+declare const it: any;
+declare const expect: any;
+
+describe('checkSIWEDomain', () => {
+  it('returns true when parsed domain matches origin host', () => {
+    const parsedMessage: any = { domain: 'example.com' };
+    expect(checkSIWEDomain('https://example.com', parsedMessage)).toBe(true);
+  });
+
+  it('returns false when origin is not a valid URL', () => {
+    const parsedMessage: any = { domain: 'example.com' };
+    expect(checkSIWEDomain('not a url', parsedMessage)).toBe(false);
+  });
+});

--- a/src/ui/utils/siwe.ts
+++ b/src/ui/utils/siwe.ts
@@ -26,8 +26,12 @@ export const checkSIWEDomain = (
   let isSIWEDomainValid = false;
 
   if (origin) {
-    const { host } = new URL(origin);
-    isSIWEDomainValid = parsedMessage.domain === host;
+    try {
+      const { host } = new URL(origin);
+      isSIWEDomainValid = parsedMessage.domain === host;
+    } catch (error) {
+      isSIWEDomainValid = false;
+    }
   }
   return isSIWEDomainValid;
 };


### PR DESCRIPTION
## Motivation
_checkSIWEDomain_ currently parses origin using new URL(origin) without guarding against invalid inputs. If origin is malformed, URL parsing throws and can break the SIWE validation flow.

## Solution
Wrap origin URL parsing in a try/catch and return false when origin is not a valid URL. **Add unit tests for valid and invalid origin inputs.**