### PR TITLE
fix: prevent duplicate BitBox02 pairing popups

### DIFF
--- a/__tests__/service/bitbox02OffscreenBridge.test.ts
+++ b/__tests__/service/bitbox02OffscreenBridge.test.ts
@@ -1,0 +1,56 @@
+import browser from 'webextension-polyfill';
+import BitBox02OffscreenBridge from '@/background/service/keyring/eth-bitbox02-keyring/bitbox02-offscreen-bridge';
+import {
+  OffscreenCommunicationEvents,
+  OffscreenCommunicationTarget,
+} from '@/constant/offscreen-communication';
+
+jest.mock('hdkey', () => jest.fn());
+
+jest.mock('webextension-polyfill', () => ({
+  __esModule: true,
+  default: {
+    runtime: {
+      onMessage: {
+        addListener: jest.fn(),
+      },
+      sendMessage: jest.fn(() => new Promise(() => {})),
+    },
+    windows: {
+      create: jest.fn(() => Promise.resolve()),
+    },
+  },
+}));
+
+describe('BitBox02OffscreenBridge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens one pairing popup after repeated initialization', async () => {
+    const bridge = new BitBox02OffscreenBridge();
+
+    void bridge.init("m/44'/60'/0'");
+    void bridge.init("m/44'/60'/0'");
+    void bridge.init("m/44'/60'/0'");
+
+    const addListener = browser.runtime.onMessage.addListener as jest.Mock;
+    expect(addListener).toHaveBeenCalledTimes(1);
+
+    const event = {
+      target: OffscreenCommunicationTarget.extension,
+      event: OffscreenCommunicationEvents.bitbox02DeviceConnect,
+      payload: {
+        name: 'open-popup',
+        pairingCode: 'AAAAA BBBBB\nCCCCC DDDDD',
+      },
+    };
+
+    for (const [listener] of addListener.mock.calls) {
+      listener(event, {}, jest.fn());
+    }
+    await Promise.resolve();
+
+    expect(browser.windows.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/service/bitbox02OffscreenBridge.test.ts
+++ b/__tests__/service/bitbox02OffscreenBridge.test.ts
@@ -5,7 +5,11 @@ import {
   OffscreenCommunicationTarget,
 } from '@/constant/offscreen-communication';
 
-jest.mock('hdkey', () => jest.fn());
+jest.mock('hdkey', () =>
+  Object.assign(jest.fn(), {
+    fromExtendedKey: jest.fn((key) => ({ key })),
+  })
+);
 
 jest.mock('webextension-polyfill', () => ({
   __esModule: true,
@@ -14,7 +18,7 @@ jest.mock('webextension-polyfill', () => ({
       onMessage: {
         addListener: jest.fn(),
       },
-      sendMessage: jest.fn(() => new Promise(() => {})),
+      sendMessage: jest.fn(() => Promise.resolve({ pubKey: 'xpub-live' })),
     },
     windows: {
       create: jest.fn(() => Promise.resolve()),
@@ -23,34 +27,67 @@ jest.mock('webextension-polyfill', () => ({
 }));
 
 describe('BitBox02OffscreenBridge', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('opens one pairing popup after repeated initialization', async () => {
-    const bridge = new BitBox02OffscreenBridge();
-
-    void bridge.init("m/44'/60'/0'");
-    void bridge.init("m/44'/60'/0'");
-    void bridge.init("m/44'/60'/0'");
-
+  it('opens one pairing popup no matter how many bridges exist', async () => {
     const addListener = browser.runtime.onMessage.addListener as jest.Mock;
+
+    const bridge = new BitBox02OffscreenBridge();
+    await bridge.init("m/44'/60'/0'");
+    await bridge.init("m/44'/60'/0'");
+
+    // lock/unlock, or reopening the import page, builds a brand new bridge
+    const restoredBridge = new BitBox02OffscreenBridge();
+    await restoredBridge.init("m/44'/60'/0'");
+
+    // one listener for the whole service worker, registered at module load
     expect(addListener).toHaveBeenCalledTimes(1);
 
-    const event = {
-      target: OffscreenCommunicationTarget.extension,
-      event: OffscreenCommunicationEvents.bitbox02DeviceConnect,
-      payload: {
-        name: 'open-popup',
-        pairingCode: 'AAAAA BBBBB\nCCCCC DDDDD',
+    const [listener] = addListener.mock.calls[0];
+    listener(
+      {
+        target: OffscreenCommunicationTarget.extension,
+        event: OffscreenCommunicationEvents.bitbox02DeviceConnect,
+        payload: {
+          name: 'open-popup',
+          pairingCode: 'AAAAA BBBBB\nCCCCC DDDDD',
+        },
       },
-    };
-
-    for (const [listener] of addListener.mock.calls) {
-      listener(event, {}, jest.fn());
-    }
+      {},
+      jest.fn()
+    );
     await Promise.resolve();
 
     expect(browser.windows.create).toHaveBeenCalledTimes(1);
+
+    // the pub key rides on the init response, so it can only land on the
+    // bridge that asked for it
+    expect(restoredBridge.hdk).toEqual({ key: 'xpub-live' });
+  });
+
+  it('rejects init when the offscreen document is unreachable', async () => {
+    (browser.runtime.sendMessage as jest.Mock).mockRejectedValueOnce(
+      new Error('Could not establish connection')
+    );
+
+    await expect(
+      new BitBox02OffscreenBridge().init("m/44'/60'/0'")
+    ).rejects.toThrow('Could not establish connection');
+  });
+
+  it('rejects a signing request when the offscreen document errors', async () => {
+    (browser.runtime.sendMessage as jest.Mock).mockResolvedValueOnce({
+      error: 'user cancelled',
+    });
+
+    await expect(
+      new BitBox02OffscreenBridge().ethSignMessage(1, "m/44'/60'/0'/0/0", '0x')
+    ).rejects.toEqual('user cancelled');
+  });
+
+  it('rejects init when the offscreen document returns no pub key', async () => {
+    (browser.runtime.sendMessage as jest.Mock).mockResolvedValueOnce({});
+
+    await expect(
+      new BitBox02OffscreenBridge().init("m/44'/60'/0'")
+    ).rejects.toThrow('no pub key');
   });
 });

--- a/src/background/service/keyring/eth-bitbox02-keyring/bitbox02-offscreen-bridge.ts
+++ b/src/background/service/keyring/eth-bitbox02-keyring/bitbox02-offscreen-bridge.ts
@@ -5,13 +5,15 @@ import {
   OffscreenCommunicationEvents,
   BitBox02Action,
 } from '@/constant/offscreen-communication';
-import * as HDKey from 'hdkey';
+import HDKey from 'hdkey';
 
 export default class BitBox02OffscreenBridge
   implements BitBox02BridgeInterface {
   isDeviceConnected = false;
 
   hdk: HDKey = new HDKey();
+
+  private isMessageListenerRegistered = false;
 
   private async openPopup(url) {
     await browser.windows.create({
@@ -26,7 +28,11 @@ export default class BitBox02OffscreenBridge
     browser.runtime.sendMessage({ type: 'bitbox02', action: 'popup-close' });
   }
 
-  init: BitBox02BridgeInterface['init'] = async (hdPath) => {
+  private registerMessageListener() {
+    if (this.isMessageListenerRegistered) {
+      return;
+    }
+
     browser.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       if (
         msg.target === OffscreenCommunicationTarget.extension &&
@@ -54,6 +60,11 @@ export default class BitBox02OffscreenBridge
 
       return true;
     });
+    this.isMessageListenerRegistered = true;
+  }
+
+  init: BitBox02BridgeInterface['init'] = async (hdPath) => {
+    this.registerMessageListener();
 
     return new Promise((resolve, reject) => {
       browser.runtime

--- a/src/background/service/keyring/eth-bitbox02-keyring/bitbox02-offscreen-bridge.ts
+++ b/src/background/service/keyring/eth-bitbox02-keyring/bitbox02-offscreen-bridge.ts
@@ -7,160 +7,110 @@ import {
 } from '@/constant/offscreen-communication';
 import HDKey from 'hdkey';
 
+async function openPopup(url: string) {
+  await browser.windows.create({
+    url,
+    type: 'popup',
+    width: 320,
+    height: 175,
+  });
+}
+
+function maybeClosePopup() {
+  // Having no pairing window open is the normal case, and nobody answering
+  // must not surface as an unhandled rejection in the service worker.
+  browser.runtime
+    .sendMessage({ type: 'bitbox02', action: 'popup-close' })
+    .catch(() => {
+      // no popup to close
+    });
+}
+
+// The pairing popup is a process-wide UI side effect, not per-bridge state, so
+// the listener is registered once per service worker. A per-instance guard used
+// to leak one listener per bridge, and a lock/unlock cycle or a reopened import
+// page builds a new bridge, so every pairing then opened N popups.
+browser.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (
+    msg.target !== OffscreenCommunicationTarget.extension ||
+    msg.event !== OffscreenCommunicationEvents.bitbox02DeviceConnect
+  ) {
+    return;
+  }
+
+  const event = msg.payload;
+  if (event.name === 'open-popup') {
+    openPopup(
+      `vendor/bitbox02/bitbox02-pairing.html?code=${encodeURIComponent(
+        event.pairingCode
+      )}`
+    ).then(sendResponse);
+  }
+
+  if (event.name === 'close-popup') {
+    maybeClosePopup();
+    sendResponse();
+  }
+
+  return true;
+});
+
 export default class BitBox02OffscreenBridge
   implements BitBox02BridgeInterface {
   isDeviceConnected = false;
 
   hdk: HDKey = new HDKey();
 
-  private isMessageListenerRegistered = false;
-
-  private async openPopup(url) {
-    await browser.windows.create({
-      url,
-      type: 'popup',
-      width: 320,
-      height: 175,
+  // Awaited rather than wrapped in `new Promise`: a rejected sendMessage (no
+  // offscreen document, closed port) has to reject the caller instead of
+  // leaving it pending forever behind the signing UI.
+  private async request(action: BitBox02Action, params: any[]) {
+    const res = await browser.runtime.sendMessage({
+      target: OffscreenCommunicationTarget.bitbox02Offscreen,
+      action,
+      params,
     });
-  }
 
-  private maybeClosePopup() {
-    browser.runtime.sendMessage({ type: 'bitbox02', action: 'popup-close' });
-  }
-
-  private registerMessageListener() {
-    if (this.isMessageListenerRegistered) {
-      return;
+    if (res?.error) {
+      throw res.error;
     }
 
-    browser.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-      if (
-        msg.target === OffscreenCommunicationTarget.extension &&
-        msg.event === OffscreenCommunicationEvents.bitbox02DeviceConnect
-      ) {
-        const event = msg.payload;
-        if (event.name === 'open-popup') {
-          this.openPopup(
-            `vendor/bitbox02/bitbox02-pairing.html?code=${encodeURIComponent(
-              event.pairingCode
-            )}`
-          ).then(sendResponse);
-        }
-
-        if (event.name === 'close-popup') {
-          this.maybeClosePopup();
-          sendResponse();
-        }
-
-        if (event.name === 'pub-key') {
-          this.hdk = HDKey.fromExtendedKey(event.pubKey);
-          sendResponse();
-        }
-      }
-
-      return true;
-    });
-    this.isMessageListenerRegistered = true;
+    return res;
   }
 
   init: BitBox02BridgeInterface['init'] = async (hdPath) => {
-    this.registerMessageListener();
+    const res = await this.request(BitBox02Action.init, [hdPath]);
 
-    return new Promise((resolve, reject) => {
-      browser.runtime
-        .sendMessage({
-          target: OffscreenCommunicationTarget.bitbox02Offscreen,
-          action: BitBox02Action.init,
-          params: [hdPath],
-        })
-        .then((res) => {
-          if (res?.error) {
-            reject(res.error);
-          } else {
-            this.isDeviceConnected = true;
-            resolve(res);
-          }
-        });
-    });
+    if (!res?.pubKey) {
+      throw new Error('BitBox02: init returned no pub key');
+    }
+
+    this.hdk = HDKey.fromExtendedKey(res.pubKey);
+    this.isDeviceConnected = true;
+    return res;
   };
 
   ethSign1559Transaction: BitBox02BridgeInterface['ethSign1559Transaction'] = async (
     ...params
   ) => {
-    return new Promise((resolve, reject) => {
-      browser.runtime
-        .sendMessage({
-          target: OffscreenCommunicationTarget.bitbox02Offscreen,
-          action: BitBox02Action.ethSign1559Transaction,
-          params,
-        })
-        .then((res) => {
-          if (res?.error) {
-            reject(res.error);
-          } else {
-            resolve(res);
-          }
-        });
-    });
+    return this.request(BitBox02Action.ethSign1559Transaction, params);
   };
 
   ethSignMessage: BitBox02BridgeInterface['ethSignMessage'] = async (
     ...params
   ) => {
-    return new Promise((resolve, reject) => {
-      browser.runtime
-        .sendMessage({
-          target: OffscreenCommunicationTarget.bitbox02Offscreen,
-          action: BitBox02Action.ethSignMessage,
-          params,
-        })
-        .then((res) => {
-          if (res?.error) {
-            reject(res.error);
-          } else {
-            resolve(res);
-          }
-        });
-    });
+    return this.request(BitBox02Action.ethSignMessage, params);
   };
 
   ethSignTransaction: BitBox02BridgeInterface['ethSignTransaction'] = async (
     ...params
   ) => {
-    return new Promise((resolve, reject) => {
-      browser.runtime
-        .sendMessage({
-          target: OffscreenCommunicationTarget.bitbox02Offscreen,
-          action: BitBox02Action.ethSignTransaction,
-          params,
-        })
-        .then((res) => {
-          if (res?.error) {
-            reject(res.error);
-          } else {
-            resolve(res);
-          }
-        });
-    });
+    return this.request(BitBox02Action.ethSignTransaction, params);
   };
 
   ethSignTypedMessage: BitBox02BridgeInterface['ethSignTypedMessage'] = async (
     ...params
   ) => {
-    return new Promise((resolve, reject) => {
-      browser.runtime
-        .sendMessage({
-          target: OffscreenCommunicationTarget.bitbox02Offscreen,
-          action: BitBox02Action.ethSignTypedMessage,
-          params,
-        })
-        .then((res) => {
-          if (res?.error) {
-            reject(res.error);
-          } else {
-            resolve(res);
-          }
-        });
-    });
+    return this.request(BitBox02Action.ethSignTypedMessage, params);
   };
 }

--- a/src/offscreen/scripts/bitbox02.ts
+++ b/src/offscreen/scripts/bitbox02.ts
@@ -53,19 +53,14 @@ export function initBitBox02() {
           onCloseCb();
           bridge.isDeviceConnected = true;
           const rootPub = await bridge.app.ethXpub(msg.params[0]);
-          await browser.runtime.sendMessage({
-            target: OffscreenCommunicationTarget.extension,
-            event: OffscreenCommunicationEvents.bitbox02DeviceConnect,
-            payload: {
-              name: 'pub-key',
-              pubKey: rootPub,
-            },
-          });
 
           if (!bridge.app.ethSupported()) {
             sendResponse({ error: 'Unsupported device' });
+            return;
           }
-          sendResponse();
+          // The pub key answers this init request, so it goes back as its
+          // response rather than as a broadcast every listener has to sort out.
+          sendResponse({ pubKey: rootPub });
         } catch (err) {
           console.error(err);
           if (bridge.app) {


### PR DESCRIPTION
## Summary

Recreate the fix from #4013 in an internal PR for security review.

The MV3 BitBox02 offscreen bridge registered a global runtime.onMessage listener on every init() call. Repeated initialization caused one pairing event to be handled multiple times and opened duplicate pairing popups.

This change registers the listener once per bridge instance and adds a regression test covering repeated initialization.

## Security / reliability

Duplicate pairing UI can confuse the device-pairing flow and leave multiple authorization surfaces open. The fix keeps a single listener and prevents duplicate popup creation without changing signing behavior.

## Validation

- Targeted Jest test passed
- Targeted ESLint passed
- git diff --check passed
- Full typecheck is blocked by existing Keystone dependency export errors in src/ui/utils/keystone.ts

Original external PR: #4013