### PR TITLE
fix: extend WINDOW_ID_NONE focus guard to macOS

### DIFF
--- a/src/background/service/notification.ts
+++ b/src/background/service/notification.ts
@@ -132,8 +132,8 @@ class NotificationService extends Events {
 
     winMgr.event.on('windowFocusChange', (winId: number) => {
       if (IS_VIVALDI || IS_LINUX) return;
-      if (IS_CHROME && winId === browser.windows.WINDOW_ID_NONE && IS_WINDOWS) {
-        // When sign on Linux or Windows, will focus on -1 first then focus on sign window
+      if (IS_CHROME && winId === browser.windows.WINDOW_ID_NONE && !IS_LINUX) {
+        // When sign on non-Linux Chromium (Windows, macOS), focus goes to -1 first then to the sign window
         return;
       }
 


### PR DESCRIPTION
## What

One-line change in `src/background/service/notification.ts` so the spurious `chrome.windows.onFocusChanged(WINDOW_ID_NONE)` transient — fired by Chromium during popup window creation — no longer triggers `rejectApproval()` on macOS.

```diff
- if (IS_CHROME && winId === browser.windows.WINDOW_ID_NONE && IS_WINDOWS) {
+ if (IS_CHROME && winId === browser.windows.WINDOW_ID_NONE && !IS_LINUX) {
    return;
  }
```

Linux is already returned out of the handler by the prior guard (`if (IS_VIVALDI || IS_LINUX) return;`), so `!IS_LINUX` is effectively "any non-Linux Chromium platform". This covers Windows (preserving the previous behavior), macOS (the bug being fixed), and any future Chromium platform that exhibits the same transient.

## Why

This is the same class of bug as the Linux fix in #910 and the Windows guard added afterward — same Chromium `-1` transient during popup creation, just on a different platform. The handler's prior comment from #910 captures it:

> *"When sign on Linux, will focus on -1 first then focus on sign window"*

The behavior is identical on macOS. Without the guard, every approval popup is silently rejected the moment it opens.

## How

In `src/constant/index.ts`, `IS_LINUX` and `IS_WINDOWS` are derived from `navigator.userAgent`:

```ts
export const IS_LINUX   = /linux/i.test(global.navigator?.userAgent);
export const IS_WINDOWS = /windows/i.test(global.navigator?.userAgent);
```

On macOS both resolve to `false`, so neither of the existing guards short-circuits. Execution falls through to `rejectApproval()`. Switching the second guard from `IS_WINDOWS` → `!IS_LINUX` is the smallest semantic change that closes the gap without altering behavior on already-handled platforms.

## Test plan

- [ ] Native Chrome on macOS → connect to a dApp → approval popup stays open and accepts input
- [ ] Native Chrome on any OS with `--user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ..."` → same as above
- [ ] User clicks away to a different browser window → popup still auto-rejects (preserved UX)
- [ ] Linux unchanged (covered by first guard)
- [ ] Windows unchanged (still matches `!IS_LINUX`)

Verified locally by patching the minified `background.js` in an AdsPower macOS profile and reloading the extension. Approval popups now persist; the "user navigated away" auto-reject path still fires correctly when the user actually focuses another window.

Closes #<issue-number-here>
