### PR TITLE
fix: guard JSON parsing in current balance error handler

### DIFF
--- a/src/ui/hooks/useCurrentBalance.ts
+++ b/src/ui/hooks/useCurrentBalance.ts
@@ -70,7 +70,11 @@ export default function useCurrentBalance(
       onError(e) {
         setBalanceLoading(false);
         try {
-          const { error_code, err_chain_ids } = JSON.parse(e.message);
+          const msg = typeof (e as any)?.message === 'string' ? (e as any).message : '';
+          if (!msg || msg[0] !== '{') {
+            throw new Error('non-json error message');
+          }
+          const { error_code, err_chain_ids } = JSON.parse(msg);
           if (error_code === 2) {
             const chainNames = err_chain_ids.map((serverId: string) => {
               const chain = findChainByServerID(serverId);


### PR DESCRIPTION
## Motivation
_useCurrentBalance_ tries to parse e.message as JSON in the error handler. In some cases the error message is not a JSON string, causing a secondary exception inside onError and producing noisy logs / hiding the original failure mode.

## Solution
Guard JSON parsing by ensuring e.message is a string and looks like a JSON object before calling JSON.parse. If it’s not JSON, fall back to the existing error path.