### PR TITLE
fix(ui): add thousand separators to token amount input

### DIFF
--- a/src/ui/component/TokenAmountInput/index.tsx
+++ b/src/ui/component/TokenAmountInput/index.tsx
@@ -355,7 +355,7 @@ const TokenAmountInput = ({
             insufficientError && 'text-rabby-red-default'
           )}
           autoFocus
-          value={value}
+          value={value ? splitNumberByStep(value) : ''}
           size="large"
           onChange={handleChange}
           title={value}


### PR DESCRIPTION
## Summary

Adds comma/thousand separators to the `TokenAmountInput` component to improve readability for large token values.

Example:
- Before: `1000000.25`
- After: `1,000,000.25`

## Changes
- Added formatted display for token amount inputs (using `splitNumberByStep`)
- Preserved decimal precision and input behavior
- Improved readability for large balances/amounts

## Notes
- Formatting is UI-only and does not affect underlying numeric values