### PR TITLE
fix: prevent duplicate Trezor Connect tabs

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -35,10 +35,6 @@ import {
   KEYRING_CATEGORY_MAP,
   KEYRING_TYPE,
 } from 'consts';
-import {
-  OffscreenCommunicationTarget,
-  TrezorBrowserAction,
-} from '@/constant/offscreen-communication';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { ethErrors } from 'eth-rpc-errors';
@@ -286,41 +282,6 @@ async function restoreAppState() {
         },
       });
       return;
-    }
-    if (
-      message?.target === OffscreenCommunicationTarget.trezorBrowser &&
-      sender.id === chrome.runtime.id &&
-      Object.values(TrezorBrowserAction).includes(message.action)
-    ) {
-      const request = (() => {
-        switch (message.action) {
-          case TrezorBrowserAction.getCurrentWindow:
-            return browser.windows.getCurrent();
-          case TrezorBrowserAction.createWindow:
-            return browser.windows.create(message.params);
-          case TrezorBrowserAction.queryTabs:
-            return browser.tabs.query(message.params);
-          case TrezorBrowserAction.createTab:
-            return browser.tabs.create(message.params);
-          case TrezorBrowserAction.getTab:
-            return browser.tabs.get(message.params);
-          case TrezorBrowserAction.updateTab:
-            return browser.tabs.update(
-              message.params.tabId,
-              message.params.updateProperties
-            );
-          case TrezorBrowserAction.removeTab:
-            return browser.tabs.remove(message.params);
-          default:
-            return undefined;
-        }
-      })();
-      Promise.resolve(request).then(sendResponse, (error) =>
-        sendResponse({
-          error: error instanceof Error ? error.message : String(error),
-        })
-      );
-      return true;
     }
     // Native chrome.runtime.onMessage requires explicit `sendResponse(...)` + `return true`
     // on async paths — returning a Promise would let Chrome close the channel immediately.


### PR DESCRIPTION
## Summary
- remove the duplicate Trezor browser proxy from `src/background/index.ts`
- keep `_raw/sw.js` as the single MV3 proxy entrypoint

## Root cause
Both runtime message listeners handled the same `trezor-browser-create-tab` message, so each Trezor popup request called `tabs.create()` twice.

## Validation
- one Trezor tab creator source check
- `yarn eslint src/background/index.ts`
- `yarn typecheck`