### PR TITLE
feat: add .igra (INS) name resolution to send + watch flows

### DIFF
--- a/src/ui/utils/ins.ts
+++ b/src/ui/utils/ins.ts
@@ -1,0 +1,54 @@
+/**
+ * INS — Igra Name Service resolver.
+ *
+ * Mirrors the shape of resolveEnsAddressByName (./ens.ts) so EnterAddress
+ * and ImportWatchAddress can swap helpers based on the input suffix
+ * without changing their consumer code.
+ *
+ * Uses the public INS REST API at insdomains.org/api/resolve, which
+ * unions INS V1 + V2 registries on Igra L2 (chain 38833). Read-only,
+ * CORS-enabled, no auth, no rate limit. Rabby's wallet never touches
+ * the user's keys or Igra RPC for resolution — the API does the on-chain
+ * read server-side, mirroring the way ENS resolution avoids forcing a
+ * direct contract call from the extension.
+ *
+ * Source + threat model:
+ *   https://github.com/ItsGoonBoyCrypto/INSdomains
+ *   https://github.com/ItsGoonBoyCrypto/INSdomains/blob/main/snap/SECURITY.md
+ */
+
+const INS_API = 'https://insdomains.org/api';
+
+const looksLikeIgraName = (input: string): boolean => {
+  const lower = input.trim().toLowerCase();
+  return lower.endsWith('.igra') && lower.length > 5;
+};
+
+export const resolveInsAddressByName = async (
+  name: string
+): Promise<{ addr: string; name: string } | null> => {
+  const input = name?.trim();
+  if (!input || !looksLikeIgraName(input)) return null;
+
+  try {
+    const ctl = new AbortController();
+    const timeout = setTimeout(() => ctl.abort(), 5000);
+    const res = await fetch(
+      `${INS_API}/resolve?name=${encodeURIComponent(input.toLowerCase())}`,
+      { signal: ctl.signal }
+    );
+    clearTimeout(timeout);
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      exists?: boolean;
+      address?: string;
+    };
+    if (!data?.exists || !data?.address) return null;
+    return {
+      addr: data.address,
+      name: input.toLowerCase(),
+    };
+  } catch {
+    return null;
+  }
+};

--- a/src/ui/utils/ins.ts
+++ b/src/ui/utils/ins.ts
@@ -44,6 +44,11 @@ export const resolveInsAddressByName = async (
       address?: string;
     };
     if (!data?.exists || !data?.address) return null;
+    // Reject anything that isn't a real EVM address - the watch-import
+    // flow only checks startsWith('0x') downstream so we have to be
+    // strict here. Rejecting at the resolver boundary matches what
+    // resolveEnsAddressByName does in ./ens.ts.
+    if (!/^0x[a-fA-F0-9]{40}$/.test(data.address)) return null;
     return {
       addr: data.address,
       name: input.toLowerCase(),

--- a/src/ui/views/ImportWatchAddress.tsx
+++ b/src/ui/views/ImportWatchAddress.tsx
@@ -20,6 +20,7 @@ import { useRepeatImportConfirm } from 'ui/utils/useRepeatImportConfirm';
 import eventBus from '@/eventBus';
 import { safeJSONParse } from '@/utils';
 import { resolveEnsAddressByName } from '@/ui/utils/ens';
+import { resolveInsAddressByName } from '@/ui/utils/ins';
 import WatchLogo from 'ui/assets/watch-only-hero.svg';
 import { useCreateAddressActions } from './AddAddress/useCreateAddress';
 import { RcWatchAddressScan } from '../assets/add-address';
@@ -158,7 +159,10 @@ const ImportWatchAddress: React.FC<{
     () =>
       debounce(async (address: string) => {
         try {
-          const result = await resolveEnsAddressByName(address, wallet);
+          const isIgra = address?.trim().toLowerCase().endsWith('.igra');
+          const result = isIgra
+            ? await resolveInsAddressByName(address)
+            : await resolveEnsAddressByName(address, wallet);
           setDisableKeydown(true);
           if (result && result.addr && result.addr.startsWith('0x')) {
             setEnsResult(result);

--- a/src/ui/views/ImportWatchAddress.tsx
+++ b/src/ui/views/ImportWatchAddress.tsx
@@ -87,7 +87,10 @@ const ImportWatchAddress: React.FC<{
       address: result,
     });
     setIsValidAddr(true);
-    setTags([`ENS: ${ensResult!.name}`]);
+    const tagPrefix = ensResult!.name?.toLowerCase().endsWith('.igra')
+      ? 'INS'
+      : 'ENS';
+    setTags([`${tagPrefix}: ${ensResult!.name}`]);
     setEnsResult(null);
   };
   const handleKeyDown = useMemo(() => {

--- a/src/ui/views/SelectToAddress/components/EnterAddress.tsx
+++ b/src/ui/views/SelectToAddress/components/EnterAddress.tsx
@@ -19,6 +19,7 @@ import { isSameAddress, useAlias, useCexId, useWallet } from 'ui/utils';
 import { IconClearCC } from '@/ui/assets/component/IconClear';
 import { ReactComponent as RcIconWarningCC } from '@/ui/assets/warning-cc.svg';
 import { resolveEnsAddressByName } from '@/ui/utils/ens';
+import { resolveInsAddressByName } from '@/ui/utils/ins';
 import { AccountList } from './AccountList';
 import { useAccounts } from '@/ui/hooks/useAccounts';
 import { AddressTypeCard } from '@/ui/component/AddressRiskAlert';
@@ -151,7 +152,10 @@ export const EnterAddress = ({
     (result: string) => {
       setInputAddress(result);
       // setIsValidAddr(true);
-      setTags([`ENS: ${ensResult?.name || ''}`]);
+      const tagPrefix = ensResult?.name?.toLowerCase().endsWith('.igra')
+        ? 'INS'
+        : 'ENS';
+      setTags([`${tagPrefix}: ${ensResult?.name || ''}`]);
       setEnsResult(null);
     },
     [ensResult?.name]
@@ -182,7 +186,10 @@ export const EnterAddress = ({
         setTags([]);
         if (!isValidAddress(address)) {
           try {
-            const result = await resolveEnsAddressByName(address, wallet);
+            const isIgra = address?.trim().toLowerCase().endsWith('.igra');
+            const result = isIgra
+              ? await resolveInsAddressByName(address)
+              : await resolveEnsAddressByName(address, wallet);
             if (result && result.addr) {
               setEnsResult(result);
               // setIsValidAddr(true);


### PR DESCRIPTION
## Summary

Adds `.igra` (Igra Name Service) name resolution to Rabby's **send** and **watch-import** flows. Mirrors the existing ENS pattern exactly â€” small, isolated, and reversible.

- **New:** `src/ui/utils/ins.ts` â€” REST client (50 lines, 5s timeout, no SDK)
- **Modified:** `EnterAddress.tsx` + `ImportWatchAddress.tsx` â€” route `.igra` to the INS resolver, everything else to the existing ENS path

`.igra` names show an **"INS:"** tag (vs **"ENS:"**) so users can see which resolver answered.

## Why

INS is the canonical naming service for [Igra L2](https://docs.igralabs.com) (chain `38833`, EVM L2 on Kaspa). The Igra chain config is already in Rabby via [ethereum-lists/chains#7884](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-38833.json) â€” adding `.igra` resolution lets Rabby users send to human-readable names on that chain instead of `0xâ€¦` strings.

Public REST API (no API key, no auth, free): https://insdomains.org/api/resolve?name=yourname.igra

## How it works

```ts
// src/ui/utils/ins.ts â€” drop-in mirror of resolveEnsAddressByName shape
GET https://insdomains.org/api/resolve?name=yourname.igra
â†’ { "exists": true, "address": "0xâ€¦", "name": "yourname.igra" }
```

- Only fires for inputs matching `*.igra` (length > 5)
- 5-second AbortController timeout
- Returns `null` on any failure â†’ flow degrades gracefully (no error UI, just no resolution)
- Reuses Rabby's existing tag UI â€” no new components, no new state
- **No new dependencies** (uses native `fetch` + `AbortController`)

## Files

```
 src/ui/utils/ins.ts                                  | new (50 lines)
 src/ui/views/SelectToAddress/components/EnterAddress.tsx | +9 -2
 src/ui/views/ImportWatchAddress.tsx                  | +9 -1
```

## Test plan

- [ ] Type `igra.igra` into the Send â†’ "Send to" field â€” resolves to `0xfBE7â€¦2bD0`, tag shows `INS: igra.igra`
- [ ] Type `vitalik.eth` â€” still resolves via ENS, tag shows `ENS: vitalik.eth` (no regression)
- [ ] Type `nonexistent.igra` â€” no tag, no error (graceful null)
- [ ] Watch-import: paste `igra.igra` â†’ same flow works
- [ ] Offline / API down: send field doesn't hang (5s timeout)

## Project & contact

- Site: https://insdomains.org
- Source: https://github.com/ItsGoonBoyCrypto/ins-dapp
- API docs: https://insdomains.org/api
- Existing wallet integrations: MetaMask (via Snap directory submission in progress), ENS CCIP-Read wildcard at `*.insdomains.eth`
- Happy to adjust copy, change the tag string, gate behind a feature flag, or split into smaller PRs if helpful
