### PR TITLE
fix: batch revoke stuck on first row when entries differ only by permit2_id

### DIFF
--- a/src/ui/views/DesktopProfile/components/ApprovalsTabPane/components/BatchRevoke/useBatchRevokeTask.ts
+++ b/src/ui/views/DesktopProfile/components/ApprovalsTabPane/components/BatchRevoke/useBatchRevokeTask.ts
@@ -103,7 +103,8 @@ const updateAssetApprovalSpender = (
   const index = list.findIndex((data) => {
     if (
       data.id === item.id &&
-      data.$assetParent?.id === item.$assetParent?.id
+      data.$assetParent?.id === item.$assetParent?.id &&
+      (data.permit2_id || '') === (item.permit2_id || '')
     ) {
       return true;
     }

--- a/src/ui/views/ManageBatchApprovals/hooks/useBatchRevokeTask.ts
+++ b/src/ui/views/ManageBatchApprovals/hooks/useBatchRevokeTask.ts
@@ -154,7 +154,8 @@ const updateAssetApprovalSpender = (
   const index = list.findIndex((data) => {
     if (
       data.id === item.id &&
-      data.$assetParent?.id === item.$assetParent?.id
+      data.$assetParent?.id === item.$assetParent?.id &&
+      (data.permit2_id || '') === (item.permit2_id || '')
     ) {
       return true;
     }


### PR DESCRIPTION
## Bug

In **Batch Revoke**, when two selected entries share the same token and spender but differ only in `permit2_id` (e.g. one regular ERC20 approval + one Permit2 approval to the same router — Stargate in my case), the modal gets stuck on row 1:

- The button / progress text stays on `(1/2)` for **both** Ledger signatures
- Row 1 is the only row that ever shows a `pending` / `success` / `fail` status
- Row 2 never updates — visually it looks like "every signature is for the first row, the second is never reached"

> [!NOTE]
> Screenshot of the reproduction (two `S*USDT → Stargate` rows, button stuck on `(1/2)`) — please drag-and-drop into this PR body via the web UI:

<img width="791" height="1173" alt="telegram-cloud-photo-size-4-6014688466819550572-y" src="https://github.com/user-attachments/assets/27780bc6-117d-4cc8-a2ed-d1688956a5c5" />


## Root cause

`updateAssetApprovalSpender` matches list entries by `id` (spender) + `$assetParent.id` (token) only:

```ts
const index = list.findIndex((data) => {
  if (
    data.id === item.id &&
    data.$assetParent?.id === item.$assetParent?.id
  ) {
    return true;
  }
});
```

For two rows that share spender + token but differ in `permit2_id`, both rows match index `0`, so:

- Every `setList(... updateAssetApprovalSpender(prev, cloneItem))` call writes onto `list[0]`
- `list[1].$status` is never set
- `currentApprovalIndex = list.findIndex(item => item.$status?.status === 'pending')` is permanently `0` while a task runs, and `-1` otherwise
- `revokedApprovals = list.filter(... === 'success').length` caps at `1`

(The actual transactions submitted are still distinct — `findIndexRevokeList` does check `permit2_id`, so each task picks the correct `revokeItem`. But on Ledger the token + spender look identical between the two prompts, so it reads as "same tx signed twice / second never appears.")

## Fix

Include `permit2_id` in the matching key (normalised with `|| ''` so `undefined` and missing values compare equal). Both batch-revoke task hooks have the same pattern and are fixed identically:

- `src/ui/views/ManageBatchApprovals/hooks/useBatchRevokeTask.ts`
- `src/ui/views/DesktopProfile/components/ApprovalsTabPane/components/BatchRevoke/useBatchRevokeTask.ts`

```diff
 const index = list.findIndex((data) => {
   if (
     data.id === item.id &&
-    data.\$assetParent?.id === item.\$assetParent?.id
+    data.\$assetParent?.id === item.\$assetParent?.id &&
+    (data.permit2_id || '') === (item.permit2_id || '')
   ) {
     return true;
   }
 });
```

## Test plan

- [ ] On an account that has both a regular ERC20 approval **and** a Permit2 approval pointing at the same token + spender (e.g. `S*USDT → Stargate`), select both and run Batch Revoke
- [ ] Verify the progress label advances `(1/2)` → `(2/2)` across the two Ledger signatures
- [ ] Verify both rows independently transition through `pending` → `success` and the gas fee is shown for each
- [ ] Regression: a normal batch revoke of unrelated approvals (different spenders / tokens) still works end-to-end