### PR TITLE
fix: fix regression for broken custom RPC URLs

### DIFF
--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -1710,4 +1710,4 @@ export const SELF_HOST_SAFE_NETWORKS = [
   '10',
   '8453',
 ];
-export const CUSTOM_RPC_ENABLED = false;
+export const CUSTOM_RPC_ENABLED = true;

--- a/src/ui/views/CustomTestnet/components/EditTestnetModal.tsx
+++ b/src/ui/views/CustomTestnet/components/EditTestnetModal.tsx
@@ -103,16 +103,17 @@ export const EditCustomTestnetModal = ({
           errors: [res.error.message],
         },
       ]);
-      requestAnimationFrame(() => {
-        form.scrollToField(res.error.key, {
-          behavior: 'smooth',
-          block: 'center',
+      if (!isEdit && res.error.status === 'alreadySupported') {
+        setIsShowModifyRpcModal(true);
+        setFormValues(form.getFieldsValue());
+      } else {
+        requestAnimationFrame(() => {
+          form.scrollToField(res.error.key, {
+            behavior: 'smooth',
+            block: 'center',
+          });
         });
-      });
-      // if (!isEdit && res.error.status === 'alreadySupported') {
-      //   setIsShowModifyRpcModal(true);
-      //   setFormValues(form.getFieldsValue());
-      // }
+      }
     } else {
       onConfirm?.(res);
     }


### PR DESCRIPTION
Fixes #3919 

Adds back modifying RPC URL for known networks. This feature was existing until v0.93.98 but got broken in v0.93.99, hence a regression fix