### PR TITLE
Correcting Link Format: Replacing Raw URL with Readable Project Name

### DIFF
--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -12,7 +12,7 @@ gasPrice means how much you will pay for each step of this transaction, if DApp 
 
 ## value
 
-Sometimes DApp doesn't set value param (like [https://pancakeswap.finance/farms](https://pancakeswap.finance/farms), when you enable a Stake LP, value is not set), we will set `0x0` as default.
+Sometimes DApp doesn't set value param (like [PancakeSwap](https://pancakeswap.finance/farms), when you enable a Stake LP, value is not set), we will set `0x0` as default.
 
 ## data
 


### PR DESCRIPTION
The link in the text has been updated: instead of displaying the full URL (https://pancakeswap.finance/farms), the project name (PancakeSwap) is now used while preserving the same hyperlink.
This aligns with common documentation standards: links appear cleaner, avoid cluttering the text, and maintain ease of navigation.