### PR TITLE
fix(deps): bump nanoid 3.3.6 -> 3.3.16 to clear HIGH advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "lottie-react": "2.4.0",
     "lru-cache": "6.0.0",
     "multiformats": "13.3.2",
-    "nanoid": "3.3.6",
+    "nanoid": "3.3.16",
     "obs-store": "4.0.3",
     "p-queue": "7.3.0",
     "p-retry": "5.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19507,12 +19507,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:3.3.6":
-  version: 3.3.6
-  resolution: "nanoid@npm:3.3.6"
+"nanoid@npm:3.3.16":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/606b355960d0fcbe3d27924c4c52ef7d47d3b57208808ece73279420d91469b01ec1dce10fae512b6d4a8c5a5432b352b228336a8b2202a6ea68e67fa348e2ee
+  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
   languageName: node
   linkType: hard
 
@@ -21614,7 +21614,7 @@ __metadata:
     lottie-react: "npm:2.4.0"
     lru-cache: "npm:6.0.0"
     multiformats: "npm:13.3.2"
-    nanoid: "npm:3.3.6"
+    nanoid: "npm:3.3.16"
     obs-store: "npm:4.0.3"
     p-queue: "npm:7.3.0"
     p-retry: "npm:5.1.2"


### PR DESCRIPTION
Summary
nanoid is declared as a direct production dependency at 3.3.6, which is below the patched floor 3.3.16 (HIGH advisory GHSA-28wg-ghj8-5hjv — non-secure generators can loop indefinitely with negative size; also GHSA-mwcw-c2x4-8c55).

It is imported across 16 production source files, including security/identity-relevant ID generation:
- src/utils/message/index.ts:186 — ident = nanoid()
- src/background/utils/persistStore.ts:13 — persistStoreOrigin = nanoid()
- src/background/service/customTestnet.ts:1222,1254,1329 — id: nanoid()
- src/background/service/transactionHistory.ts:208, src/ui/hooks/useAccounts.ts:93, and others

In a wallet, identifiers expected to be unguessable should not be produced by a version with documented predictability/DoS weaknesses.

Change
- Bump nanoid to 3.3.16 (drop-in, same major).
- Regenerated yarn.lock via yarn install.

Verification
yarn why nanoid now resolves nanoid@npm:3.3.16 for the direct dependency.