### PR TITLE
docs: fix translation guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ Thanks to contributions from the MetaMask team to the browser extension wallet c
 
 ## Other Docs
 
-- [How to add a new translation to Rabby](/docs/translation.md)
+- [How to add a new translation to Rabby](docs/translation.md)

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -3,11 +3,11 @@
 - Each supported language is represented by a folder in _raw/locales whose name is that language's subtag (example: _raw/locales/es/). (look up a language subtag using the [r12a "Find" tool](https://r12a.github.io/app-subtags/) or this wikipedia list).
 - Inside that folder there should be a messages.json.
 - An easy way to start your translation is to first make a copy of `_raw/locales/en/messages.json` (the English translation), and then translate the message key for each in-app message.
-- Add the language to the [locales index](/_raw/locales/index.json) `_raw/locales/index.json`
+- Add the language to the [locales index](../_raw/locales/index.json) `_raw/locales/index.json`
 
 ## Testing
 If you use VSCode, [i18n Ally extension](https://marketplace.visualstudio.com/items?itemName=Lokalise.i18n-ally) is suggested to be installed to check for missing content. After enabling, there will be an additional "i18n Ally" option on the left sidebar. Click on "Progress" to view the translation completion of each language
 
 ![i18n Ally](./i18n-ally.png)
 
-If you want to verify that your translations are displayed correctly in Rabby Wallet, follow the [local startup tutorial](/README.md#contribution) to start Rabby and switch to your language.
+If you want to verify that your translations are displayed correctly in Rabby Wallet, follow the [local startup tutorial](../README.md#contribution) to start Rabby and switch to your language.


### PR DESCRIPTION
## Summary

- make the README translation guide link relative
- make the translation guide's locales index link relative
- make the translation guide's README contribution backlink relative

## Why

The current docs use root-relative links such as `/docs/translation.md`, `/_raw/locales/index.json`, and `/README.md#contribution`. In GitHub's repository Markdown view, those point at the site root instead of the files in this repository, so contributors following the translation onboarding path can land on broken or misleading URLs.

## Validation

- Verified the linked files exist in the repository:
  - `docs/translation.md`
  - `_raw/locales/index.json`
  - `README.md`
- `git diff --check`
