### PR TITLE
fix: make OneKey SDK initialization idempotent

### DIFF
--- a/__tests__/service/onekey-bridge.test.ts
+++ b/__tests__/service/onekey-bridge.test.ts
@@ -1,0 +1,42 @@
+jest.mock('@onekeyfe/hd-core', () => ({
+  UI_EVENT: 'ui-event',
+  UI_REQUEST: {
+    REQUEST_PIN: 'request-pin',
+    REQUEST_PASSPHRASE: 'request-passphrase',
+  },
+  UI_RESPONSE: {
+    RECEIVE_PIN: 'receive-pin',
+    RECEIVE_PASSPHRASE: 'receive-passphrase',
+  },
+}));
+
+const init = jest.fn(() => Promise.resolve());
+const on = jest.fn();
+
+jest.mock('@onekeyfe/hd-web-sdk', () => ({
+  __esModule: true,
+  default: {
+    HardwareWebSdk: {
+      init,
+      on,
+      uiResponse: jest.fn(),
+    },
+  },
+}));
+
+import OneKeyBridge from '@/background/service/keyring/eth-onekey-keyring/onekey-bridge';
+
+describe('OneKeyBridge', () => {
+  it('initializes the SDK and UI listener once for concurrent bridge inits', async () => {
+    const bridges = [
+      new OneKeyBridge(),
+      new OneKeyBridge(),
+      new OneKeyBridge(),
+    ];
+
+    await Promise.all(bridges.map((bridge) => bridge.init()));
+
+    expect(init).toHaveBeenCalledTimes(1);
+    expect(on).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/background/service/keyring/eth-onekey-keyring/onekey-bridge.ts
+++ b/src/background/service/keyring/eth-onekey-keyring/onekey-bridge.ts
@@ -3,37 +3,49 @@ import { OneKeyBridgeInterface } from './onekey-bridge-interface';
 import HardwareSDK from '@onekeyfe/hd-web-sdk';
 const { HardwareWebSdk } = HardwareSDK;
 
+let initPromise: Promise<void> | undefined;
+
 export default class OneKeyBridge implements OneKeyBridgeInterface {
-  init: OneKeyBridgeInterface['init'] = async () => {
-    await HardwareWebSdk.init({
-      debug: false,
-      // The official iframe page deployed by OneKey
-      // of course you can also deploy it yourself
-      connectSrc: 'https://jssdk.onekey.so/1.1.0/',
-      env: 'webusb',
-    });
-    HardwareWebSdk.on(UI_EVENT, (e) => {
-      switch (e.type) {
-        case UI_REQUEST.REQUEST_PIN:
-          HardwareWebSdk.uiResponse({
-            type: UI_RESPONSE.RECEIVE_PIN,
-            payload: '@@ONEKEY_INPUT_PIN_IN_DEVICE',
+  init: OneKeyBridgeInterface['init'] = () => {
+    if (!initPromise) {
+      initPromise = HardwareWebSdk.init({
+        debug: false,
+        // The official iframe page deployed by OneKey
+        // of course you can also deploy it yourself
+        connectSrc: 'https://jssdk.onekey.so/1.1.0/',
+        env: 'webusb',
+      })
+        .then(() => {
+          HardwareWebSdk.on(UI_EVENT, (e) => {
+            switch (e.type) {
+              case UI_REQUEST.REQUEST_PIN:
+                HardwareWebSdk.uiResponse({
+                  type: UI_RESPONSE.RECEIVE_PIN,
+                  payload: '@@ONEKEY_INPUT_PIN_IN_DEVICE',
+                });
+                break;
+              case UI_REQUEST.REQUEST_PASSPHRASE:
+                HardwareWebSdk.uiResponse({
+                  type: UI_RESPONSE.RECEIVE_PASSPHRASE,
+                  payload: {
+                    value: '',
+                    passphraseOnDevice: true,
+                    save: true,
+                  },
+                });
+                break;
+              default:
+              // NOTHING
+            }
           });
-          break;
-        case UI_REQUEST.REQUEST_PASSPHRASE:
-          HardwareWebSdk.uiResponse({
-            type: UI_RESPONSE.RECEIVE_PASSPHRASE,
-            payload: {
-              value: '',
-              passphraseOnDevice: true,
-              save: true,
-            },
-          });
-          break;
-        default:
-        // NOTHING
-      }
-    });
+        })
+        .catch((error) => {
+          initPromise = undefined;
+          throw error;
+        });
+    }
+
+    return initPromise;
   };
 
   evmSignTransaction = HardwareWebSdk.evmSignTransaction;


### PR DESCRIPTION
## Summary
- Make OneKey SDK initialization shared and idempotent across bridge instances.
- Register the OneKey UI listener only after successful initialization and only once.
- Reset the cached initialization promise after failure so a later attempt can retry.
- Add a regression test for concurrent bridge initialization.

## Root cause
`OneKeyKeyring` starts `bridge.init()` from its constructor. Multiple keyring instances could call `HardwareWebSdk.init()` in the same extension runtime, causing OneKey SDK error 301: `IFrame alerady initialized`.

## Validation
- `yarn test __tests__/service/onekey-bridge.test.ts --runInBand --watchman=false`
- targeted ESLint
- `yarn typecheck`
- `git diff --check`