### PR TITLE
fix: avoid WalletConnect relayer provider race

### DIFF
--- a/__tests__/service/walletconnect-relayer.test.ts
+++ b/__tests__/service/walletconnect-relayer.test.ts
@@ -1,0 +1,62 @@
+import { EventEmitter } from 'events';
+
+jest.mock('@walletconnect/sign-client', () => ({
+  __esModule: true,
+  default: {
+    init: jest.fn(),
+  },
+}));
+
+const signClient = jest.requireMock('@walletconnect/sign-client').default as {
+  init: jest.Mock;
+};
+const { V2SDK } = require('@rabby-wallet/eth-walletconnect-keyring/dist/v2sdk');
+
+const createClient = () => {
+  const client = new EventEmitter() as EventEmitter & {
+    core: { relayer: EventEmitter };
+    session: { keys: string[] };
+  };
+  client.core = { relayer: new EventEmitter() };
+  client.session = { keys: [] };
+  return client;
+};
+
+const createSDK = () => {
+  const sdk = Object.create(V2SDK.prototype) as any;
+  sdk.options = { projectId: 'test', clientMeta: {} };
+  sdk.cached = { getAllTopics: () => [] };
+  sdk._closeConnector = jest.fn();
+  sdk.onAfterSessionCreated = jest.fn();
+  return sdk;
+};
+
+describe('WalletConnect relayer error listener', () => {
+  beforeEach(() => {
+    signClient.init.mockReset();
+  });
+
+  it('initializes when the relayer does not expose provider', async () => {
+    const client = createClient();
+    signClient.init.mockResolvedValue(client);
+
+    expect((client.core.relayer as any).provider).toBeUndefined();
+    await expect(createSDK().initSDK()).resolves.toBeUndefined();
+  });
+
+  it('re-initializes on a relayer JWT error', async () => {
+    const firstClient = createClient();
+    const secondClient = createClient();
+    signClient.init
+      .mockResolvedValueOnce(firstClient)
+      .mockResolvedValueOnce(secondClient);
+    const sdk = createSDK();
+
+    await sdk.initSDK();
+    firstClient.core.relayer.emit('error', new Error('3000 JWT expired'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(signClient.init).toHaveBeenCalledTimes(2);
+    expect(sdk.onAfterSessionCreated).toHaveBeenCalledWith('');
+  });
+});

--- a/patches/@rabby-wallet+eth-walletconnect-keyring+2.1.7.patch
+++ b/patches/@rabby-wallet+eth-walletconnect-keyring+2.1.7.patch
@@ -1,9 +1,9 @@
 diff --git a/node_modules/@rabby-wallet/eth-walletconnect-keyring/dist/v2sdk.js b/node_modules/@rabby-wallet/eth-walletconnect-keyring/dist/v2sdk.js
-index 0000000..0000000 100644
+index 7c7fddd..cf85321 100644
 --- a/node_modules/@rabby-wallet/eth-walletconnect-keyring/dist/v2sdk.js
 +++ b/node_modules/@rabby-wallet/eth-walletconnect-keyring/dist/v2sdk.js
-@@ -138,7 +138,7 @@ class WalletConnectKeyringV2 extends WalletConnectKeyringBase {
-             };
+@@ -138,7 +138,7 @@ class V2SDK extends sdk_1.SDK {
+             });
              const listenerJwtError = () => {
                  var _a;
 -                (_a = this.client) === null || _a === void 0 ? void 0 : _a.core.relayer.provider.once('error', (e) => __awaiter(this, void 0, void 0, function* () {

--- a/patches/@rabby-wallet+eth-walletconnect-keyring+2.1.7.patch
+++ b/patches/@rabby-wallet+eth-walletconnect-keyring+2.1.7.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@rabby-wallet/eth-walletconnect-keyring/dist/v2sdk.js b/node_modules/@rabby-wallet/eth-walletconnect-keyring/dist/v2sdk.js
+index 0000000..0000000 100644
+--- a/node_modules/@rabby-wallet/eth-walletconnect-keyring/dist/v2sdk.js
++++ b/node_modules/@rabby-wallet/eth-walletconnect-keyring/dist/v2sdk.js
+@@ -138,7 +138,7 @@ class WalletConnectKeyringV2 extends WalletConnectKeyringBase {
+             };
+             const listenerJwtError = () => {
+                 var _a;
+-                (_a = this.client) === null || _a === void 0 ? void 0 : _a.core.relayer.provider.once('error', (e) => __awaiter(this, void 0, void 0, function* () {
++                (_a = this.client) === null || _a === void 0 ? void 0 : _a.core.relayer.once('error', (e) => __awaiter(this, void 0, void 0, function* () {
+                     var _b;
+                     // error code 3000 meaning the jwt token is expired, need to re-init the client
+                     // only appear in connect method


### PR DESCRIPTION
## Summary
- listen for JWT/relay errors on the stable relayer event emitter
- avoid calling `.once()` on the lazily-created relayer provider

## Validation
- focused runtime probe reproduces the pre-connect provider state and passes with `relayer.once`
- `git diff --check` passed
- `yarn typecheck` was started but stopped after producing no output; no typecheck result

Fixes RABBY-3TJ.