### PR TITLE
fix: prevent duplicate BitBox02 pairing popups

### DIFF
--- a/__tests__/service/bitbox02OffscreenBridge.test.ts
+++ b/__tests__/service/bitbox02OffscreenBridge.test.ts
@@ -1,0 +1,56 @@
+import browser from 'webextension-polyfill';
+import BitBox02OffscreenBridge from '@/background/service/keyring/eth-bitbox02-keyring/bitbox02-offscreen-bridge';
+import {
+  OffscreenCommunicationEvents,
+  OffscreenCommunicationTarget,
+} from '@/constant/offscreen-communication';
+
+jest.mock('hdkey', () => jest.fn());
+
+jest.mock('webextension-polyfill', () => ({
+  __esModule: true,
+  default: {
+    runtime: {
+      onMessage: {
+        addListener: jest.fn(),
+      },
+      sendMessage: jest.fn(() => new Promise(() => {})),
+    },
+    windows: {
+      create: jest.fn(() => Promise.resolve()),
+    },
+  },
+}));
+
+describe('BitBox02OffscreenBridge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens one pairing popup after repeated initialization', async () => {
+    const bridge = new BitBox02OffscreenBridge();
+
+    void bridge.init("m/44'/60'/0'");
+    void bridge.init("m/44'/60'/0'");
+    void bridge.init("m/44'/60'/0'");
+
+    const addListener = browser.runtime.onMessage.addListener as jest.Mock;
+    expect(addListener).toHaveBeenCalledTimes(1);
+
+    const event = {
+      target: OffscreenCommunicationTarget.extension,
+      event: OffscreenCommunicationEvents.bitbox02DeviceConnect,
+      payload: {
+        name: 'open-popup',
+        pairingCode: 'AAAAA BBBBB\nCCCCC DDDDD',
+      },
+    };
+
+    for (const [listener] of addListener.mock.calls) {
+      listener(event, {}, jest.fn());
+    }
+    await Promise.resolve();
+
+    expect(browser.windows.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/background/service/keyring/eth-bitbox02-keyring/bitbox02-offscreen-bridge.ts
+++ b/src/background/service/keyring/eth-bitbox02-keyring/bitbox02-offscreen-bridge.ts
@@ -5,13 +5,15 @@ import {
   OffscreenCommunicationEvents,
   BitBox02Action,
 } from '@/constant/offscreen-communication';
-import * as HDKey from 'hdkey';
+import HDKey from 'hdkey';
 
 export default class BitBox02OffscreenBridge
   implements BitBox02BridgeInterface {
   isDeviceConnected = false;
 
   hdk: HDKey = new HDKey();
+
+  private isMessageListenerRegistered = false;
 
   private async openPopup(url) {
     await browser.windows.create({
@@ -26,7 +28,11 @@ export default class BitBox02OffscreenBridge
     browser.runtime.sendMessage({ type: 'bitbox02', action: 'popup-close' });
   }
 
-  init: BitBox02BridgeInterface['init'] = async (hdPath) => {
+  private registerMessageListener() {
+    if (this.isMessageListenerRegistered) {
+      return;
+    }
+
     browser.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       if (
         msg.target === OffscreenCommunicationTarget.extension &&
@@ -54,6 +60,11 @@ export default class BitBox02OffscreenBridge
 
       return true;
     });
+    this.isMessageListenerRegistered = true;
+  }
+
+  init: BitBox02BridgeInterface['init'] = async (hdPath) => {
+    this.registerMessageListener();
 
     return new Promise((resolve, reject) => {
       browser.runtime


### PR DESCRIPTION
Repeated BitBox02 initialization registered another runtime message listener each time, so one pairing event could open multiple windows.

Register the listener once per offscreen bridge instance and cover repeated initialization with a regression test.

This was introduced some time ago in the Manifest V3 architecture which introduced the BitBox02OffscreenBridge