### PR TITLE
Recover GridPlus signing from stale Lattice credentials

### DIFF
--- a/__tests__/offscreen/lattice.test.ts
+++ b/__tests__/offscreen/lattice.test.ts
@@ -1,0 +1,74 @@
+import initLattice from '@/offscreen/scripts/lattice';
+import {
+  KnownOrigins,
+  OffscreenCommunicationTarget,
+} from '@/constant/offscreen-communication';
+
+describe('Lattice offscreen connector', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    (chrome.runtime.onMessage.addListener as any).resetHistory();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('ignores messages from a different window before accepting Lattice credentials', async () => {
+    const connectorWindow = { closed: false } as Window;
+    const otherWindow = { closed: false } as Window;
+    const sendResponse = jest.fn();
+
+    jest.spyOn(window, 'open').mockReturnValue(connectorWindow);
+
+    initLattice();
+
+    const listener = (chrome.runtime.onMessage.addListener as any).getCall(0)
+      .args[0];
+    const keepPortOpen = listener(
+      {
+        target: OffscreenCommunicationTarget.latticeOffscreen,
+        params: { url: 'https://lattice.gridplus.io' },
+      },
+      {},
+      sendResponse
+    );
+
+    await Promise.resolve();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: KnownOrigins.lattice,
+        source: otherWindow,
+        data: JSON.stringify({ deviceID: 'bad', password: 'bad' }),
+      })
+    );
+
+    expect(sendResponse).not.toHaveBeenCalled();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: KnownOrigins.lattice,
+        source: connectorWindow,
+        data: { deviceID: 'bad', password: 'bad' },
+      })
+    );
+
+    expect(sendResponse).not.toHaveBeenCalled();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: KnownOrigins.lattice,
+        source: connectorWindow,
+        data: JSON.stringify({ deviceID: 'device', password: 'password' }),
+      })
+    );
+
+    expect(keepPortOpen).toBe(true);
+    expect(sendResponse).toHaveBeenCalledTimes(1);
+    expect(sendResponse).toHaveBeenCalledWith({
+      result: { deviceID: 'device', password: 'password' },
+    });
+  });
+});

--- a/__tests__/service/lattice-keyring.test.ts
+++ b/__tests__/service/lattice-keyring.test.ts
@@ -1,0 +1,121 @@
+import LatticeKeyring from '@/background/service/keyring/eth-lattice-keyring/eth-lattice-keyring';
+import OldLatticeKeyring from '@rabby-wallet/eth-lattice-keyring';
+
+jest.mock('@/utils/env', () => ({
+  isManifestV3: true,
+}));
+
+jest.mock('@/background/utils', () => ({
+  isSameAddress: (a: string, b: string) => a.toLowerCase() === b.toLowerCase(),
+}));
+
+const makeKeyring = () => {
+  const keyring = new LatticeKeyring() as any;
+
+  keyring.accounts = ['0x0000000000000000000000000000000000000001'];
+  keyring.accountIndices = [0];
+  keyring.accountOpts = [{ hdPath: "m/44'/60'/0'/0/x" }];
+  keyring.hdPath = "m/44'/60'/0'/0/x";
+  keyring.unlockedAccount = 0;
+  keyring.creds = {
+    deviceID: 'stale-device-id',
+    password: 'stale-password',
+    endpoint: 'https://stale.example',
+  };
+  keyring.sdkSession = { stale: true };
+  keyring.walletUID = 'stale-wallet';
+  keyring.isLocked = false;
+
+  return keyring;
+};
+
+describe('LatticeKeyring signing recovery', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('clears stale connection state and retries typed data signing once', async () => {
+    const keyring = makeKeyring();
+    const accounts = keyring.accounts;
+    const accountIndices = keyring.accountIndices;
+    const accountOpts = keyring.accountOpts;
+
+    const signTypedData = jest
+      .spyOn(OldLatticeKeyring.prototype as any, 'signTypedData')
+      .mockRejectedValueOnce(new Error('No active wallet in Lattice.'))
+      .mockResolvedValueOnce('0xsig');
+
+    await expect(
+      keyring.signTypedData(
+        '0x0000000000000000000000000000000000000001',
+        { message: 'hello' },
+        { version: 'V4' }
+      )
+    ).resolves.toBe('0xsig');
+
+    expect(signTypedData).toHaveBeenCalledTimes(2);
+    expect(keyring.creds).toEqual({
+      deviceID: null,
+      password: null,
+      endpoint: null,
+    });
+    expect(keyring.sdkSession).toBeNull();
+    expect(keyring.walletUID).toBeNull();
+    expect(keyring.isLocked).toBe(true);
+    expect(keyring.accounts).toBe(accounts);
+    expect(keyring.accountIndices).toBe(accountIndices);
+    expect(keyring.accountOpts).toBe(accountOpts);
+  });
+
+  it.each([
+    ['signTransaction', ['0x0000000000000000000000000000000000000001', {}]],
+    ['signMessage', ['0x0000000000000000000000000000000000000001', '0x1234']],
+  ])('recovers stale connection state for %s', async (method, args) => {
+    const keyring = makeKeyring();
+
+    const sign = jest
+      .spyOn(OldLatticeKeyring.prototype as any, method)
+      .mockRejectedValueOnce(new Error('NOT_PAIRED'))
+      .mockResolvedValueOnce('0xsig');
+
+    await expect(keyring[method](...args)).resolves.toBe('0xsig');
+
+    expect(sign).toHaveBeenCalledTimes(2);
+    expect(keyring.creds).toEqual({
+      deviceID: null,
+      password: null,
+      endpoint: null,
+    });
+    expect(keyring.accounts).toEqual([
+      '0x0000000000000000000000000000000000000001',
+    ]);
+  });
+
+  it('does not retry or clear credentials for signing validation errors', async () => {
+    const keyring = makeKeyring();
+
+    const signTypedData = jest
+      .spyOn(OldLatticeKeyring.prototype as any, 'signTypedData')
+      .mockRejectedValueOnce(
+        new Error('Only signTypedData V3 and V4 messages are supported.')
+      );
+
+    await expect(
+      keyring.signTypedData(
+        '0x0000000000000000000000000000000000000001',
+        { message: 'hello' },
+        { version: 'V1' }
+      )
+    ).rejects.toThrow('Only signTypedData V3 and V4 messages are supported.');
+
+    expect(signTypedData).toHaveBeenCalledTimes(1);
+    expect(keyring.creds).toEqual({
+      deviceID: 'stale-device-id',
+      password: 'stale-password',
+      endpoint: 'https://stale.example',
+    });
+    expect(keyring.sdkSession).toEqual({ stale: true });
+    expect(keyring.walletUID).toBe('stale-wallet');
+    expect(keyring.isLocked).toBe(false);
+  });
+});

--- a/src/background/service/keyring/eth-lattice-keyring/eth-lattice-keyring.ts
+++ b/src/background/service/keyring/eth-lattice-keyring/eth-lattice-keyring.ts
@@ -25,6 +25,15 @@ const HD_PATH_TYPE = {
   [HD_PATH_BASE[HDPathType.LedgerLive]]: HDPathType.LedgerLive,
 };
 
+const RECOVERABLE_LATTICE_CONNECTION_ERRORS = [
+  'not_paired',
+  'no active wallet in lattice',
+  'no connection to lattice',
+  'lattice connector closed',
+  'invalid credentials returned from lattice',
+  'failed to get accounts',
+];
+
 let callStackCounter = 0;
 
 class LatticeKeyring extends OldLatticeKeyring {
@@ -32,6 +41,52 @@ class LatticeKeyring extends OldLatticeKeyring {
   appName = 'Rabby';
   static type = keyringType;
   type = keyringType;
+
+  private isRecoverableConnectionError(error: any) {
+    const message = String(error?.message || error || '').toLowerCase();
+
+    return RECOVERABLE_LATTICE_CONNECTION_ERRORS.some((recoverableError) =>
+      message.includes(recoverableError)
+    );
+  }
+
+  private resetConnectionState() {
+    this.creds = {
+      deviceID: null,
+      password: null,
+      endpoint: null,
+    };
+    this.sdkSession = null;
+    this.walletUID = null;
+    this.isLocked = true;
+  }
+
+  private async withConnectionRecovery<T>(sign: () => Promise<T>) {
+    try {
+      return await sign();
+    } catch (error) {
+      if (!this.isRecoverableConnectionError(error)) {
+        throw error;
+      }
+
+      this.resetConnectionState();
+      return sign();
+    }
+  }
+
+  async signTransaction(address, tx) {
+    return this.withConnectionRecovery(() => super.signTransaction(address, tx));
+  }
+
+  async signMessage(address, msg) {
+    return this.withConnectionRecovery(() => super.signMessage(address, msg));
+  }
+
+  async signTypedData(address, msg, opts) {
+    return this.withConnectionRecovery(() =>
+      super.signTypedData(address, msg, opts)
+    );
+  }
 
   async _getCreds() {
     if (!isManifestV3) {

--- a/src/offscreen/scripts/lattice.ts
+++ b/src/offscreen/scripts/lattice.ts
@@ -53,10 +53,11 @@ export default function initLattice() {
       window.addEventListener(
         'message',
         (event) => {
-          // Ensure origin
+          // Ensure origin, source is the browser tab, and data is a string (JSON to be parsed)
           if (
-            event.origin !== KnownOrigins.lattice &&
-            event.source === browserTab
+            event.origin !== KnownOrigins.lattice ||
+            event.source !== browserTab ||
+            typeof event.data !== 'string'
           ) {
             return;
           }


### PR DESCRIPTION
## Summary

This updates the GridPlus/Lattice flow in two places:

- recover GridPlus signing when stored Lattice credentials/session state is stale by clearing only connection state and retrying the sign once
- mirror MetaMask's Lattice offscreen message validation so only string payloads from the opened connector window and Lattice origin are accepted

## Context

The Chrome Web Store 0.93.87 package is MV3, but MV3 and the Lattice offscreen bridge were introduced earlier. The GridPlus dependencies did not change in 0.93.87. User reports point to signing breaking until the device ID is reset; that workaround clears stored Lattice credentials. This patch makes Rabby do that recovery automatically for recoverable connection/pairing failures without forgetting imported GridPlus accounts.

## Test plan

- yarn test __tests__/service/lattice-keyring.test.ts __tests__/offscreen/lattice.test.ts --runInBand