### PR TITLE
fix: auto-lock timer fires earlier than configured duration

### DIFF
--- a/src/background/service/autoLock.ts
+++ b/src/background/service/autoLock.ts
@@ -21,7 +21,7 @@ class AutoLockService {
     if (autoLockAt) {
       if (Date.now() >= autoLockAt) {
         this.onAutoLock?.();
-      } else {
+      } else if (this.timer === null) {
         this.autoLockAt = autoLockAt;
         this.timer = setTimeout(
           () => this.onAutoLock?.(),
@@ -41,12 +41,12 @@ class AutoLockService {
     }
     const duration = autoLockTime * 60 * 1000;
     this.autoLockAt = Date.now() + duration;
+    this.timer = setTimeout(() => this.onAutoLock?.(), duration);
     if (isManifestV3) {
       await browser.storage.session.set({
         [AUTO_LOCK_AT_KEY]: this.autoLockAt,
       });
     }
-    this.timer = setTimeout(() => this.onAutoLock?.(), duration);
   }
 
   setLastActiveTime() {


### PR DESCRIPTION
## Problem

Users who set auto-lock to 24 hours report the wallet locking after just a few hours, or even while actively using it.

## Root Cause

Race condition between `syncAutoLockAt()` and `resetTimer()` in `src/background/service/autoLock.ts`.

In MV3, `resetTimer()` has an async gap: `clearTimeout(this.timer)` runs first, then `await browser.storage.session.set(...)` yields, and `this.timer = setTimeout(...)` runs **after** the await. During that gap, `syncAutoLockAt()` (or another concurrent `resetTimer()` call) can set `this.timer` to a new timeout — which then gets overwritten, creating an **orphaned timer that can never be cancelled**.

The orphaned timer from `syncAutoLockAt()` carries the **remaining time** from the previous deadline. For example, if the user last interacted 18 hours ago, the orphaned timer fires in just 6 hours — even though the user just started a fresh 24-hour session.

## How to Reproduce

1. Set auto-lock to 24 hours
2. Close the popup and wait several hours
3. Reopen the popup — service worker restarts, `syncAutoLockAt()` and `resetTimer()` race
4. Wallet locks after the old remaining time instead of a full 24 hours

## Fix

Two minimal changes (2 lines moved/added):

1. **Move `setTimeout` before `await`** in `resetTimer()` — `clearTimeout` and `setTimeout` now execute synchronously with no async gap, so every subsequent call properly clears the previous timer.
2. **Add `this.timer === null` guard** in `syncAutoLockAt()` — if `resetTimer()` already set a fresh timer, `syncAutoLockAt()` skips instead of overwriting it.