### PR TITLE
Add native XDCID .xdc name resolution

### DIFF
--- a/src/ui/utils/ens.test.ts
+++ b/src/ui/utils/ens.test.ts
@@ -1,0 +1,16 @@
+import { normalizeXdcidName } from './ens';
+
+describe('normalizeXdcidName', () => {
+  it('canonicalizes valid XDCID names', () => {
+    expect(normalizeXdcidName(' Alice.XDC ')).toBe('alice.xdc');
+    expect(normalizeXdcidName('abc-123.xdc')).toBe('abc-123.xdc');
+  });
+
+  it('rejects invalid XDCID labels', () => {
+    expect(normalizeXdcidName('ab.xdc')).toBeNull();
+    expect(normalizeXdcidName('-alice.xdc')).toBeNull();
+    expect(normalizeXdcidName('alice-.xdc')).toBeNull();
+    expect(normalizeXdcidName('alice_name.xdc')).toBeNull();
+    expect(normalizeXdcidName('alice.eth')).toBeNull();
+  });
+});

--- a/src/ui/utils/ens.ts
+++ b/src/ui/utils/ens.ts
@@ -1,16 +1,136 @@
-import { createPublicClient, custom } from 'viem';
+import {
+  createPublicClient,
+  custom,
+  defineChain,
+  getAddress,
+  keccak256,
+  stringToHex,
+  zeroAddress,
+} from 'viem';
 import { mainnet } from 'viem/chains';
 import { normalize } from 'viem/ens';
 import { findChainByID } from '@/utils/chain';
 import type { WalletControllerType } from '@/ui/utils';
 
-export const resolveEnsAddressByName = async (
-  name: string,
-  wallet: WalletControllerType
-): Promise<{ addr: string; name: string } | null> => {
-  const input = name?.trim();
-  if (!input) return null;
+const XDC_CHAIN_ID = 50;
+const XDCID_REGISTRY_ADDRESS =
+  '0x05fa64a05bc205DeDF47e023d2D90c2d119cd097';
+const XDCID_RESOLVER_ADDRESS =
+  '0x52bfa70B30190050F77033Fe427De8B3d4A8F453';
 
+const xdcMainnet = defineChain({
+  id: XDC_CHAIN_ID,
+  name: 'XDC Network',
+  nativeCurrency: {
+    name: 'XDC',
+    symbol: 'XDC',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.xdcrpc.com'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'XDCScan',
+      url: 'https://xdcscan.com',
+    },
+  },
+});
+
+const xdcidRegistryAbi = [
+  {
+    type: 'function',
+    name: 'ownerOf',
+    stateMutability: 'view',
+    inputs: [{ name: 'node', type: 'bytes32' }],
+    outputs: [{ name: 'owner', type: 'address' }],
+  },
+] as const;
+
+const xdcidResolverAbi = [
+  {
+    type: 'function',
+    name: 'addresses',
+    stateMutability: 'view',
+    inputs: [{ name: 'node', type: 'bytes32' }],
+    outputs: [{ name: 'addr', type: 'address' }],
+  },
+] as const;
+
+export type ResolvedAddressName = {
+  addr: string;
+  name: string;
+  protocol: 'ENS' | 'XDCID';
+};
+
+export const normalizeXdcidName = (name: string): string | null => {
+  const canonicalName = name.trim().toLowerCase();
+  if (!canonicalName.endsWith('.xdc')) return null;
+
+  const label = canonicalName.slice(0, -4);
+  if (label.length < 3 || label.length > 63) return null;
+  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(label)) return null;
+
+  return label + '.xdc';
+};
+
+const resolveXdcidAddressByName = async (
+  input: string,
+  wallet: WalletControllerType
+): Promise<ResolvedAddressName | null> => {
+  const canonicalName = normalizeXdcidName(input);
+  if (!canonicalName) return null;
+
+  const xdcServerId = findChainByID(XDC_CHAIN_ID)?.serverId || 'xdc';
+  const xdcClient = createPublicClient({
+    chain: xdcMainnet,
+    transport: custom({
+      request: async ({ method, params }) =>
+        wallet.requestETHRpc(
+          {
+            method,
+            params: (params || []) as any[],
+          },
+          xdcServerId
+        ),
+    }),
+  });
+
+  try {
+    const node = keccak256(stringToHex(canonicalName));
+    const [owner, resolvedAddress] = await Promise.all([
+      xdcClient.readContract({
+        address: XDCID_REGISTRY_ADDRESS,
+        abi: xdcidRegistryAbi,
+        functionName: 'ownerOf',
+        args: [node],
+      }),
+      xdcClient.readContract({
+        address: XDCID_RESOLVER_ADDRESS,
+        abi: xdcidResolverAbi,
+        functionName: 'addresses',
+        args: [node],
+      }),
+    ]);
+
+    if (owner === zeroAddress || resolvedAddress === zeroAddress) return null;
+
+    return {
+      addr: getAddress(resolvedAddress),
+      name: canonicalName,
+      protocol: 'XDCID',
+    };
+  } catch {
+    return null;
+  }
+};
+
+const resolveEnsAddressByName = async (
+  input: string,
+  wallet: WalletControllerType
+): Promise<ResolvedAddressName | null> => {
   const ethServerId = findChainByID(1)?.serverId || 'eth';
   const ensClient = createPublicClient({
     chain: mainnet,
@@ -35,8 +155,23 @@ export const resolveEnsAddressByName = async (
     return {
       addr,
       name: normalizedName,
+      protocol: 'ENS',
     };
   } catch {
     return null;
   }
+};
+
+export const resolveAddressByName = async (
+  name: string,
+  wallet: WalletControllerType
+): Promise<ResolvedAddressName | null> => {
+  const input = name?.trim();
+  if (!input) return null;
+
+  if (input.toLowerCase().endsWith('.xdc')) {
+    return resolveXdcidAddressByName(input, wallet);
+  }
+
+  return resolveEnsAddressByName(input, wallet);
 };

--- a/src/ui/views/ImportWatchAddress.tsx
+++ b/src/ui/views/ImportWatchAddress.tsx
@@ -19,7 +19,7 @@ import IconBack from 'ui/assets/icon-back.svg';
 import { useRepeatImportConfirm } from 'ui/utils/useRepeatImportConfirm';
 import eventBus from '@/eventBus';
 import { safeJSONParse } from '@/utils';
-import { resolveEnsAddressByName } from '@/ui/utils/ens';
+import { resolveAddressByName } from '@/ui/utils/ens';
 import WatchLogo from 'ui/assets/watch-only-hero.svg';
 import { useCreateAddressActions } from './AddAddress/useCreateAddress';
 import { RcWatchAddressScan } from '../assets/add-address';
@@ -40,6 +40,7 @@ const ImportWatchAddress: React.FC<{
   const [ensResult, setEnsResult] = useState<null | {
     addr: string;
     name: string;
+    protocol: 'ENS' | 'XDCID';
   }>(null);
   const [tags, setTags] = useState<string[]>([]);
   const isWide = useMedia('(min-width: 401px)');
@@ -86,7 +87,7 @@ const ImportWatchAddress: React.FC<{
       address: result,
     });
     setIsValidAddr(true);
-    setTags([`ENS: ${ensResult!.name}`]);
+    setTags([`${ensResult!.protocol}: ${ensResult!.name}`]);
     setEnsResult(null);
   };
   const handleKeyDown = useMemo(() => {
@@ -158,7 +159,7 @@ const ImportWatchAddress: React.FC<{
     () =>
       debounce(async (address: string) => {
         try {
-          const result = await resolveEnsAddressByName(address, wallet);
+          const result = await resolveAddressByName(address, wallet);
           setDisableKeydown(true);
           if (result && result.addr && result.addr.startsWith('0x')) {
             setEnsResult(result);
@@ -327,7 +328,7 @@ function InputWithScanIcon({
     <div className="relative">
       <Input.TextArea
         placeholder={t('page.newAddress.addContacts.addressEns')}
-        maxLength={44}
+        maxLength={67}
         size="large"
         className="border-bright-on-active leading-normal min-h-[100px]"
         autoFocus

--- a/src/ui/views/SelectToAddress/components/EnterAddress.tsx
+++ b/src/ui/views/SelectToAddress/components/EnterAddress.tsx
@@ -18,7 +18,7 @@ import { isSameAddress, useAlias, useCexId, useWallet } from 'ui/utils';
 
 import { IconClearCC } from '@/ui/assets/component/IconClear';
 import { ReactComponent as RcIconWarningCC } from '@/ui/assets/warning-cc.svg';
-import { resolveEnsAddressByName } from '@/ui/utils/ens';
+import { resolveAddressByName } from '@/ui/utils/ens';
 import { AccountList } from './AccountList';
 import { useAccounts } from '@/ui/hooks/useAccounts';
 import { AddressTypeCard } from '@/ui/component/AddressRiskAlert';
@@ -97,6 +97,7 @@ export const EnterAddress = ({
   const [ensResult, setEnsResult] = useState<null | {
     addr: string;
     name: string;
+    protocol: 'ENS' | 'XDCID';
   }>(null);
   const [tags, setTags] = useState<string[]>([]);
   const isValidAddr = useMemo(() => {
@@ -151,7 +152,7 @@ export const EnterAddress = ({
     (result: string) => {
       setInputAddress(result);
       // setIsValidAddr(true);
-      setTags([`ENS: ${ensResult?.name || ''}`]);
+      setTags([`${ensResult?.protocol || 'ENS'}: ${ensResult?.name || ''}`]);
       setEnsResult(null);
     },
     [ensResult?.name]
@@ -182,7 +183,7 @@ export const EnterAddress = ({
         setTags([]);
         if (!isValidAddress(address)) {
           try {
-            const result = await resolveEnsAddressByName(address, wallet);
+            const result = await resolveAddressByName(address, wallet);
             if (result && result.addr) {
               setEnsResult(result);
               // setIsValidAddr(true);
@@ -232,7 +233,7 @@ export const EnterAddress = ({
             $hasError={!isValidAddr && !filteredAccounts.length}
           >
             <Input.TextArea
-              maxLength={44}
+              maxLength={67}
               placeholder={t('page.selectToAddress.enterAddressOrENS')}
               allowClear={false}
               autoFocus

--- a/src/ui/views/SelectToAddress/components/EnterAddress.tsx
+++ b/src/ui/views/SelectToAddress/components/EnterAddress.tsx
@@ -155,7 +155,7 @@ export const EnterAddress = ({
       setTags([`${ensResult?.protocol || 'ENS'}: ${ensResult?.name || ''}`]);
       setEnsResult(null);
     },
-    [ensResult?.name]
+    [ensResult?.name, ensResult?.protocol]
   );
 
   const handleKeyDown = useMemo(() => {


### PR DESCRIPTION
## What changed

- Resolve `.xdc` recipient input directly against XDCID Registry `0x05fa64a05bc205DeDF47e023d2D90c2d119cd097` and Resolver `0x52bfa70B30190050F77033Fe427De8B3d4A8F453` on XDC chain ID 50.
- Preserve existing ENS resolution.
- Validate and canonicalize XDCID labels, and reject expired or unregistered names through the registry `ownerOf` check.
- Show the XDCID source label in recipient and watch-address flows.
- Increase the accepted input length to 67 characters and add canonicalization tests.

## Why

This adds direct, on-chain human-readable address resolution for XDC Network without API keys or an off-chain gateway dependency.

## Security and namespace policy

In this patch, `.xdc` resolves exclusively through the specified XDCID registry. It does not query or fall back to other `.xdc` registries. Maintainers should explicitly review this canonical-registry choice because another `.xdc` registry exists.

No dependency or package changes are included.

## Validation

- Reviewed the complete remote diff and added Jest coverage for XDCID canonicalization.
- `yarn` and `yarn check` were not run because this contribution was prepared without a local checkout. GitHub CI is required before review or merge.
