### PR TITLE
fix: handle uppercase protocol in IPFS gateway URL

### DIFF
--- a/src/background/utils/ipfs.ts
+++ b/src/background/utils/ipfs.ts
@@ -69,7 +69,7 @@ export function getFormattedIpfsUrl(
  * @returns A URL with a https:// prepended.
  */
 export function addUrlProtocolPrefix(urlString: string): string {
-  if (!urlString.match(/(^http:\/\/)|(^https:\/\/)/u)) {
+  if (!urlString.match(/^https?:\/\//iu)) {
     return `https://${urlString}`;
   }
   return urlString;


### PR DESCRIPTION
## Motivation
_addUrlProtocolPrefix_ is used to normalize user-provided IPFS gateway URLs. The current protocol detection is case-sensitive, so inputs like HTTPS://ipfs.io are treated as missing a protocol and get double-prefixed (https://HTTPS://...), producing an invalid URL.

## Solution
Make protocol detection case-insensitive (/^https?:\\/\\//iu) so http://, https://, and HTTPS:// are all recognized correctly. 