### PR TITLE
docs: align README Node requirement with current toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Please don't hesitate to reach out if you have any doubts.
 
 ### Install Dependency
 
-1. Install Node.js version 14 or later.
+1. Install Node.js version 22 (`v22` in `.nvmrc`).
 2. Install Yarn: `npm install -g yarn`
 3. Run `yarn` to install dependencies.
 


### PR DESCRIPTION
## Summary
- update the README Node.js requirement from `14 or later` to `22`
- match the documented requirement with the current `.nvmrc`
- keep the contributor setup instructions aligned with the Node 22 CI baseline

## Why
The repository currently documents `Node.js version 14 or later`, but the checked-in toolchain points contributors to Node 22:
- `.nvmrc` is `v22`
- `.github/workflows/build.yml` uses `22.17.1`

## Testing
- verified the README requirement against `.nvmrc`
- verified the CI workflow uses Node 22
