### PR TITLE
fix: fall back to EIP-712 hash signing when Ledger clear signing fails (large Safe payloads)

### DIFF
--- a/src/background/service/keyring/eth-ledger-keyring.ts
+++ b/src/background/service/keyring/eth-ledger-keyring.ts
@@ -2,6 +2,7 @@ import {
   recoverPersonalSignature,
   recoverTypedSignature,
   SignTypedDataVersion,
+  TypedDataUtils,
 } from '@metamask/eth-sig-util';
 import {
   toChecksumAddress,
@@ -11,18 +12,25 @@ import {
 } from '@ethereumjs/util';
 import { RLP, utils } from '@ethereumjs/rlp';
 import {
+  ApduBuilder,
+  ApduParser,
   CloseAppCommand,
+  CommandResultFactory,
   DeviceActionStatus,
   DeviceSessionStateType,
   DeviceStatus,
   DeviceManagementKitBuilder,
   GetAppAndVersionCommand,
+  InvalidStatusWordError,
   OpenAppDeviceAction,
   UserInteractionRequired,
   isSuccessCommandResult,
 } from '@ledgerhq/device-management-kit';
 
 import type {
+  Apdu,
+  ApduResponse,
+  Command,
   DeviceManagementKit,
   DeviceSessionState,
   DeviceSessionId,
@@ -367,6 +375,99 @@ const toSignatureHex = (signature: Signature) => {
 
   return `0x${payload.r}${payload.s}${payload.v}`;
 };
+
+const HARDENED_PATH_FLAG = 0x80000000;
+
+const splitHdPath = (hdPath: string) =>
+  hdPath
+    .split('/')
+    .filter((segment) => segment !== '' && segment !== 'm')
+    .map((segment) => {
+      const isHardened = segment.endsWith("'");
+      const index = parseInt(isHardened ? segment.slice(0, -1) : segment, 10);
+      return isHardened ? HARDENED_PATH_FLAG + index : index;
+    });
+
+const EIP712_HASH_BYTE_LENGTH = 32;
+
+type SignEIP712HashedMessageCommandArgs = {
+  derivationPath: string;
+  domainHash: string;
+  messageHash: string;
+};
+
+// Sign-EIP712 APDU in legacy (v0) mode: the device signs
+// keccak256("\x19\x01" ‖ domainHash ‖ messageHash) without streaming the
+// typed struct, so it works regardless of payload size. Same wire format as
+// hw-app-eth's signEIP712HashedMessage, which this keyring used before the
+// DMK migration. Requires Blind signing to be enabled in the Ethereum app.
+// https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/ethapp.adoc#sign-eth-eip-712
+class SignEIP712HashedMessageCommand implements Command<Signature, void, void> {
+  readonly name = 'signEIP712HashedMessage';
+
+  constructor(private readonly args: SignEIP712HashedMessageCommandArgs) {}
+
+  getApdu(): Apdu {
+    const { derivationPath, domainHash, messageHash } = this.args;
+    const builder = new ApduBuilder({
+      cla: 0xe0,
+      ins: 0x0c,
+      p1: 0x00,
+      p2: 0x00,
+    });
+    const paths = splitHdPath(derivationPath);
+    builder.add8BitUIntToData(paths.length);
+    for (const path of paths) {
+      builder.add32BitUIntToData(path);
+    }
+    builder.addHexaStringToData(domainHash);
+    builder.addHexaStringToData(messageHash);
+    return builder.build();
+  }
+
+  parseResponse(apduResponse: ApduResponse) {
+    const statusWord = Array.from(apduResponse.statusCode)
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('');
+    if (statusWord !== '9000') {
+      return CommandResultFactory<Signature, void>({
+        error: new InvalidStatusWordError(
+          statusWord === '6985'
+            ? 'Ledger: Signing was denied on the device, or Blind signing is disabled in the Ethereum app settings 0x6985'
+            : `0x${statusWord}`
+        ),
+      });
+    }
+
+    const parser = new ApduParser(apduResponse);
+    const v = parser.extract8BitUInt();
+    if (v === undefined) {
+      return CommandResultFactory<Signature, void>({
+        error: new InvalidStatusWordError('V is missing'),
+      });
+    }
+    const r = parser.encodeToHexaString(
+      parser.extractFieldByLength(EIP712_HASH_BYTE_LENGTH),
+      true
+    );
+    if (!r) {
+      return CommandResultFactory<Signature, void>({
+        error: new InvalidStatusWordError('R is missing'),
+      });
+    }
+    const s = parser.encodeToHexaString(
+      parser.extractFieldByLength(EIP712_HASH_BYTE_LENGTH),
+      true
+    );
+    if (!s) {
+      return CommandResultFactory<Signature, void>({
+        error: new InvalidStatusWordError('S is missing'),
+      });
+    }
+
+    return CommandResultFactory<Signature, void>({ data: { v, r, s } });
+  }
+}
 
 interface Account {
   address: string;
@@ -949,19 +1050,41 @@ class LedgerBridgeKeyring {
     }
 
     const hdPath = await this.unlockAccountByAddress(withAccount);
+    let signature: string;
     try {
       await this.ensureEthApp();
       const signer = this.buildSigner();
       if (!signer) {
         throw new Error('Ledger: Device disconnected');
       }
-      const signature = toSignatureHex(
+      signature = toSignatureHex(
         await runDeviceAction(
           signer.signTypedData(this._toLedgerPath(hdPath), data, {
             skipOpenApp: true,
           })
         )
       );
+    } catch (e: any) {
+      if (getLedgerStatusWord(e) === '6985' || !sessionId) {
+        throw toLedgerError(e, 'Ledger: Unknown error while signing message');
+      }
+      // Clear signing failed for a reason other than an explicit refusal on
+      // the device — typically an EIP-712 payload too large for the Ethereum
+      // app to stream (large Safe transactions), or a transport error while
+      // streaming it. Fall back to signing the EIP-712 hashes, which yields
+      // the same signature over the same digest. The pre-DMK keyring did the
+      // same via hw-app-eth's signEIP712HashedMessage, and the DMK signer
+      // itself falls back this way for the failure paths it catches.
+      try {
+        signature = await this.signTypedDataAsHashes(hdPath, data);
+      } catch (fallbackError: any) {
+        throw toLedgerError(
+          fallbackError,
+          'Ledger: Unknown error while signing message'
+        );
+      }
+    }
+    try {
       const addressSignedWith = recoverTypedSignature({
         data,
         signature,
@@ -975,6 +1098,46 @@ class LedgerBridgeKeyring {
       return signature;
     } catch (e: any) {
       throw toLedgerError(e, 'Ledger: Unknown error while signing message');
+    }
+  }
+
+  private async signTypedDataAsHashes(hdPath: string, data) {
+    const domainHash = bytesToHex(
+      TypedDataUtils.hashStruct(
+        'EIP712Domain',
+        data.domain,
+        data.types,
+        SignTypedDataVersion.V4
+      )
+    );
+    const { EIP712Domain: _domainType, ...messageTypes } = data.types;
+    const messageHash = bytesToHex(
+      TypedDataUtils.hashStruct(
+        data.primaryType,
+        data.message,
+        messageTypes,
+        SignTypedDataVersion.V4
+      )
+    );
+
+    beginLedgerOperation();
+    try {
+      const result = await getDmk().sendCommand({
+        sessionId: sessionId!,
+        command: new SignEIP712HashedMessageCommand({
+          derivationPath: this._toLedgerPath(hdPath),
+          domainHash,
+          messageHash,
+        }),
+      });
+
+      if (!isSuccessCommandResult(result)) {
+        throw result.error;
+      }
+
+      return toSignatureHex(result.data);
+    } finally {
+      endLedgerOperation();
     }
   }
 


### PR DESCRIPTION
## Problem

Since the DMK migration (#3875 / #3906, shipped in v0.93.98/v0.93.99), signing large EIP-712 typed data on Ledger fails hard with no recovery path. The most common real-world case is Safe (multisig) transaction confirmations whose `SafeTx.data` embeds large calldata: the typed-data device action streams the whole struct to the device for clear signing, and payloads past the Ethereum app's capacity fail. We (Across Protocol / Risk Labs) hit this in production this week: a Safe confirmation with 15,812 bytes of calldata failed for every Rabby+Ledger signer (Nano X), while a 4,292-byte one signed fine.

Two failure paths reach the user as a dead end today:

1. Errors **thrown** during struct streaming (transport errors, timeouts) bypass the DMK signer's own internal `SignTypedDataLegacy` fallback (`ProvideContext.onError` routes to its terminal `Error` state — see upstream issue below).
2. When the internal fallback *is* reached but Blind signing is disabled, the surfaced error is generic and unactionable.

The pre-DMK keyring (up to v0.93.97) handled unsupported typed-data payloads by falling back to `hw-app-eth`'s `signEIP712HashedMessage`. That behaviour was lost in the migration.

## Fix

In `signTypedData`, when the DMK device action fails with anything **other than a user refusal (0x6985)** and a device session exists, fall back to signing the EIP-712 hashes:

- compute `hashStruct(EIP712Domain)` and `hashStruct(primaryType)` client-side with `@metamask/eth-sig-util` (already a dependency, and the same hashing the pre-DMK fallback used);
- send the legacy **sign-EIP712 v0** APDU (`E0 0C 00 00`, path + domainHash + messageHash) via a small local `Command` built on the public DMK command API (`ApduBuilder`/`ApduParser`), since `@ledgerhq/device-signer-kit-ethereum` does not export its internal `SignEIP712Command`;
- the signed digest `keccak256("\x19\x01" ‖ domainHash ‖ messageHash)` is identical to the clear-signing one, so the existing `recoverTypedSignature` address check applies unchanged to both paths.

If the fallback itself is rejected with 0x6985, the error message now tells the user this can mean Blind signing is disabled in the Ethereum app settings.

## Security considerations

- The fallback only triggers when clear signing has already failed **and** the failure is not a user refusal; a user's explicit reject on the device is still surfaced as a rejection and never retried.
- The fallback requires the user to approve the two hashes on the device (standard blind-sign flow, gated by the device's own Blind signing setting) — no signature happens without device interaction.
- This matches the security posture of: the pre-DMK Rabby fallback, the DMK signer's own internal `SignTypedDataLegacy` fallback, Ledger Live, and Safe's direct-Ledger flow.

## Testing

- `yarn && yarn check` (lint + typecheck) pass.
- Not yet exercised on hardware from this environment; the APDU construction and response parsing mirror `SignEIP712Command` (legacy mode) from `device-signer-kit-ethereum` 1.16.0 byte-for-byte. Happy to iterate if maintainers can repro on a device — the failing case is easy to reproduce by signing any EIP-712 message with a `bytes` field ≳16 KB via WebHID Ledger.

## Upstream

The root cause (thrown streaming errors bypassing the internal fallback) has a proposed fix upstream in LedgerHQ/device-sdk-ts#1665; this PR protects Rabby users regardless of the pinned signer-kit version and remains correct after an upstream fix (the fallback then simply stops being reached).
