### PR TITLE
docs: correct Rabby UI wallet proxy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ It has 2 main controllers:
 
 1. `walletController`
 
-   Exposes methods to the background window, so other scripts can access these methods with `runtime.getBackgroundPage`, e.g., `ui.js`.
+   Exposes methods on the background controller. UI pages call them through the `wallet` proxy created in `src/ui/app.tsx`, which forwards requests over `PortMessage`.
 
 2. `providerController`
 

--- a/docs/background.md
+++ b/docs/background.md
@@ -4,7 +4,7 @@
 
 there are 2 controllers handle the requests.
 
-- `walletController` is mounted to background's window, `ui` will get it with `runtime.getBackgroundWindow`.
+- `walletController` lives in the background controller, and UI pages use the `wallet` proxy from `src/ui/app.tsx`, which forwards calls through `PortMessage`.
 
 - `providerController` is listening message from `runtime.onConnect` and handle these request.
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -14,9 +14,9 @@ This extension has 3 kinds of UI pages.
 
   When the extension needs more space to ensure the user can get information easily, it will open a browser tab to display content.
 
-These pages share the same code. At the start of `ui` display, the extension will try to execute `getBackgroundWindow` first.
+These pages share the same code. At startup, `src/ui/app.tsx` creates a `wallet` proxy backed by `PortMessage` and passes it into the React tree.
 
-All operations regarding the wallet are mounted in the `background window.wallet`.
+All wallet operations are dispatched through that `wallet` proxy to the background controller.
 
 ## Route
 


### PR DESCRIPTION
Small documentation correction for Rabby UI wallet proxy usage and linked paths.\n\nThis PR is created from the existing `buyua9` fork branch used for the same change, but targeted upstream to `RabbyHub/Rabby`.