### PR TITLE
fix: update judgeIsSmallUsdTx filter logic

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -31,3 +31,16 @@ db.version(6).upgrade((trans) => {
     });
 });
 db.version(7).stores(schema);
+// re-judge is_small_tx after including sends in judgeIsSmallUsdTx
+db.version(8).upgrade((trans) => {
+  trans
+    .table('history')
+    .toCollection()
+    .modify((item: TxHistoryItemRow) => {
+      try {
+        item.is_small_tx = judgeIsSmallUsdTx(item);
+      } catch (e) {
+        console.error('judgeIsSmallUsdTx error', e, item);
+      }
+    });
+});

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -25,14 +25,14 @@ export const judgeIsSmallUsdTx = (item: TxHistoryItemRow) => {
     return false;
   }
 
-  const receives = item.receives;
+  const transfers = [...(item.receives || []), ...(item.sends || [])];
 
-  if (!receives || !receives.length) {
+  if (!transfers.length) {
     return true;
   }
   let allUsd = 0;
 
-  for (const i of receives) {
+  for (const i of transfers) {
     const token = i.token;
     const tokenIsNft = i.token_id?.length === 32;
     if (tokenIsNft) {


### PR DESCRIPTION
This pull request updates the logic for determining whether a transaction is considered "small" by including both received and sent transfers in the calculation. It also adds a database migration to re-evaluate this property for existing transaction history records.

**Transaction size logic update:**

* The `judgeIsSmallUsdTx` function now considers both `sends` and `receives` when determining if a transaction is "small", instead of only looking at `receives`. (`src/utils/history.ts`)

**Database migration:**

* A new database migration (version 8) is added to re-calculate the `is_small_tx` property for all history records using the updated logic, ensuring consistency for existing data. (`src/db/index.ts`)