### PR TITLE
fix: Update perps meta retry & Locale and internationalization improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@rabby-wallet/eth-walletconnect-keyring": "2.1.7",
     "@rabby-wallet/eth-watch-keyring": "1.0.0",
     "@rabby-wallet/gnosis-sdk": "1.4.9",
-    "@rabby-wallet/hyperliquid-sdk": "1.1.15-beta.1",
+    "@rabby-wallet/hyperliquid-sdk": "1.1.15",
     "@rabby-wallet/page-provider": "0.4.11",
     "@rabby-wallet/rabby-action": "0.1.14",
     "@rabby-wallet/rabby-api": "0.9.62",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@rabby-wallet/eth-walletconnect-keyring": "2.1.7",
     "@rabby-wallet/eth-watch-keyring": "1.0.0",
     "@rabby-wallet/gnosis-sdk": "1.4.9",
-    "@rabby-wallet/hyperliquid-sdk": "1.1.14",
+    "@rabby-wallet/hyperliquid-sdk": "1.1.15-beta.1",
     "@rabby-wallet/page-provider": "0.4.11",
     "@rabby-wallet/rabby-action": "0.1.14",
     "@rabby-wallet/rabby-api": "0.9.62",

--- a/src/ui/models/_uistore.ts
+++ b/src/ui/models/_uistore.ts
@@ -1,4 +1,5 @@
 import { RabbyRootState, RabbyDispatch } from '@/ui/models';
+import { changeLanguage } from '@/i18n';
 import { onBackgroundStoreChanged } from '../utils/broadcastToUI';
 
 export default (store: typeof import('@/ui/store').default) => {
@@ -28,6 +29,14 @@ export default (store: typeof import('@/ui/store').default) => {
         dispatch.preference.setField({
           themeMode: payload.partials.themeMode,
         });
+        break;
+      }
+      case 'locale': {
+        const locale = payload.partials.locale;
+        if (locale) {
+          changeLanguage(locale);
+          dispatch.preference.setField({ locale });
+        }
         break;
       }
       // case 'curvePointsMap': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4949,9 +4949,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rabby-wallet/hyperliquid-sdk@npm:1.1.15-beta.1":
-  version: 1.1.15-beta.1
-  resolution: "@rabby-wallet/hyperliquid-sdk@npm:1.1.15-beta.1"
+"@rabby-wallet/hyperliquid-sdk@npm:1.1.15":
+  version: 1.1.15
+  resolution: "@rabby-wallet/hyperliquid-sdk@npm:1.1.15"
   dependencies:
     "@ethereumjs/util": "npm:9.0.0"
     "@metamask/eth-sig-util": "npm:5.1.0"
@@ -4959,7 +4959,7 @@ __metadata:
     "@noble/hashes": "npm:1.8.0"
     ethereum-cryptography: "npm:2.2.1"
     fflate: "npm:0.8.2"
-  checksum: 10c0/5a07226b2efc8be29b64994208c5a4173b223763be29fa364405a80f3d5b8e7917191e2f68003d607b91b19d1b861fd73785ec0057a5ca0990c40a0a5016058c
+  checksum: 10c0/4caf086d36b8a2672e7c012a3c9578148a9521c573ed4ea4d65a06457c84ae85c8f29b80c852a43dea31319be8f09f092744417091b3e6bb85fd215f51524a69
   languageName: node
   linkType: hard
 
@@ -21499,7 +21499,7 @@ __metadata:
     "@rabby-wallet/eth-walletconnect-keyring": "npm:2.1.7"
     "@rabby-wallet/eth-watch-keyring": "npm:1.0.0"
     "@rabby-wallet/gnosis-sdk": "npm:1.4.9"
-    "@rabby-wallet/hyperliquid-sdk": "npm:1.1.15-beta.1"
+    "@rabby-wallet/hyperliquid-sdk": "npm:1.1.15"
     "@rabby-wallet/page-provider": "npm:0.4.11"
     "@rabby-wallet/rabby-action": "npm:0.1.14"
     "@rabby-wallet/rabby-api": "npm:0.9.62"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4949,9 +4949,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rabby-wallet/hyperliquid-sdk@npm:1.1.14":
-  version: 1.1.14
-  resolution: "@rabby-wallet/hyperliquid-sdk@npm:1.1.14"
+"@rabby-wallet/hyperliquid-sdk@npm:1.1.15-beta.1":
+  version: 1.1.15-beta.1
+  resolution: "@rabby-wallet/hyperliquid-sdk@npm:1.1.15-beta.1"
   dependencies:
     "@ethereumjs/util": "npm:9.0.0"
     "@metamask/eth-sig-util": "npm:5.1.0"
@@ -4959,7 +4959,7 @@ __metadata:
     "@noble/hashes": "npm:1.8.0"
     ethereum-cryptography: "npm:2.2.1"
     fflate: "npm:0.8.2"
-  checksum: 10c0/c4a52653b37abfa88bcf20ab479886645073e77d31dd626907cb00d271bb027b0baf23a012f2001baafc0d1d5adb838c140d36ad94c3d14c108fa671653b0ad7
+  checksum: 10c0/5a07226b2efc8be29b64994208c5a4173b223763be29fa364405a80f3d5b8e7917191e2f68003d607b91b19d1b861fd73785ec0057a5ca0990c40a0a5016058c
   languageName: node
   linkType: hard
 
@@ -21499,7 +21499,7 @@ __metadata:
     "@rabby-wallet/eth-walletconnect-keyring": "npm:2.1.7"
     "@rabby-wallet/eth-watch-keyring": "npm:1.0.0"
     "@rabby-wallet/gnosis-sdk": "npm:1.4.9"
-    "@rabby-wallet/hyperliquid-sdk": "npm:1.1.14"
+    "@rabby-wallet/hyperliquid-sdk": "npm:1.1.15-beta.1"
     "@rabby-wallet/page-provider": "npm:0.4.11"
     "@rabby-wallet/rabby-action": "npm:0.1.14"
     "@rabby-wallet/rabby-api": "npm:0.9.62"


### PR DESCRIPTION
This pull request introduces a minor dependency update and adds locale switching support to the UI store. The most important changes are outlined below.

**Dependency updates:**

* Updated `@rabby-wallet/hyperliquid-sdk` dependency from version `1.1.14` to `1.1.15` in `package.json`.

**Locale and internationalization improvements:**

* Imported the `changeLanguage` function from `@/i18n` in `_uistore.ts` to support dynamic language changes.
* Added a new case for handling the `locale` field in the UI store, which updates the language using `changeLanguage` and updates the preference state accordingly.