### PR TITLE
fix: BitBox02 connection broken by security SDK scuttling

### DIFF
--- a/SecSDK/policy-over.json
+++ b/SecSDK/policy-over.json
@@ -487,5 +487,14 @@
       },
       "disallow": []
     }
+  },
+  "node_modules/bitbox-api/bitbox_api.js": {
+    "enable": false
+  },
+  "node_modules/bitbox-api/bitbox_api_bg.js": {
+    "enable": false
+  },
+  "node_modules/bitbox-api/webhid.js": {
+    "enable": false
   }
 }

--- a/SecSDK/policy.json
+++ b/SecSDK/policy.json
@@ -60805,7 +60805,7 @@
             "node_modules/bitbox-api/bitbox_api_bg.wasm"
         ],
         "global": {},
-        "enable": true
+        "enable": false
     },
     "node_modules/bitbox-api/bitbox_api_bg.js": {
         "dependency": [
@@ -60821,7 +60821,7 @@
             "queueMicrotask": "r",
             "toString": "r"
         },
-        "enable": true
+        "enable": false
     },
     "node_modules/bitbox-api/webhid.js": {
         "dependency": [],
@@ -60832,7 +60832,7 @@
             "navigator": "r",
             "setTimeout": "r"
         },
-        "enable": true
+        "enable": false
     },
     "node_modules/bn.js/lib/bn.js": {
         "dependency": [

--- a/build/webpack.debug.config.js
+++ b/build/webpack.debug.config.js
@@ -25,7 +25,6 @@ const config = {
       scuttleFiles: [
         'desktop.html',
         'index.html',
-        'offscreen.html',
         'popup.html',
         'notification.html',
         'background.html',

--- a/build/webpack.pro.config.js
+++ b/build/webpack.pro.config.js
@@ -41,7 +41,6 @@ const config = {
       scuttleFiles: [
         'desktop.html',
         'index.html',
-        'offscreen.html',
         'popup.html',
         'notification.html',
         'background.html',


### PR DESCRIPTION
  The security SDK introduced in 0.93.73 breaks BitBox02 connectivity
  The bitbox-api library requires direct access to browser globals (localStorage, WebSocket,
  navigator.hid, etc.) that the SDK's scuttling mechanism restricts.

  Two changes are needed:

  1. Disable policy enforcement for bitbox-api modules in policy-over.json This prevents the SDK from wrapping/restricting the WASM bindings.

  2. Remove offscreen.html from scuttleFiles in webpack configs The offscreen document is where BitBox02 communication occurs. The scuttle runtime injection into this document breaks localStorage access needed by the noise protocol for pairing persistence.

  The scuttle isn't designed for this use case,
  WASM libraries like bitbox-api need direct browser API access,
  not proxied access through a wrapper object