### PR TITLE
Lazy-load and cache perps widget catalogs

### DIFF
--- a/__tests__/service/perpsLive.test.ts
+++ b/__tests__/service/perpsLive.test.ts
@@ -1,0 +1,250 @@
+const mockSessionGet = jest.fn();
+const mockSessionSet = jest.fn();
+const mockOpenapiGetTopTokens = jest.fn();
+const mockGetPerpsAllMetas = jest.fn();
+const mockGetPerpDexs = jest.fn();
+const mockSubscribeAllDexs = jest.fn();
+const mockSdkConstructor = jest.fn();
+const mockEventBusAddListener = jest.fn();
+
+let mockWidgetEnabled = true;
+const mockPerpsStore: {
+  currentAccount: { address: string } | null;
+} = {
+  currentAccount: {
+    address: '0x0000000000000000000000000000000000000001',
+  },
+};
+
+jest.mock('webextension-polyfill', () => ({
+  __esModule: true,
+  default: {
+    storage: {
+      session: {
+        get: mockSessionGet,
+        set: mockSessionSet,
+      },
+    },
+  },
+}));
+
+jest.mock('@rabby-wallet/hyperliquid-sdk', () => ({
+  HyperliquidSDK: jest
+    .fn()
+    .mockImplementation((config) => mockSdkConstructor(config)),
+}));
+
+jest.mock('@/eventBus', () => ({
+  __esModule: true,
+  default: {
+    addEventListener: mockEventBusAddListener,
+  },
+}));
+
+jest.mock('@/constant', () => ({
+  EVENTS: {
+    PERPS: {
+      WIDGET_ACCOUNT_CHANGED: 'WIDGET_ACCOUNT_CHANGED',
+      WIDGET_ENABLED_CHANGED: 'WIDGET_ENABLED_CHANGED',
+    },
+  },
+}));
+
+jest.mock('@/background/service/openapi', () => ({
+  __esModule: true,
+  default: {
+    getPerpTopTokenListV3: mockOpenapiGetTopTokens,
+  },
+}));
+
+jest.mock('@/background/service/perps', () => ({
+  __esModule: true,
+  default: {
+    store: mockPerpsStore,
+  },
+}));
+
+jest.mock('@/background/service/preference', () => ({
+  __esModule: true,
+  default: {
+    getPerpsWidgetEnabled: () => mockWidgetEnabled,
+  },
+}));
+
+import { PerpsLiveService } from '@/background/service/perpsLive';
+
+const CATALOG_CACHE_KEY = 'perpsLiveCatalogV1';
+const CATALOG_TTL_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 7, 18, 0, 0, 0);
+
+const token = {
+  id: 'btc',
+  token_id: 1,
+  name: 'BTC',
+  daily_volume: 1,
+  display_name: 'BTC/USDC',
+};
+
+function createPort() {
+  const disconnectListeners: Array<() => void> = [];
+  return {
+    postMessage: jest.fn(),
+    onDisconnect: {
+      addListener: jest.fn((listener: () => void) => {
+        disconnectListeners.push(listener);
+      }),
+    },
+    disconnect: () => disconnectListeners.forEach((listener) => listener()),
+  } as any;
+}
+
+function createFreshCache(fetchedAt = NOW) {
+  return {
+    version: 1,
+    fetchedAt,
+    tokenCatalog: [token],
+    dexLookup: [{ dexId: '', quoteAsset: 'USDC' }],
+  };
+}
+
+async function waitForCatalog(service: PerpsLiveService) {
+  const promise = (service as any).catalogLoadPromise as Promise<void> | null;
+  if (promise) await promise;
+}
+
+describe('PerpsLiveService lazy catalogs', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    jest.clearAllMocks();
+    mockWidgetEnabled = true;
+    mockPerpsStore.currentAccount = {
+      address: '0x0000000000000000000000000000000000000001',
+    };
+    mockSessionGet.mockResolvedValue({});
+    mockSessionSet.mockResolvedValue(undefined);
+    mockOpenapiGetTopTokens.mockResolvedValue([token]);
+    mockGetPerpsAllMetas.mockResolvedValue([{ collateralToken: 0 }]);
+    mockGetPerpDexs.mockResolvedValue([null]);
+    mockSubscribeAllDexs.mockReturnValue({ unsubscribe: jest.fn() });
+    mockSdkConstructor.mockImplementation(() => ({
+      ws: {
+        isConnected: true,
+        subscribeToAllDexsClearinghouseState: mockSubscribeAllDexs,
+        subscribeToActiveAssetCtx: jest.fn(),
+      },
+      info: {
+        getPerpsAllMetas: mockGetPerpsAllMetas,
+        getPerpDexs: mockGetPerpDexs,
+        candleSnapshot: jest.fn(),
+      },
+      disconnectWebSocket: jest.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('boot registers lifecycle listeners without constructing an SDK or reading the cache', () => {
+    const service = new PerpsLiveService();
+
+    service.boot();
+
+    expect(mockEventBusAddListener).toHaveBeenCalledTimes(2);
+    expect(mockSdkConstructor).not.toHaveBeenCalled();
+    expect(mockSessionGet).not.toHaveBeenCalled();
+    expect(mockOpenapiGetTopTokens).not.toHaveBeenCalled();
+  });
+
+  test('does not load catalogs when a port attaches while the widget is disabled', () => {
+    mockWidgetEnabled = false;
+    const service = new PerpsLiveService();
+
+    service.attachPort(createPort());
+
+    expect(mockSdkConstructor).not.toHaveBeenCalled();
+    expect(mockSessionGet).not.toHaveBeenCalled();
+    expect(mockOpenapiGetTopTokens).not.toHaveBeenCalled();
+  });
+
+  test('does not load catalogs without a current perps account', () => {
+    mockPerpsStore.currentAccount = null;
+    const service = new PerpsLiveService();
+
+    service.attachPort(createPort());
+
+    expect(mockSdkConstructor).not.toHaveBeenCalled();
+    expect(mockSessionGet).not.toHaveBeenCalled();
+    expect(mockOpenapiGetTopTokens).not.toHaveBeenCalled();
+  });
+
+  test('loads and persists catalogs once for the first active stream', async () => {
+    const service = new PerpsLiveService();
+
+    service.attachPort(createPort());
+    const concurrentLoad = (service as any).ensureCatalogs();
+    await Promise.all([waitForCatalog(service), concurrentLoad]);
+
+    expect(mockSdkConstructor).toHaveBeenCalledTimes(1);
+    expect(mockSessionGet).toHaveBeenCalledTimes(1);
+    expect(mockOpenapiGetTopTokens).toHaveBeenCalledTimes(1);
+    expect(mockGetPerpsAllMetas).toHaveBeenCalledTimes(1);
+    expect(mockGetPerpDexs).toHaveBeenCalledTimes(1);
+    expect(mockSessionSet).toHaveBeenCalledWith({
+      [CATALOG_CACHE_KEY]: createFreshCache(),
+    });
+  });
+
+  test('hydrates a fresh session cache without any catalog REST requests', async () => {
+    mockSessionGet.mockResolvedValue({
+      [CATALOG_CACHE_KEY]: createFreshCache(),
+    });
+    const service = new PerpsLiveService();
+
+    service.attachPort(createPort());
+    await waitForCatalog(service);
+
+    expect(mockSessionGet).toHaveBeenCalledTimes(1);
+    expect(mockOpenapiGetTopTokens).not.toHaveBeenCalled();
+    expect(mockGetPerpsAllMetas).not.toHaveBeenCalled();
+    expect(mockGetPerpDexs).not.toHaveBeenCalled();
+    expect(mockSessionSet).not.toHaveBeenCalled();
+    expect((service as any).tokenCatalog.get('BTC')).toEqual(token);
+    expect((service as any).dexLookup.get('')).toEqual({ quoteAsset: 'USDC' });
+  });
+
+  test('refreshes an expired cache and uses a fresh SDK after the TTL', async () => {
+    const service = new PerpsLiveService();
+    service.attachPort(createPort());
+    await waitForCatalog(service);
+
+    jest.setSystemTime(NOW + CATALOG_TTL_MS);
+    mockSessionGet.mockResolvedValue({
+      [CATALOG_CACHE_KEY]: createFreshCache(NOW),
+    });
+    await (service as any).ensureCatalogs();
+
+    expect(mockSdkConstructor).toHaveBeenCalledTimes(2);
+    expect(mockOpenapiGetTopTokens).toHaveBeenCalledTimes(2);
+    expect(mockGetPerpsAllMetas).toHaveBeenCalledTimes(2);
+    expect(mockGetPerpDexs).toHaveBeenCalledTimes(2);
+    expect(mockSessionSet).toHaveBeenLastCalledWith({
+      [CATALOG_CACHE_KEY]: createFreshCache(NOW + CATALOG_TTL_MS),
+    });
+  });
+
+  test('clears the in-flight guard after a failed load so the next check can retry', async () => {
+    mockOpenapiGetTopTokens.mockRejectedValueOnce(new Error('offline'));
+    const service = new PerpsLiveService();
+    service.attachPort(createPort());
+    await waitForCatalog(service);
+
+    mockOpenapiGetTopTokens.mockResolvedValue([token]);
+    await (service as any).ensureCatalogs();
+
+    expect(mockOpenapiGetTopTokens).toHaveBeenCalledTimes(2);
+    expect(mockSessionSet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/service/perpsLive.test.ts
+++ b/__tests__/service/perpsLive.test.ts
@@ -75,6 +75,7 @@ import { PerpsLiveService } from '@/background/service/perpsLive';
 
 const CATALOG_CACHE_KEY = 'perpsLiveCatalogV1';
 const CATALOG_TTL_MS = 24 * 60 * 60 * 1000;
+const CATALOG_RETRY_BASE_MS = 5 * 60 * 1000;
 const NOW = Date.UTC(2026, 7, 18, 0, 0, 0);
 
 const token = {
@@ -235,16 +236,39 @@ describe('PerpsLiveService lazy catalogs', () => {
     });
   });
 
-  test('clears the in-flight guard after a failed load so the next check can retry', async () => {
+  test('backs off exponentially after failed loads and resets after recovery', async () => {
     mockOpenapiGetTopTokens.mockRejectedValueOnce(new Error('offline'));
     const service = new PerpsLiveService();
     service.attachPort(createPort());
     await waitForCatalog(service);
 
+    await (service as any).ensureCatalogs();
+    expect(mockOpenapiGetTopTokens).toHaveBeenCalledTimes(1);
+    expect(mockSessionSet).not.toHaveBeenCalled();
+
+    jest.setSystemTime(NOW + CATALOG_RETRY_BASE_MS - 1);
+    await (service as any).ensureCatalogs();
+    expect(mockOpenapiGetTopTokens).toHaveBeenCalledTimes(1);
+
+    mockOpenapiGetTopTokens.mockRejectedValueOnce(new Error('still offline'));
+    jest.setSystemTime(NOW + CATALOG_RETRY_BASE_MS);
+    await (service as any).ensureCatalogs();
+    expect(mockOpenapiGetTopTokens).toHaveBeenCalledTimes(2);
+    expect((service as any).catalogRetryAt).toBe(
+      NOW + CATALOG_RETRY_BASE_MS * 3
+    );
+
+    jest.setSystemTime(NOW + CATALOG_RETRY_BASE_MS * 3 - 1);
+    await (service as any).ensureCatalogs();
+    expect(mockOpenapiGetTopTokens).toHaveBeenCalledTimes(2);
+
     mockOpenapiGetTopTokens.mockResolvedValue([token]);
+    jest.setSystemTime(NOW + CATALOG_RETRY_BASE_MS * 3);
     await (service as any).ensureCatalogs();
 
-    expect(mockOpenapiGetTopTokens).toHaveBeenCalledTimes(2);
+    expect(mockOpenapiGetTopTokens).toHaveBeenCalledTimes(3);
     expect(mockSessionSet).toHaveBeenCalledTimes(1);
+    expect((service as any).catalogRetryAt).toBe(0);
+    expect((service as any).catalogRetryDelayMs).toBe(CATALOG_RETRY_BASE_MS);
   });
 });

--- a/src/background/service/perpsLive.ts
+++ b/src/background/service/perpsLive.ts
@@ -57,6 +57,8 @@ const ON_DEMAND_KLINE_COOLDOWN_MS = 5 * 1000;
 const CATALOG_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const CATALOG_CACHE_KEY = 'perpsLiveCatalogV1';
 const CATALOG_CACHE_VERSION = 1;
+const CATALOG_RETRY_BASE_MS = 5 * 60 * 1000;
+const CATALOG_RETRY_MAX_MS = 60 * 60 * 1000;
 const WS_WATCHDOG_INTERVAL_MS = 60 * 1000;
 /**
  * With open positions the assetCtx WS pushes ~every second, so this much
@@ -191,6 +193,8 @@ export class PerpsLiveService {
   private tokenCatalog = new Map<string, PerpTopTokenV3>();
   private catalogFetchedAt = 0;
   private catalogLoadPromise: Promise<void> | null = null;
+  private catalogRetryAt = 0;
+  private catalogRetryDelayMs = CATALOG_RETRY_BASE_MS;
 
   /** dex prefix → quoteAsset; main dex uses '' as key */
   private dexLookup = new Map<string, { quoteAsset: PerpsQuoteAsset }>();
@@ -724,7 +728,10 @@ export class PerpsLiveService {
   }
 
   private ensureCatalogs(): Promise<void> {
-    if (this.isCatalogFresh()) return Promise.resolve();
+    const now = Date.now();
+    if (this.isCatalogFresh(now) || now < this.catalogRetryAt) {
+      return Promise.resolve();
+    }
     if (this.catalogLoadPromise) return this.catalogLoadPromise;
 
     const loadPromise = this.loadCatalogs().finally(() => {
@@ -752,10 +759,27 @@ export class PerpsLiveService {
       this.refreshTokenCatalog(),
       this.refreshDexLookup(catalogSdk),
     ]);
-    if (!tokenCatalogOk || !dexLookupOk) return;
+    if (!tokenCatalogOk || !dexLookupOk) {
+      this.deferCatalogRetry();
+      return;
+    }
 
     this.catalogFetchedAt = Date.now();
+    this.resetCatalogRetry();
     await this.writeCatalogCache();
+  }
+
+  private deferCatalogRetry(now = Date.now()): void {
+    this.catalogRetryAt = now + this.catalogRetryDelayMs;
+    this.catalogRetryDelayMs = Math.min(
+      this.catalogRetryDelayMs * 2,
+      CATALOG_RETRY_MAX_MS
+    );
+  }
+
+  private resetCatalogRetry(): void {
+    this.catalogRetryAt = 0;
+    this.catalogRetryDelayMs = CATALOG_RETRY_BASE_MS;
   }
 
   private async readCatalogCache(): Promise<PerpsLiveCatalogCache | null> {
@@ -781,6 +805,7 @@ export class PerpsLiveService {
       this.dexLookup.set(entry.dexId, { quoteAsset: entry.quoteAsset });
     }
     this.catalogFetchedAt = cache.fetchedAt;
+    this.resetCatalogRetry();
     this.scheduleRebuild();
   }
 

--- a/src/background/service/perpsLive.ts
+++ b/src/background/service/perpsLive.ts
@@ -14,6 +14,7 @@ import {
   CandleSnapshot,
   PerpDex,
 } from '@rabby-wallet/hyperliquid-sdk';
+import browser from 'webextension-polyfill';
 import type { Runtime } from 'webextension-polyfill';
 import type { PerpTopTokenV3 } from '@rabby-wallet/rabby-api/dist/types';
 import eventBus from '@/eventBus';
@@ -27,6 +28,7 @@ import {
 } from '@/utils/message/perpsLive';
 import { getHyperliquidCoinLogoUrl } from '@/utils/perps/coinLogo';
 import {
+  ALL_PERPS_QUOTE_ASSETS,
   PerpsQuoteAsset,
   getQuoteAssetFromMeta,
 } from '@/utils/perps/quoteAsset';
@@ -52,7 +54,9 @@ const KLINE_INTERVAL = '15m';
 const TOP_N_KLINE = 3;
 /** Min gap between WS-driven (on-demand) kline kicks; bounds retries if a fetch keeps failing */
 const ON_DEMAND_KLINE_COOLDOWN_MS = 5 * 1000;
-const CATALOG_REFRESH_MS = 24 * 60 * 60 * 1000;
+const CATALOG_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const CATALOG_CACHE_KEY = 'perpsLiveCatalogV1';
+const CATALOG_CACHE_VERSION = 1;
 const WS_WATCHDOG_INTERVAL_MS = 60 * 1000;
 /**
  * With open positions the assetCtx WS pushes ~every second, so this much
@@ -76,6 +80,58 @@ interface AssetCtxEntry {
 }
 
 type DexClearinghousePair = [string, ClearinghouseState];
+
+interface PerpsLiveCatalogCache {
+  version: typeof CATALOG_CACHE_VERSION;
+  fetchedAt: number;
+  tokenCatalog: PerpTopTokenV3[];
+  dexLookup: Array<{
+    dexId: string;
+    quoteAsset: PerpsQuoteAsset;
+  }>;
+}
+
+function parseCatalogCache(
+  value: unknown,
+  now: number
+): PerpsLiveCatalogCache | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Partial<PerpsLiveCatalogCache>;
+  if (
+    candidate.version !== CATALOG_CACHE_VERSION ||
+    typeof candidate.fetchedAt !== 'number' ||
+    !Number.isFinite(candidate.fetchedAt)
+  ) {
+    return null;
+  }
+
+  const age = now - candidate.fetchedAt;
+  if (age < 0 || age >= CATALOG_CACHE_TTL_MS) return null;
+  if (
+    !Array.isArray(candidate.tokenCatalog) ||
+    candidate.tokenCatalog.length === 0 ||
+    !candidate.tokenCatalog.every(
+      (token) =>
+        token && typeof token.name === 'string' && token.name.length > 0
+    )
+  ) {
+    return null;
+  }
+  if (
+    !Array.isArray(candidate.dexLookup) ||
+    candidate.dexLookup.length === 0 ||
+    !candidate.dexLookup.every(
+      (entry) =>
+        entry &&
+        typeof entry.dexId === 'string' &&
+        ALL_PERPS_QUOTE_ASSETS.includes(entry.quoteAsset)
+    )
+  ) {
+    return null;
+  }
+
+  return candidate as PerpsLiveCatalogCache;
+}
 
 /** Avoid float noise like `1.7000000000001` in the reverse-derived markPx */
 function alignDecimals(value: number, refStr: string | undefined): string {
@@ -101,7 +157,7 @@ function appendLivePrice(
   return [...base, livePx];
 }
 
-class PerpsLiveService {
+export class PerpsLiveService {
   private sdk: HyperliquidSDK | null = null;
   private wsClearinghouse: { unsubscribe: () => void } | null = null;
 
@@ -133,23 +189,18 @@ class PerpsLiveService {
 
   /** Keyed by Hyperliquid coin string. DeBank's `t.name` is already in that format — `t.dex_id` is redundant */
   private tokenCatalog = new Map<string, PerpTopTokenV3>();
-  private catalogRefreshTimer: TimerHandle | null = null;
+  private catalogFetchedAt = 0;
+  private catalogLoadPromise: Promise<void> | null = null;
 
   /** dex prefix → quoteAsset; main dex uses '' as key */
   private dexLookup = new Map<string, { quoteAsset: PerpsQuoteAsset }>();
 
   private booted = false;
 
-  async boot(): Promise<void> {
+  boot(): void {
     if (this.booted) return;
     this.booted = true;
     console.log('[perpsLive] boot');
-
-    this.sdk = new HyperliquidSDK({
-      isTestnet: false,
-      timeout: 10000,
-      wsConfig: { autoReconnect: true },
-    });
 
     eventBus.addEventListener(
       EVENTS.PERPS.WIDGET_ACCOUNT_CHANGED,
@@ -162,18 +213,6 @@ class PerpsLiveService {
       console.log('[perpsLive] enabledChange');
       this.applyAddress(this.deriveCurrentAddress());
     });
-
-    // 2s ceiling so a slow REST doesn't block SW boot; the pending Promise.all
-    // keeps running and eventually fills the maps anyway.
-    await Promise.race([
-      Promise.all([this.refreshTokenCatalog(), this.refreshDexLookup()]),
-      new Promise<void>((r) => setTimeout(r, 2000)),
-    ]);
-
-    this.catalogRefreshTimer = setInterval(() => {
-      this.refreshTokenCatalog();
-      this.refreshDexLookup();
-    }, CATALOG_REFRESH_MS);
   }
 
   attachPort(port: Port): void {
@@ -234,15 +273,8 @@ class PerpsLiveService {
     this.stopStream();
     this.broadcastWsState('connecting');
 
-    if (!this.sdk) {
-      // Defensive — boot() constructs sdk synchronously.
-      console.warn('[perpsLive] SDK not ready, retrying soon');
-      this.scheduleWsRetry(address);
-      return;
-    }
-    const sdk = this.sdk;
-
     try {
+      const sdk = this.getSdk();
       this.wsClearinghouse = sdk.ws.subscribeToAllDexsClearinghouseState(
         address,
         (data) => this.onAllDexsClearinghouseStates(data)
@@ -253,6 +285,10 @@ class PerpsLiveService {
       this.startWsWatchdog();
       this.broadcastWsState('open');
       console.log('[perpsLive] ws open (all dexs) for', address);
+      // Public display metadata is useful only while the widget has an active
+      // consumer. Cache/session reads and all three REST requests stay behind
+      // the same enabled + port + account gate as the live stream.
+      void this.ensureCatalogs();
     } catch (err) {
       console.warn('[perpsLive] ws subscribe failed, retry in 5s', err);
       this.broadcastWsState('closed');
@@ -287,7 +323,8 @@ class PerpsLiveService {
       this.wsClearinghouse = null;
     }
 
-    // WS disconnects but SDK stays — refreshDexLookup and the next startStream both reuse it.
+    // WS disconnects but the live SDK stays for the next stream and kline fetches.
+    // Catalog refreshes use a separate fresh SDK once their TTL expires.
     if (this.sdk) {
       try {
         this.sdk.disconnectWebSocket();
@@ -325,6 +362,10 @@ class PerpsLiveService {
   private startWsWatchdog(): void {
     this.stopWsWatchdog();
     this.wsWatchdogTimer = setInterval(() => {
+      // Also acts as the active-only catalog TTL check. When there is no live
+      // widget stream, stopWsWatchdog removes this timer, so metadata refreshes
+      // never wake an otherwise idle extension.
+      void this.ensureCatalogs();
       if (!this.currentAddress || !this.sdk) return;
       const quietFor = Date.now() - this.lastWsMessageAt;
       // The quiet-period grace avoids stomping on an in-flight connect or the
@@ -662,12 +703,112 @@ class PerpsLiveService {
     );
   }
 
-  private async refreshTokenCatalog(): Promise<void> {
+  private createSdk(): HyperliquidSDK {
+    return new HyperliquidSDK({
+      isTestnet: false,
+      timeout: 10000,
+      wsConfig: { autoReconnect: true },
+    });
+  }
+
+  private getSdk(): HyperliquidSDK {
+    if (!this.sdk) {
+      this.sdk = this.createSdk();
+    }
+    return this.sdk;
+  }
+
+  private isCatalogFresh(now = Date.now()): boolean {
+    const age = now - this.catalogFetchedAt;
+    return age >= 0 && age < CATALOG_CACHE_TTL_MS;
+  }
+
+  private ensureCatalogs(): Promise<void> {
+    if (this.isCatalogFresh()) return Promise.resolve();
+    if (this.catalogLoadPromise) return this.catalogLoadPromise;
+
+    const loadPromise = this.loadCatalogs().finally(() => {
+      if (this.catalogLoadPromise === loadPromise) {
+        this.catalogLoadPromise = null;
+      }
+    });
+    this.catalogLoadPromise = loadPromise;
+    return this.catalogLoadPromise;
+  }
+
+  private async loadCatalogs(): Promise<void> {
+    const cached = await this.readCatalogCache();
+    if (cached) {
+      this.applyCatalogCache(cached);
+      return;
+    }
+
+    // The SDK caches these metadata calls for its own lifetime. Reuse the live
+    // SDK for the first load, but use a fresh HTTP client after our TTL expires
+    // so the advertised 24h refresh actually reaches Hyperliquid.
+    const catalogSdk =
+      this.catalogFetchedAt > 0 ? this.createSdk() : this.getSdk();
+    const [tokenCatalogOk, dexLookupOk] = await Promise.all([
+      this.refreshTokenCatalog(),
+      this.refreshDexLookup(catalogSdk),
+    ]);
+    if (!tokenCatalogOk || !dexLookupOk) return;
+
+    this.catalogFetchedAt = Date.now();
+    await this.writeCatalogCache();
+  }
+
+  private async readCatalogCache(): Promise<PerpsLiveCatalogCache | null> {
+    try {
+      const session = browser.storage?.session;
+      if (!session) return null;
+      const result = await session.get(CATALOG_CACHE_KEY);
+      return parseCatalogCache(result?.[CATALOG_CACHE_KEY], Date.now());
+    } catch (err) {
+      console.warn('[perpsLive] read catalog cache failed', err);
+      return null;
+    }
+  }
+
+  private applyCatalogCache(cache: PerpsLiveCatalogCache): void {
+    this.tokenCatalog.clear();
+    for (const token of cache.tokenCatalog) {
+      this.tokenCatalog.set(token.name, token);
+    }
+
+    this.dexLookup.clear();
+    for (const entry of cache.dexLookup) {
+      this.dexLookup.set(entry.dexId, { quoteAsset: entry.quoteAsset });
+    }
+    this.catalogFetchedAt = cache.fetchedAt;
+    this.scheduleRebuild();
+  }
+
+  private async writeCatalogCache(): Promise<void> {
+    try {
+      const session = browser.storage?.session;
+      if (!session) return;
+      const cache: PerpsLiveCatalogCache = {
+        version: CATALOG_CACHE_VERSION,
+        fetchedAt: this.catalogFetchedAt,
+        tokenCatalog: Array.from(this.tokenCatalog.values()),
+        dexLookup: Array.from(
+          this.dexLookup.entries()
+        ).map(([dexId, { quoteAsset }]) => ({ dexId, quoteAsset })),
+      };
+      await session.set({ [CATALOG_CACHE_KEY]: cache });
+    } catch (err) {
+      // Cache persistence is an optimization; live data remains usable.
+      console.warn('[perpsLive] write catalog cache failed', err);
+    }
+  }
+
+  private async refreshTokenCatalog(): Promise<boolean> {
     try {
       const list = await openapiService.getPerpTopTokenListV3?.({
         dex_id: 'all',
       });
-      if (!Array.isArray(list)) return;
+      if (!Array.isArray(list) || list.length === 0) return false;
       this.tokenCatalog.clear();
       for (const t of list) {
         if (t?.name) {
@@ -679,15 +820,15 @@ class PerpsLiveService {
         this.tokenCatalog.size
       );
       this.scheduleRebuild();
+      return true;
     } catch (err) {
       console.warn('[perpsLive] refreshTokenCatalog failed', err);
+      return false;
     }
   }
 
   /** perpDexs and allMetas are index-aligned; perpDexs[i] === null marks the main dex (key '') */
-  private async refreshDexLookup(): Promise<void> {
-    if (!this.sdk) return;
-    const sdk = this.sdk;
+  private async refreshDexLookup(sdk: HyperliquidSDK): Promise<boolean> {
     try {
       const [allMetas, perpDexs] = await Promise.all([
         sdk.info.getPerpsAllMetas(),
@@ -704,8 +845,10 @@ class PerpsLiveService {
         this.dexLookup.size
       );
       this.scheduleRebuild();
+      return this.dexLookup.size > 0;
     } catch (err) {
       console.warn('[perpsLive] refreshDexLookup failed', err);
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary

- Defer Hyperliquid SDK and catalog initialization until the perps widget has an active stream.
- Cache token and DEX metadata in session storage with versioning and a 24-hour TTL.
- Reuse fresh cached catalogs, refresh expired entries with a new SDK, and retry failed loads.
- Add lifecycle and cache behavior tests for `PerpsLiveService`.

## Testing

- Added Jest coverage for lazy initialization, gating, cache hydration, TTL refresh, persistence, and retry behavior.