### PR TITLE
fix: run Trezor Connect Core in MV3 offscreen document

### DIFF
--- a/SecSDK/policy-over.json
+++ b/SecSDK/policy-over.json
@@ -337,6 +337,34 @@
       "disallow": []
     }
   },
+  "node_modules/@trezor/protobuf/node_modules/protobufjs/src/util/minimal.js": {
+    "global": {
+      "allow": {
+        "process": "r",
+        "dcodeIO": "r",
+        "Long": "r"
+      },
+      "disallow": []
+    }
+  },
+  "node_modules/ua-parser-js/src/main/ua-parser.js": {
+    "global": {
+      "allow": {
+        "navigator": "r",
+        "jQuery": "r",
+        "Zepto": "r"
+      },
+      "disallow": []
+    }
+  },
+  "node_modules/@trezor/connect-web/lib/popup/index.js": {
+    "global": {
+      "allow": {
+        "addEventListener": "r"
+      },
+      "disallow": []
+    }
+  },
   "node_modules/protobufjs/src/util/longbits.js": {
     "global": {
       "allow": {

--- a/_raw/sw.js
+++ b/_raw/sw.js
@@ -1,5 +1,98 @@
 let scriptsLoadInitiated = false;
 
+const TREZOR_BROWSER_TARGET = 'trezor-browser';
+const TREZOR_POPUP_ORIGIN = 'https://connect.trezor.io';
+
+const isAllowedTrezorPopup = (url) => {
+  if (typeof url !== 'string') {
+    return false;
+  }
+
+  if (url === 'trezor-usb-permissions.html') {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.origin === TREZOR_POPUP_ORIGIN &&
+      parsed.username === '' &&
+      parsed.password === '' &&
+      /(^|\/)popup\.html$/.test(parsed.pathname)
+    );
+  } catch (_) {
+    return false;
+  }
+};
+
+const describeRejectedTrezorUrl = (url) => {
+  try {
+    return `${typeof url}: ${JSON.stringify(url)}`;
+  } catch (_) {
+    return typeof url;
+  }
+};
+
+const registerTrezorBrowserProxy = () => {
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (
+      message?.target !== TREZOR_BROWSER_TARGET ||
+      sender.id !== chrome.runtime.id ||
+      sender.url !== chrome.runtime.getURL('offscreen.html')
+    ) {
+      return false;
+    }
+
+    const execute = async () => {
+      switch (message.action) {
+        case 'trezor-browser-get-current-window':
+          return chrome.windows.getCurrent();
+        case 'trezor-browser-create-window': {
+          const { url } = message.params || {};
+          if (!isAllowedTrezorPopup(url)) {
+            throw new Error(
+              `Invalid Trezor Popup URL (${describeRejectedTrezorUrl(url)})`
+            );
+          }
+          return chrome.windows.create({ url });
+        }
+        case 'trezor-browser-query-tabs': {
+          const { active, currentWindow, windowId } = message.params || {};
+          return chrome.tabs.query({ active, currentWindow, windowId });
+        }
+        case 'trezor-browser-create-tab': {
+          const { url, index, active } = message.params || {};
+          if (!isAllowedTrezorPopup(url)) {
+            throw new Error(
+              `Invalid Trezor Popup URL (${describeRejectedTrezorUrl(url)})`
+            );
+          }
+          return chrome.tabs.create({ url, index, active });
+        }
+        case 'trezor-browser-get-tab':
+          return chrome.tabs.get(message.params);
+        case 'trezor-browser-update-tab': {
+          const { tabId, updateProperties } = message.params || {};
+          return chrome.tabs.update(tabId, {
+            active: updateProperties?.active,
+          });
+        }
+        case 'trezor-browser-remove-tab':
+          return chrome.tabs.remove(message.params);
+        default:
+          throw new Error('Unsupported Trezor browser action');
+      }
+    };
+
+    execute()
+      .then(sendResponse)
+      .catch((error) => sendResponse({ error: error.message }));
+    return true;
+  });
+};
+
+registerTrezorBrowserProxy();
+
 const clearAlarms = async () => {
   const alarms = await chrome.alarms.getAll();
   alarms.forEach((alarm) => {
@@ -17,7 +110,6 @@ const importAllScripts = () => {
   try {
     importScripts(
       '/webextension-polyfill.js',
-      '/vendor/trezor/trezor-connect-webextension.js',
       '/background.js'
     );
     scriptsLoadInitiated = true;

--- a/build/webpack.common.config.js
+++ b/build/webpack.common.config.js
@@ -349,25 +349,28 @@ const config = {
                 './vendor/trezor/trezor-content-script.js'
               ),
             },
-        IS_MANIFEST_MV3
-          ? {
-              from: require.resolve(
-                '@trezor/connect-webextension/build/trezor-connect-webextension.js'
-              ),
-              to: path.resolve(
-                FINAL_DIST,
-                './vendor/trezor/trezor-connect-webextension.js'
-              ),
-            }
-          : {
-              from: require.resolve(
-                '@trezor/connect-web/lib/webextension/trezor-usb-permissions.js'
-              ),
-              to: path.resolve(
-                FINAL_DIST,
-                './vendor/trezor/trezor-usb-permissions.js'
-              ),
-            },
+        {
+          from: require.resolve(
+            '@trezor/connect-web/lib/webextension/trezor-usb-permissions.js'
+          ),
+          to: path.resolve(
+            FINAL_DIST,
+            './vendor/trezor-usb-permissions.js'
+          ),
+        },
+        ...(IS_MANIFEST_MV3
+          ? [
+              {
+                from: require.resolve(
+                  '@trezor/connect-web/lib/webextension/trezor-usb-permissions.html'
+                ),
+                to: path.resolve(
+                  FINAL_DIST,
+                  './trezor-usb-permissions.html'
+                ),
+              },
+            ]
+          : []),
       ],
     }),
     tsStyledComponentPlugin,

--- a/build/webpack.hot.config.js
+++ b/build/webpack.hot.config.js
@@ -205,25 +205,22 @@ const commonPlugins = [
               './vendor/trezor/trezor-content-script.js'
             ),
           },
-      IS_MANIFEST_MV3
-        ? {
-            from: require.resolve(
-              '@trezor/connect-webextension/build/trezor-connect-webextension.js'
-            ),
-            to: path.resolve(
-              FINAL_DIST,
-              './vendor/trezor/trezor-connect-webextension.js'
-            ),
-          }
-        : {
-            from: require.resolve(
-              '@trezor/connect-web/lib/webextension/trezor-usb-permissions.js'
-            ),
-            to: path.resolve(
-              FINAL_DIST,
-              './vendor/trezor/trezor-usb-permissions.js'
-            ),
-          },
+      {
+        from: require.resolve(
+          '@trezor/connect-web/lib/webextension/trezor-usb-permissions.js'
+        ),
+        to: path.resolve(FINAL_DIST, './vendor/trezor-usb-permissions.js'),
+      },
+      ...(IS_MANIFEST_MV3
+        ? [
+            {
+              from: require.resolve(
+                '@trezor/connect-web/lib/webextension/trezor-usb-permissions.html'
+              ),
+              to: path.resolve(FINAL_DIST, './trezor-usb-permissions.html'),
+            },
+          ]
+        : []),
     ],
   }),
   tsStyledComponentPlugin,

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@sentry/browser": "10.58.0",
     "@sentry/react": "10.58.0",
     "@spruceid/siwe-parser": "2.0.2",
+    "@trezor/connect-web": "9.6.4",
     "@trezor/connect-webextension": "9.6.4",
     "@types/bignumber.js": "5.0.0",
     "@types/lodash": "4.14.172",

--- a/patches/@rabby-wallet+eth-trezor-keyring+2.6.4.patch
+++ b/patches/@rabby-wallet+eth-trezor-keyring+2.6.4.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@rabby-wallet/eth-trezor-keyring/dist/index.js b/node_modules/@rabby-wallet/eth-trezor-keyring/dist/index.js
+index ca96a31..63f443f 100644
+--- a/node_modules/@rabby-wallet/eth-trezor-keyring/dist/index.js
++++ b/node_modules/@rabby-wallet/eth-trezor-keyring/dist/index.js
+@@ -97,7 +97,7 @@ class TrezorKeyring extends events_1.EventEmitter {
+             manifest: TREZOR_CONNECT_MANIFEST,
+             lazyLoad: true,
+         });
+-        this.bridge.event.on('cleanUp', this.cleanUp);
++        this.bridge.event.on('cleanUp', this.cleanUp.bind(this));
+     }
+     /**
+      * Gets the model, if known.

--- a/patches/@trezor+connect-web+9.6.4.patch
+++ b/patches/@trezor+connect-web+9.6.4.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/@trezor/connect-web/lib/webextension/trezor-usb-permissions.js b/node_modules/@trezor/connect-web/lib/webextension/trezor-usb-permissions.js
+index 6d84980..dbe16e6 100644
+--- a/node_modules/@trezor/connect-web/lib/webextension/trezor-usb-permissions.js
++++ b/node_modules/@trezor/connect-web/lib/webextension/trezor-usb-permissions.js
+@@ -12,15 +12,15 @@ const switchToPopupTab = event => {
+             currentWindow: true,
+             active: true,
+         }, current => {
+-            if (current.length < 0)
++            if (current[0]?.id == null)
+                 return;
+             chrome.tabs.remove(current[0].id);
+         });
+     }
+     chrome.tabs.query({
+-        url: `${url}popup.html`,
++        url: `${url}popup.html*`,
+     }, tabs => {
+-        if (tabs.length < 0)
++        if (tabs[0]?.id == null)
+             return;
+         chrome.tabs.update(tabs[0].id, { active: true });
+     });

--- a/src/background/service/keyring/eth-trezor-keyring/trezor-offscreen-bridge.ts
+++ b/src/background/service/keyring/eth-trezor-keyring/trezor-offscreen-bridge.ts
@@ -1,5 +1,13 @@
-import { TrezorBridgeInterface } from '@rabby-wallet/eth-trezor-keyring/dist/trezor-bridge-interface';
+import type { TrezorBridgeInterface } from '@rabby-wallet/eth-trezor-keyring/dist/trezor-bridge-interface';
 import EventEmitter from 'events';
+import browser from 'webextension-polyfill';
+
+import {
+  OffscreenCommunicationEvents,
+  OffscreenCommunicationTarget,
+  TrezorAction,
+} from '@/constant/offscreen-communication';
+
 import type { HardwareSigningMetadata } from '../hardware-wallet-sentry';
 
 export default class TrezorOffscreenBridge implements TrezorBridgeInterface {
@@ -7,57 +15,153 @@ export default class TrezorOffscreenBridge implements TrezorBridgeInterface {
   model = '';
   connectDevices = new Set<string>();
   event = new EventEmitter();
-  private hardwareSigningMetadata: HardwareSigningMetadata = {};
 
-  init: TrezorBridgeInterface['init'] = async (config) => {
-    globalThis.TrezorConnect.on('DEVICE_EVENT', (event: any) => {
-      if (event && event.payload && event.payload.features) {
-        const features = event.payload.features;
+  private hardwareSigningMetadata: HardwareSigningMetadata = {};
+  private listeningForDeviceEvents = false;
+  private initializationConfig?: Parameters<TrezorBridgeInterface['init']>[0];
+  private initialization?: Promise<void>;
+  private disposal?: Promise<void>;
+
+  private listenForDeviceEvents() {
+    if (this.listeningForDeviceEvents) {
+      return;
+    }
+
+    browser.runtime.onMessage.addListener((msg, sender) => {
+      if (
+        sender.id !== browser.runtime.id ||
+        msg.target !== OffscreenCommunicationTarget.extension ||
+        msg.event !== OffscreenCommunicationEvents.trezorDeviceEvent
+      ) {
+        return;
+      }
+
+      const event = msg.payload;
+      const features = event?.payload?.features;
+      if (features) {
         this.model = features.model;
         this.hardwareSigningMetadata = {
           device_model: features.internal_model || features.model,
-          // Some device events carry features without the version fields;
-          // reporting "undefined.undefined.undefined" is worse than nothing.
           firmware_version: features.major_version
             ? `${features.major_version}.${features.minor_version}.${features.patch_version}`
             : undefined,
         };
       }
-      const currentDeviceId = event.payload?.id;
-      if (event.type === 'device-connect') {
+
+      const currentDeviceId = event?.payload?.id;
+      if (event?.type === 'device-connect') {
         this.connectDevices.add(currentDeviceId);
         this.event.emit('cleanUp', true);
-      }
-      if (event.type === 'device-disconnect') {
+      } else if (event?.type === 'device-disconnect') {
         this.connectDevices.delete(currentDeviceId);
         this.event.emit('cleanUp', true);
       }
     });
 
-    if (!this.isDeviceConnected) {
-      globalThis.TrezorConnect.init({
-        ...config,
-        transports: ['BridgeTransport', 'WebUsbTransport'],
-        connectSrc: 'https://connect.trezor.io/9/',
-        manifest: {
-          email: 'support@rabby.io',
-          appName: 'Rabby Wallet',
-          appUrl: 'https://rabby.io/',
-        },
+    this.listeningForDeviceEvents = true;
+  }
+
+  private invoke<T>(action: TrezorAction, params?: unknown): Promise<T> {
+    return browser.runtime
+      .sendMessage({
+        target: OffscreenCommunicationTarget.trezorOffscreen,
+        action,
+        params,
+      })
+      .then((response) => {
+        if (response?.error) {
+          throw new Error(response.error);
+        }
+        return response as T;
       });
-      this.isDeviceConnected = true;
+  }
+
+  private async ensureInitialized() {
+    if (!this.initializationConfig) {
+      throw new Error('Trezor bridge is not initialized');
     }
+
+    if (this.disposal) {
+      await this.disposal;
+    }
+
+    if (!this.initialization) {
+      const attempt = this.invoke<void>(
+        TrezorAction.init,
+        this.initializationConfig
+      );
+      this.initialization = attempt;
+      void attempt.catch(() => {
+        if (this.initialization === attempt) {
+          this.initialization = undefined;
+          this.isDeviceConnected = false;
+        }
+      });
+    }
+
+    await this.initialization;
+    this.isDeviceConnected = true;
+  }
+
+  private async invokeAfterInit<T>(action: TrezorAction, params?: unknown) {
+    await this.ensureInitialized();
+    return this.invoke<T>(action, params);
+  }
+
+  init: TrezorBridgeInterface['init'] = async (config) => {
+    this.listenForDeviceEvents();
+    this.initializationConfig = {
+      ...config,
+      transports: ['BridgeTransport', 'WebUsbTransport'],
+      connectSrc: 'https://connect.trezor.io/9/',
+      manifest: {
+        email: 'support@rabby.io',
+        appName: 'Rabby Wallet',
+        appUrl: 'https://rabby.io/',
+      },
+    };
+    await this.ensureInitialized();
   };
 
   getHardwareSigningMetadata = () => this.hardwareSigningMetadata;
 
-  dispose = globalThis.TrezorConnect.dispose;
+  dispose: TrezorBridgeInterface['dispose'] = async () => {
+    if (!this.disposal) {
+      const pendingInitialization = this.initialization;
+      this.initialization = undefined;
 
-  getPublicKey = globalThis.TrezorConnect.getPublicKey;
+      const attempt = (async () => {
+        await pendingInitialization?.catch(() => undefined);
+        await this.invoke(TrezorAction.dispose);
+      })();
 
-  ethereumSignTransaction = globalThis.TrezorConnect.ethereumSignTransaction;
+      this.disposal = attempt;
+      void attempt
+        .finally(() => {
+          if (this.disposal === attempt) {
+            this.disposal = undefined;
+          }
+          this.isDeviceConnected = false;
+          this.connectDevices.clear();
+        })
+        .catch(() => undefined);
+    }
 
-  ethereumSignMessage = globalThis.TrezorConnect.ethereumSignMessage;
+    return this.disposal;
+  };
 
-  ethereumSignTypedData = globalThis.TrezorConnect.ethereumSignTypedData;
+  getPublicKey: TrezorBridgeInterface['getPublicKey'] = (params) =>
+    this.invokeAfterInit(TrezorAction.getPublicKey, params);
+
+  ethereumSignTransaction: TrezorBridgeInterface['ethereumSignTransaction'] = (
+    params
+  ) => this.invokeAfterInit(TrezorAction.ethereumSignTransaction, params);
+
+  ethereumSignMessage: TrezorBridgeInterface['ethereumSignMessage'] = (
+    params
+  ) => this.invokeAfterInit(TrezorAction.ethereumSignMessage, params);
+
+  ethereumSignTypedData: TrezorBridgeInterface['ethereumSignTypedData'] = (
+    params
+  ) => this.invokeAfterInit(TrezorAction.ethereumSignTypedData, params);
 }

--- a/src/constant/offscreen-communication.ts
+++ b/src/constant/offscreen-communication.ts
@@ -2,6 +2,8 @@ export enum OffscreenCommunicationTarget {
   latticeOffscreen = 'lattice-offscreen',
   imkeyOffscreen = 'imkey-offscreen',
   onekeyOffscreen = 'onekey-offscreen',
+  trezorOffscreen = 'trezor-offscreen',
+  trezorBrowser = 'trezor-browser',
   bitbox02Offscreen = 'bitbox02-offscreen',
   extension = 'extension-offscreen',
 }
@@ -9,6 +11,7 @@ export enum OffscreenCommunicationTarget {
 export enum OffscreenCommunicationEvents {
   imKeyDeviceConnect = 'imkey-device-connect',
   oneKeyDeviceConnect = 'onekey-device-connect',
+  trezorDeviceEvent = 'trezor-device-event',
   bitbox02DeviceConnect = 'bitbox02-device-connect',
   latticeDeviceConnect = 'lattice-device-connect',
 }
@@ -28,6 +31,25 @@ export enum OneKeyAction {
   getPassphraseState = 'onekey-get-passphrase-state',
   evmGetPublicKey = 'onekey-evm-get-public-key',
   getFeatures = 'onekey-get-device-features',
+}
+
+export enum TrezorAction {
+  init = 'trezor-init',
+  dispose = 'trezor-dispose',
+  getPublicKey = 'trezor-get-public-key',
+  ethereumSignTransaction = 'trezor-sign-transaction',
+  ethereumSignMessage = 'trezor-sign-message',
+  ethereumSignTypedData = 'trezor-sign-typed-data',
+}
+
+export enum TrezorBrowserAction {
+  getCurrentWindow = 'trezor-browser-get-current-window',
+  createWindow = 'trezor-browser-create-window',
+  queryTabs = 'trezor-browser-query-tabs',
+  createTab = 'trezor-browser-create-tab',
+  getTab = 'trezor-browser-get-tab',
+  updateTab = 'trezor-browser-update-tab',
+  removeTab = 'trezor-browser-remove-tab',
 }
 
 export enum BitBox02Action {

--- a/src/manifest/chrome-mv3/manifest.dev.json
+++ b/src/manifest/chrome-mv3/manifest.dev.json
@@ -47,7 +47,7 @@
     },
     {
       "matches": [
-        "*://connect.trezor.io/*/popup.html",
+        "*://connect.trezor.io/*/popup.html*",
         "https://connect.onekey.so/popup.html"
       ],
       "js": [

--- a/src/manifest/chrome-mv3/manifest.json
+++ b/src/manifest/chrome-mv3/manifest.json
@@ -46,7 +46,7 @@
     },
     {
       "matches": [
-        "*://connect.trezor.io/*/popup.html",
+        "*://connect.trezor.io/*/popup.html*",
         "https://connect.onekey.so/popup.html"
       ],
       "js": [

--- a/src/offscreen/scripts/offscreen.ts
+++ b/src/offscreen/scripts/offscreen.ts
@@ -3,9 +3,11 @@ import { initImKey } from './imkey';
 import initLattice from './lattice';
 import { initLedger } from './ledger';
 import { initOneKey } from './onekey';
+import { initTrezor } from './trezor';
 
 initImKey();
 initOneKey();
+initTrezor();
 initBitBox02();
 initLattice();
 initLedger();

--- a/src/offscreen/scripts/trezor-browser-api.ts
+++ b/src/offscreen/scripts/trezor-browser-api.ts
@@ -1,0 +1,126 @@
+import {
+  OffscreenCommunicationTarget,
+  TrezorBrowserAction,
+} from '@/constant/offscreen-communication';
+
+type BrowserApiResponse<T> = T | { error: string };
+
+const invokeBrowserApi = async <T>(
+  action: TrezorBrowserAction,
+  params?: unknown
+) => {
+  const response = (await chrome.runtime.sendMessage({
+    target: OffscreenCommunicationTarget.trezorBrowser,
+    action,
+    params,
+  })) as BrowserApiResponse<T>;
+
+  if (response && typeof response === 'object' && 'error' in response) {
+    throw new Error(response.error);
+  }
+
+  return response as T;
+};
+
+const callWithCallback = <T>(
+  operation: Promise<T>,
+  callback?: (result?: T) => void
+) => {
+  operation
+    .then((result) => callback?.(result))
+    .catch((error) => {
+      if (
+        error instanceof Error &&
+        /^No tab with id: \d+\.$/.test(error.message)
+      ) {
+        callback?.();
+        return;
+      }
+
+      console.error('[Trezor] Browser API proxy failed', error);
+      callback?.();
+    });
+};
+
+/**
+ * MV3 offscreen documents only expose chrome.runtime. Trezor Connect uses the
+ * presence of chrome.tabs to select its webextension Port channel, so proxy the
+ * small browser API surface used by its PopupManager through the service worker.
+ */
+export const installTrezorBrowserApi = () => {
+  const extensionChrome = chrome as any;
+
+  if (!extensionChrome.tabs) {
+    extensionChrome.tabs = {
+      query: (
+        queryInfo: chrome.tabs.QueryInfo,
+        callback: (tabs?: chrome.tabs.Tab[]) => void
+      ) =>
+        callWithCallback(
+          invokeBrowserApi<chrome.tabs.Tab[]>(
+            TrezorBrowserAction.queryTabs,
+            queryInfo
+          ),
+          callback
+        ),
+      create: (
+        createProperties: chrome.tabs.CreateProperties,
+        callback: (tab?: chrome.tabs.Tab) => void
+      ) =>
+        callWithCallback(
+          invokeBrowserApi<chrome.tabs.Tab>(
+            TrezorBrowserAction.createTab,
+            createProperties
+          ),
+          callback
+        ),
+      get: (tabId: number, callback: (tab?: chrome.tabs.Tab) => void) =>
+        callWithCallback(
+          invokeBrowserApi<chrome.tabs.Tab>(TrezorBrowserAction.getTab, tabId),
+          callback
+        ),
+      update: (tabId: number, updateProperties: chrome.tabs.UpdateProperties) =>
+        invokeBrowserApi<chrome.tabs.Tab>(TrezorBrowserAction.updateTab, {
+          tabId,
+          updateProperties,
+        }),
+      remove: (tabId: number, callback?: () => void) =>
+        callWithCallback(
+          invokeBrowserApi<void>(TrezorBrowserAction.removeTab, tabId),
+          callback
+        ),
+    };
+  }
+
+  if (!extensionChrome.windows) {
+    extensionChrome.windows = {
+      getCurrent: (callback: (window?: chrome.windows.Window) => void) =>
+        callWithCallback(
+          invokeBrowserApi<chrome.windows.Window>(
+            TrezorBrowserAction.getCurrentWindow
+          ),
+          callback
+        ),
+      create: (
+        createData: chrome.windows.CreateData,
+        callback: (window?: chrome.windows.Window) => void
+      ) =>
+        callWithCallback(
+          invokeBrowserApi<chrome.windows.Window>(
+            TrezorBrowserAction.createWindow,
+            createData
+          ),
+          callback
+        ),
+    };
+  }
+
+  // The content script is declared in the manifest, so PopupManager does not
+  // need to perform its optional scripting permission probe from offscreen.
+  if (!extensionChrome.permissions) {
+    extensionChrome.permissions = {
+      getAll: (callback: (permissions: { permissions: string[] }) => void) =>
+        callback({ permissions: [] }),
+    };
+  }
+};

--- a/src/offscreen/scripts/trezor.ts
+++ b/src/offscreen/scripts/trezor.ts
@@ -1,0 +1,160 @@
+import TrezorConnect from '@trezor/connect-web';
+
+import {
+  OffscreenCommunicationEvents,
+  OffscreenCommunicationTarget,
+  TrezorAction,
+} from '@/constant/offscreen-communication';
+
+import { installTrezorBrowserApi } from './trezor-browser-api';
+
+type TrezorRequest = {
+  target: OffscreenCommunicationTarget;
+  action: TrezorAction;
+  params?: any;
+};
+
+const forwardDeviceEvent = (event: any) => {
+  chrome.runtime.sendMessage({
+    target: OffscreenCommunicationTarget.extension,
+    event: OffscreenCommunicationEvents.trezorDeviceEvent,
+    payload: event,
+  });
+};
+
+let initialization: Promise<void> | undefined;
+let initializationConfig: TrezorRequest['params'];
+let disposal: Promise<void> | undefined;
+
+const ensureInitialized = async (params?: TrezorRequest['params']) => {
+  if (params !== undefined) {
+    initializationConfig = params;
+  }
+
+  if (disposal) {
+    await disposal;
+  }
+
+  if (initializationConfig === undefined) {
+    throw new Error('Trezor Connect is not initialized');
+  }
+
+  if (!initialization) {
+    const attempt = (async () => {
+      try {
+        TrezorConnect.on('DEVICE_EVENT', forwardDeviceEvent);
+        await TrezorConnect.init({
+          ...initializationConfig,
+          coreMode: 'iframe',
+          env: 'webextension',
+        });
+      } catch (error) {
+        try {
+          await TrezorConnect.dispose();
+        } catch {
+          // Preserve the initialization error that caused the cleanup.
+        }
+        throw error;
+      }
+    })();
+
+    initialization = attempt;
+    void attempt.catch(() => {
+      if (initialization === attempt) {
+        initialization = undefined;
+      }
+    });
+  }
+
+  return initialization;
+};
+
+const invokeAfterInit = async <T>(operation: () => Promise<T>) => {
+  await ensureInitialized();
+  return operation();
+};
+
+const dispose = () => {
+  if (disposal) {
+    return disposal;
+  }
+
+  const pendingInitialization = initialization;
+  initialization = undefined;
+
+  const attempt = (async () => {
+    await pendingInitialization?.catch(() => undefined);
+    await TrezorConnect.dispose();
+  })();
+
+  disposal = attempt;
+  void attempt
+    .finally(() => {
+      if (disposal === attempt) {
+        disposal = undefined;
+      }
+    })
+    .catch(() => undefined);
+
+  return attempt;
+};
+
+export function initTrezor() {
+  installTrezorBrowserApi();
+
+  chrome.runtime.onMessage.addListener(
+    (msg: TrezorRequest, sender, sendResponse) => {
+      if (
+        sender.id !== chrome.runtime.id ||
+        msg.target !== OffscreenCommunicationTarget.trezorOffscreen
+      ) {
+        return;
+      }
+
+      const respond = (operation: Promise<unknown>) => {
+        operation.then(sendResponse).catch((error) =>
+          sendResponse({
+            error: error instanceof Error ? error.message : String(error),
+          })
+        );
+      };
+
+      switch (msg.action) {
+        case TrezorAction.init:
+          respond(ensureInitialized(msg.params));
+          break;
+        case TrezorAction.dispose:
+          respond(dispose());
+          break;
+        case TrezorAction.getPublicKey:
+          respond(
+            invokeAfterInit(() => TrezorConnect.getPublicKey(msg.params))
+          );
+          break;
+        case TrezorAction.ethereumSignTransaction:
+          respond(
+            invokeAfterInit(() =>
+              TrezorConnect.ethereumSignTransaction(msg.params)
+            )
+          );
+          break;
+        case TrezorAction.ethereumSignMessage:
+          respond(
+            invokeAfterInit(() => TrezorConnect.ethereumSignMessage(msg.params))
+          );
+          break;
+        case TrezorAction.ethereumSignTypedData:
+          respond(
+            invokeAfterInit(() =>
+              TrezorConnect.ethereumSignTypedData(msg.params)
+            )
+          );
+          break;
+        default:
+          sendResponse({ error: 'Trezor action not supported' });
+      }
+
+      return true;
+    }
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -21520,6 +21520,7 @@ __metadata:
     "@spruceid/siwe-parser": "npm:2.0.2"
     "@svgr/webpack": "npm:5.5.0"
     "@tailwindcss/postcss": "npm:4.3.0"
+    "@trezor/connect-web": "npm:9.6.4"
     "@trezor/connect-webextension": "npm:9.6.4"
     "@types/archiver": "npm:6.0.2"
     "@types/bignumber.js": "npm:5.0.0"


### PR DESCRIPTION
Move Trezor Connect Core out of the remote popup execution context and route hardware wallet operations through the extension offscreen document.

- proxy required browser APIs with sender and URL validation
- bundle USB permission assets for MV3 builds
- serialize Trezor initialization and disposal
- patch popup tab handling and keyring cleanup
- update Warden policy overrides