### PR TITLE
docs: fix README translation guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ Thanks to contributions from the MetaMask team to the browser extension wallet c
 
 ## Other Docs
 
-- [How to add a new translation to Rabby](/docs/translation.md)
+- [How to add a new translation to Rabby](docs/translation.md)

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -3,7 +3,7 @@
 - Each supported language is represented by a folder in _raw/locales whose name is that language's subtag (example: _raw/locales/es/). (look up a language subtag using the [r12a "Find" tool](https://r12a.github.io/app-subtags/) or this wikipedia list).
 - Inside that folder there should be a messages.json.
 - An easy way to start your translation is to first make a copy of `_raw/locales/en/messages.json` (the English translation), and then translate the message key for each in-app message.
-- Add the language to the [locales index](/_raw/locales/index.json) `_raw/locales/index.json`
+- Add the language to the [locales index](../_raw/locales/index.json) `_raw/locales/index.json`
 
 ## Testing
 If you use VSCode, [i18n Ally extension](https://marketplace.visualstudio.com/items?itemName=Lokalise.i18n-ally) is suggested to be installed to check for missing content. After enabling, there will be an additional "i18n Ally" option on the left sidebar. Click on "Progress" to view the translation completion of each language

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -10,4 +10,4 @@ If you use VSCode, [i18n Ally extension](https://marketplace.visualstudio.com/it
 
 ![i18n Ally](./i18n-ally.png)
 
-If you want to verify that your translations are displayed correctly in Rabby Wallet, follow the [local startup tutorial](/README.md#contribution) to start Rabby and switch to your language.
+If you want to verify that your translations are displayed correctly in Rabby Wallet, follow the [local startup tutorial](../README.md#contribution) to start Rabby and switch to your language.


### PR DESCRIPTION
## Summary
- change the README translation guide link from a root-relative path to a repo-relative path
- keep the link pointing at the existing `docs/translation.md` file in this repository
- avoid sending GitHub README readers to the site-root `/docs/translation.md` path instead of the repo document
