### PR TITLE
fix: populate accountsList in AccountInfo to show correct brand icon

### DIFF
--- a/src/ui/component/SendLike/AddressInfoTo.tsx
+++ b/src/ui/component/SendLike/AddressInfoTo.tsx
@@ -58,7 +58,7 @@ export function AddressInfoTo({
     address: toAccount?.address || '',
     brandName: toAccount?.brandName || '',
     type: toAccount?.type || '',
-    forceLight: false,
+    // forceLight: false,
   });
 
   const [aliasName] = useAlias(toAccount?.address || '');

--- a/src/ui/component/SendLike/AddressInfoTo.tsx
+++ b/src/ui/component/SendLike/AddressInfoTo.tsx
@@ -58,7 +58,7 @@ export function AddressInfoTo({
     address: toAccount?.address || '',
     brandName: toAccount?.brandName || '',
     type: toAccount?.type || '',
-    // forceLight: false,
+    forceLight: false,
   });
 
   const [aliasName] = useAlias(toAccount?.address || '');

--- a/src/ui/views/Approval/components/FooterBar/AccountInfo.tsx
+++ b/src/ui/views/Approval/components/FooterBar/AccountInfo.tsx
@@ -9,6 +9,7 @@ import { Chain } from '@debank/common';
 import { Tooltip } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { useBrandIcon } from '@/ui/hooks/useBrandIcon';
+import { useRabbyDispatch } from '@/ui/store';
 
 export interface Props {
   account: Account;
@@ -26,6 +27,7 @@ export const AccountInfo: React.FC<Props> = ({
   const displayBalance = splitNumberByStep((balance || 0).toFixed(2));
   const wallet = useWallet();
   const { t } = useTranslation();
+  const rDispatch = useRabbyDispatch();
 
   const init = async () => {
     const result = await wallet.getAlianName(
@@ -49,6 +51,10 @@ export const AccountInfo: React.FC<Props> = ({
   React.useEffect(() => {
     init();
   }, [account]);
+
+  React.useEffect(() => {
+    rDispatch.accountToDisplay.getAllAccountsToDisplay();
+  }, [rDispatch]);
 
   const brandIcon = useBrandIcon({
     address: account?.address,


### PR DESCRIPTION
- `AccountInfo` in the Approval flow was missing the `getAllAccountsToDisplay()` dispatch, so `useBrandIcon` read an empty `accountsList` from the store and computed the wrong `isWhitelist`, resulting in an incorrect avatar icon
- Added the dispatch in `AccountInfo` to populate the store before `useBrandIcon` reads it