### PR TITLE
Enable `RNS` Rootstock name service

### DIFF
--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -36,6 +36,7 @@ import {
   miscService,
   lendingService,
   innerDappFrameService,
+  blockscoutService,
 } from 'background/service';
 import buildinProvider, {
   EthereumProvider,
@@ -6164,6 +6165,15 @@ export class WalletController extends BaseController {
     innerDappFrameService.getInnerDappAccountByOrigin;
   setInnerDappAccount = innerDappFrameService.setInnerDappAccount;
   setInnerDappId = innerDappFrameService.setInnerDappId;
+
+  getRnsAddressByName = async (name: string) => {
+    try {
+      const rnsResult = await blockscoutService.getRnsAddressByName(name);
+      return rnsResult;
+    } catch {
+      return null;
+    }
+  };
 
   updateDashboardPanelOrder = preferenceService.updateDashboardPanelOrder;
 }

--- a/src/background/service/blockscout.ts
+++ b/src/background/service/blockscout.ts
@@ -1,0 +1,54 @@
+import { isAddress } from 'viem';
+import { http } from '../utils/http';
+
+const BENS_ROOTSTOCK_DOMAIN_API =
+  'https://bens.services.blockscout.com/api/v1/30/domains';
+
+type DomainResolveResult = {
+  addr: string;
+  name: string;
+};
+
+class BlockscoutService {
+  private extractResolvedAddress(payload: any): string | null {
+    const resolvedAddress = payload?.resolved_address?.hash;
+
+    if (
+      typeof resolvedAddress === 'string' &&
+      isAddress(resolvedAddress.toLowerCase())
+    ) {
+      return resolvedAddress;
+    }
+
+    return null;
+  }
+
+  getRnsAddressByName = async (
+    rnsName: string
+  ): Promise<DomainResolveResult | null> => {
+    const normalizedName = rnsName.trim().toLowerCase();
+    if (!normalizedName || !normalizedName.endsWith('.rsk')) {
+      return null;
+    }
+
+    const encodedName = encodeURIComponent(normalizedName);
+    const { data } = await http.get(
+      `${BENS_ROOTSTOCK_DOMAIN_API}/${encodedName}`
+    );
+
+    const addr = this.extractResolvedAddress(data);
+
+    if (!addr) {
+      return null;
+    }
+
+    return {
+      addr,
+      name: normalizedName,
+    };
+  };
+}
+
+const blockscoutService = new BlockscoutService();
+
+export default blockscoutService;

--- a/src/background/service/index.ts
+++ b/src/background/service/index.ts
@@ -26,4 +26,5 @@ export { default as OfflineChainsService } from './offlineChain';
 export { default as perpsService } from './perps';
 export { default as miscService } from './misc';
 export { default as lendingService } from './lending';
+export { default as blockscoutService } from './blockscout';
 export * from './innerDappFrame';

--- a/src/ui/views/SelectToAddress/components/EnterAddress.tsx
+++ b/src/ui/views/SelectToAddress/components/EnterAddress.tsx
@@ -150,7 +150,11 @@ export const EnterAddress = ({
     (result: string) => {
       setInputAddress(result);
       // setIsValidAddr(true);
-      setTags([`ENS: ${ensResult?.name || ''}`]);
+      let domain = 'ENS';
+      if (ensResult?.name && ensResult.name.endsWith('.rsk')) {
+        domain = 'RNS';
+      }
+      setTags([`${domain}: ${ensResult?.name || ''}`]);
       setEnsResult(null);
     },
     [ensResult?.name]
@@ -186,7 +190,13 @@ export const EnterAddress = ({
               setEnsResult(result);
               // setIsValidAddr(true);
             } else {
-              setEnsResult(null);
+              const rnsResult = await wallet.getRnsAddressByName(address);
+
+              if (rnsResult && rnsResult.addr) {
+                setEnsResult(rnsResult);
+              } else {
+                setEnsResult(null);
+              }
               // setIsValidAddr(!address.length);
             }
           } catch (e) {


### PR DESCRIPTION
## Description
This PR adds RNS service to Rabby Wallet.  On send screen, in the address field type the RNS name and wait a second to see the resolution. RNS is an important service in Rootstock like ENS in ethereum as it makes addresses easy to identify and even memorable.

## Why

Rabby wallet is most used wallet in Rootstock ecosystem. End users, builders, companies and community prefer to use Rabby wallet. So we have a legitimate demand from users to enable `RNS` feature on Rootstock.  

## RNS 

Website: https://manager.rns.rifos.org/

## RNS Explorer

Website: https://rootstock.blockscout.com/name-services?only_active=true

## Demo Video

https://github.com/user-attachments/assets/2b44b4e6-a501-4564-9586-4260018f2f32

