### PR TITLE
feat: perps slippage row is only displayed when slippage >2%

### DIFF
--- a/src/ui/views/Perps/components/MarketSlippage.tsx
+++ b/src/ui/views/Perps/components/MarketSlippage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import {
+  PERPS_SLIPPAGE_DISPLAY_MIN,
   PERPS_SLIPPAGE_THRESHOLD,
   PERPS_SLIPPAGE_WARNING,
 } from '../slippageUtils';
@@ -18,7 +19,7 @@ export interface MarketSlippageProps {
   valueClassName?: string;
 }
 
-/** Est. Slippage row (value colored <1% neutral / 1%~5% amber / >=5% red) plus a switch-to-limit banner over threshold. */
+/** Est. Slippage row, only shown above 2% (value colored 2%~5% amber / >=5% red) plus a switch-to-limit banner over threshold. */
 export const MarketSlippage: React.FC<MarketSlippageProps> = ({
   slippage,
   depthInsufficient,
@@ -30,7 +31,7 @@ export const MarketSlippage: React.FC<MarketSlippageProps> = ({
   valueClassName,
 }) => {
   const { t } = useTranslation();
-  if (!visible) return null;
+  if (!visible || slippage <= PERPS_SLIPPAGE_DISPLAY_MIN) return null;
 
   const overThreshold = slippage >= PERPS_SLIPPAGE_THRESHOLD;
   const isWarning = !overThreshold && slippage >= PERPS_SLIPPAGE_WARNING;

--- a/src/ui/views/Perps/components/MarketSlippage.tsx
+++ b/src/ui/views/Perps/components/MarketSlippage.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import {
-  PERPS_SLIPPAGE_DISPLAY_MIN,
   PERPS_SLIPPAGE_THRESHOLD,
   PERPS_SLIPPAGE_WARNING,
 } from '../slippageUtils';
@@ -19,7 +18,7 @@ export interface MarketSlippageProps {
   valueClassName?: string;
 }
 
-/** Est. Slippage row, only shown above 2% (value colored 2%~5% amber / >=5% red) plus a switch-to-limit banner over threshold. */
+/** Est. Slippage row plus a switch-to-limit banner over threshold. Visibility (sticky >2% rule) is driven by useMarketSlippage's `shouldShow`. */
 export const MarketSlippage: React.FC<MarketSlippageProps> = ({
   slippage,
   depthInsufficient,
@@ -31,7 +30,7 @@ export const MarketSlippage: React.FC<MarketSlippageProps> = ({
   valueClassName,
 }) => {
   const { t } = useTranslation();
-  if (!visible || slippage <= PERPS_SLIPPAGE_DISPLAY_MIN) return null;
+  if (!visible) return null;
 
   const overThreshold = slippage >= PERPS_SLIPPAGE_THRESHOLD;
   const isWarning = !overThreshold && slippage >= PERPS_SLIPPAGE_WARNING;

--- a/src/ui/views/Perps/hooks/useMarketSlippage.ts
+++ b/src/ui/views/Perps/hooks/useMarketSlippage.ts
@@ -4,6 +4,7 @@ import {
   BookLevel,
   computeMarketSlippage,
   MarketSlippageResult,
+  PERPS_SLIPPAGE_DISPLAY_MIN,
 } from '../slippageUtils';
 
 interface Book {
@@ -23,6 +24,8 @@ export interface UseMarketSlippageParams {
 
 export interface UseMarketSlippageResult extends MarketSlippageResult {
   isReady: boolean;
+  /** Sticky: true once slippage exceeded the display threshold; stays true until re-enabled (popup reopen etc.). */
+  shouldShow: boolean;
 }
 
 /** Subscribes to the L2 book for `coin` and estimates market fill slippage for a `size`-unit order. */
@@ -34,9 +37,11 @@ export const useMarketSlippage = ({
   enabled = true,
 }: UseMarketSlippageParams): UseMarketSlippageResult => {
   const [book, setBook] = useState<Book | null>(null);
+  const [everShown, setEverShown] = useState(false);
 
   useEffect(() => {
     setBook(null);
+    setEverShown(false);
     if (!enabled || !coin) return;
 
     const sdk = getPerpsSDK();
@@ -52,7 +57,7 @@ export const useMarketSlippage = ({
     return () => unsubscribe();
   }, [coin, enabled]);
 
-  return useMemo(() => {
+  const result = useMemo(() => {
     if (!book) {
       return {
         avgPx: 0,
@@ -67,4 +72,13 @@ export const useMarketSlippage = ({
       isReady: true,
     };
   }, [book, isBuy, size, markPrice]);
+
+  const overMin =
+    result.isReady && result.slippage > PERPS_SLIPPAGE_DISPLAY_MIN;
+
+  useEffect(() => {
+    if (overMin && !everShown) setEverShown(true);
+  }, [overMin, everShown]);
+
+  return { ...result, shouldShow: everShown || overMin };
 };

--- a/src/ui/views/Perps/popup/ClosePositionPopup.tsx
+++ b/src/ui/views/Perps/popup/ClosePositionPopup.tsx
@@ -80,6 +80,7 @@ export const ClosePositionPopup: React.FC<ClosePositionPopupProps> = ({
     slippage,
     depthInsufficient,
     isReady: slippageReady,
+    shouldShow: shouldShowSlippage,
   } = useMarketSlippage({
     coin,
     isBuy: direction === 'Short',
@@ -195,7 +196,11 @@ export const ClosePositionPopup: React.FC<ClosePositionPopupProps> = ({
                 </span>
               </div>
               <MarketSlippage
-                visible={slippageReady && Number(positionSize) > 0}
+                visible={
+                  slippageReady &&
+                  Number(positionSize) > 0 &&
+                  shouldShowSlippage
+                }
                 slippage={slippage}
                 depthInsufficient={depthInsufficient}
                 labelClassName="text-14 font-medium text-rb-neutral-body leading-[18px]"

--- a/src/ui/views/Perps/popup/OpenPositionPopup.tsx
+++ b/src/ui/views/Perps/popup/OpenPositionPopup.tsx
@@ -22,6 +22,7 @@ import { EditTpSlTag } from '../components/EditTpSlTag';
 import { EditLimitPriceTag } from '../components/EditLimitPriceTag';
 import { MarketSlippage } from '../components/MarketSlippage';
 import { useMarketSlippage } from '../hooks/useMarketSlippage';
+import { PERPS_SLIPPAGE_DISPLAY_MIN } from '../slippageUtils';
 import { isMarketableLimit } from '../limitOrderUtils';
 import { MarketData } from '@/ui/models/perps';
 import { WsActiveAssetCtx } from '@rabby-wallet/hyperliquid-sdk';
@@ -832,7 +833,10 @@ export const PerpsOpenPositionPopup: React.FC<OpenPositionPopupProps> = ({
             </div>
           </div>
         </div>
-        {orderType === 'market' && slippageReady && Number(tradeSize) > 0 && (
+        {orderType === 'market' &&
+          slippageReady &&
+          Number(tradeSize) > 0 &&
+          slippage > PERPS_SLIPPAGE_DISPLAY_MIN && (
           <div className="bg-r-neutral-card1 rounded-[8px] py-12 px-16 mb-12">
             <MarketSlippage
               slippage={slippage}

--- a/src/ui/views/Perps/popup/OpenPositionPopup.tsx
+++ b/src/ui/views/Perps/popup/OpenPositionPopup.tsx
@@ -22,7 +22,6 @@ import { EditTpSlTag } from '../components/EditTpSlTag';
 import { EditLimitPriceTag } from '../components/EditLimitPriceTag';
 import { MarketSlippage } from '../components/MarketSlippage';
 import { useMarketSlippage } from '../hooks/useMarketSlippage';
-import { PERPS_SLIPPAGE_DISPLAY_MIN } from '../slippageUtils';
 import { isMarketableLimit } from '../limitOrderUtils';
 import { MarketData } from '@/ui/models/perps';
 import { WsActiveAssetCtx } from '@rabby-wallet/hyperliquid-sdk';
@@ -167,6 +166,7 @@ export const PerpsOpenPositionPopup: React.FC<OpenPositionPopupProps> = ({
     slippage,
     depthInsufficient,
     isReady: slippageReady,
+    shouldShow: shouldShowSlippage,
   } = useMarketSlippage({
     coin,
     isBuy: direction === 'Long',
@@ -836,15 +836,15 @@ export const PerpsOpenPositionPopup: React.FC<OpenPositionPopupProps> = ({
         {orderType === 'market' &&
           slippageReady &&
           Number(tradeSize) > 0 &&
-          slippage > PERPS_SLIPPAGE_DISPLAY_MIN && (
-          <div className="bg-r-neutral-card1 rounded-[8px] py-12 px-16 mb-12">
-            <MarketSlippage
-              slippage={slippage}
-              depthInsufficient={depthInsufficient}
-              onSwitchToLimit={handleSwitchToLimit}
-            />
-          </div>
-        )}
+          shouldShowSlippage && (
+            <div className="bg-r-neutral-card1 rounded-[8px] py-12 px-16 mb-12">
+              <MarketSlippage
+                slippage={slippage}
+                depthInsufficient={depthInsufficient}
+                onSwitchToLimit={handleSwitchToLimit}
+              />
+            </div>
+          )}
 
         {/* Action Buttons */}
         <div className="fixed bottom-0 left-0 right-0">

--- a/src/ui/views/Perps/slippageUtils.ts
+++ b/src/ui/views/Perps/slippageUtils.ts
@@ -4,6 +4,8 @@ import BigNumber from 'bignumber.js';
 export const PERPS_SLIPPAGE_THRESHOLD = 0.05;
 /** Threshold above which the slippage value is highlighted (warning). */
 export const PERPS_SLIPPAGE_WARNING = 0.01;
+/** The slippage row is only displayed when slippage is above this. */
+export const PERPS_SLIPPAGE_DISPLAY_MIN = 0.02;
 
 export interface BookLevel {
   px: string;


### PR DESCRIPTION
This pull request updates how slippage information is displayed in the Perps UI, ensuring that the slippage row and associated warnings are only shown when slippage exceeds 2%, instead of always being visible. This helps reduce unnecessary UI clutter for low slippage trades.

**Slippage Display Logic Changes:**

* Introduced a new constant `PERPS_SLIPPAGE_DISPLAY_MIN` (set to 0.02) in `slippageUtils.ts`, which defines the minimum slippage value required to display the slippage row.
* Updated `MarketSlippage` so that it only renders when slippage is greater than `PERPS_SLIPPAGE_DISPLAY_MIN` (2%). The component and its documentation have been updated to reflect this new threshold. [[1]](diffhunk://#diff-e24ddc648f8cdd3bca9c4aa7df6207f3af23f777ff1c54e996a9a3d6c3ddf91eR5) [[2]](diffhunk://#diff-e24ddc648f8cdd3bca9c4aa7df6207f3af23f777ff1c54e996a9a3d6c3ddf91eL21-R22) [[3]](diffhunk://#diff-e24ddc648f8cdd3bca9c4aa7df6207f3af23f777ff1c54e996a9a3d6c3ddf91eL33-R34)
* Adjusted `OpenPositionPopup.tsx` to only display the `MarketSlippage` component if slippage exceeds the new minimum threshold, ensuring consistency across the UI. [[1]](diffhunk://#diff-0dab9900f877da40e1d1df5412be03e73c740cebe244ddaf07a24ec75d612e3dR25) [[2]](diffhunk://#diff-0dab9900f877da40e1d1df5412be03e73c740cebe244ddaf07a24ec75d612e3dL835-R839)