### PR TITLE
fix: handle missing browser windows and active tabs safely

### DIFF
--- a/__tests__/background/window.test.ts
+++ b/__tests__/background/window.test.ts
@@ -1,0 +1,48 @@
+const mockGetLastFocused = jest.fn();
+const mockCreateWindow = jest.fn();
+const mockUpdateWindow = jest.fn();
+
+jest.mock('webextension-polyfill', () => ({
+  __esModule: true,
+  default: {
+    windows: {
+      getLastFocused: mockGetLastFocused,
+      create: mockCreateWindow,
+      update: mockUpdateWindow,
+      remove: jest.fn(),
+      onFocusChanged: { addListener: jest.fn() },
+      onRemoved: { addListener: jest.fn() },
+    },
+    runtime: {
+      onMessage: { addListener: jest.fn() },
+    },
+  },
+}));
+
+jest.mock('consts', () => ({
+  IS_WINDOWS: false,
+}));
+
+jest.mock('@sentry/browser', () => ({
+  captureException: jest.fn(),
+}));
+
+import winMgr from '@/background/webapi/window';
+
+describe('background window manager', () => {
+  beforeEach(() => {
+    mockGetLastFocused.mockReset();
+    mockCreateWindow.mockReset();
+    mockUpdateWindow.mockReset();
+  });
+
+  it('returns undefined when the browser does not create a window', async () => {
+    mockGetLastFocused
+      .mockResolvedValueOnce({ top: 0, left: 0, width: 1200, height: 800 })
+      .mockResolvedValueOnce({ state: 'normal' });
+    mockCreateWindow.mockResolvedValueOnce(null);
+
+    await expect(winMgr.openNotification()).resolves.toBeUndefined();
+    expect(mockUpdateWindow).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/service/notificationQueue.test.ts
+++ b/__tests__/service/notificationQueue.test.ts
@@ -126,4 +126,31 @@ describe('notificationService SignTx queueing', () => {
       'onCurrent failed'
     );
   });
+
+  test('unlocks when the notification window is not created', async () => {
+    mockOpenNotification.mockResolvedValueOnce(undefined);
+
+    notificationService.openNotification({});
+    expect(notificationService.isLocked).toBe(true);
+
+    await Promise.resolve();
+
+    expect(notificationService.notifiWindowId).toBeNull();
+    expect(notificationService.isLocked).toBe(false);
+  });
+
+  test('unlocks and reports when notification window creation rejects', async () => {
+    const error = new Error('window creation failed');
+    mockOpenNotification.mockRejectedValueOnce(error);
+
+    notificationService.openNotification({});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(notificationService.notifiWindowId).toBeNull();
+    expect(notificationService.isLocked).toBe(false);
+    expect(mockCaptureException).toHaveBeenCalledWith(error, {
+      tags: { function: 'openNotification' },
+    });
+  });
 });

--- a/__tests__/ui/currentTab.test.ts
+++ b/__tests__/ui/currentTab.test.ts
@@ -1,0 +1,24 @@
+const mockQueryTabs = jest.fn();
+
+jest.mock('webextension-polyfill', () => ({
+  __esModule: true,
+  default: {
+    tabs: {
+      query: mockQueryTabs,
+    },
+  },
+}));
+
+import { getCurrentTab } from '@/ui/utils/currentTab';
+
+describe('getCurrentTab', () => {
+  beforeEach(() => {
+    mockQueryTabs.mockReset();
+  });
+
+  it('returns undefined when the current window has no active tab', async () => {
+    mockQueryTabs.mockResolvedValue([]);
+
+    await expect(getCurrentTab()).resolves.toBeUndefined();
+  });
+});

--- a/__tests__/ui/domAlign.test.ts
+++ b/__tests__/ui/domAlign.test.ts
@@ -1,0 +1,25 @@
+import { alignElement } from 'dom-align/dist-web/index';
+
+describe('dom-align patch', () => {
+  it('does not crash when the source has no visible rectangle', () => {
+    const source = document.createElement('div');
+    const target = document.createElement('button');
+    document.body.append(source, target);
+
+    expect(
+      (alignElement as typeof alignElement & {
+        __getVisibleRectForElement: (element: HTMLElement) => DOMRect | null;
+      }).__getVisibleRectForElement(source)
+    ).toBeNull();
+
+    expect(() =>
+      alignElement(source, target, {
+        points: ['tl', 'bl'],
+        viewportOffset: [8, 8, -8, -8],
+      } as Parameters<typeof alignElement>[2])
+    ).not.toThrow();
+
+    source.remove();
+    target.remove();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ const IGNORE_MODULES = [
   'nanoid',
   'uuid',
   '@ethereumjs',
+  'dom-align',
 ].join('|');
 /*
  * For a detailed explanation regarding each configuration property and type check, visit:

--- a/patches/dom-align+1.12.4.patch
+++ b/patches/dom-align+1.12.4.patch
@@ -2,17 +2,19 @@ diff --git a/node_modules/dom-align/dist-web/index.js b/node_modules/dom-align/d
 index 4ca5d3a..c3d22b1 100644
 --- a/node_modules/dom-align/dist-web/index.js
 +++ b/node_modules/dom-align/dist-web/index.js
-@@ -986,8 +986,13 @@ function doAlign(el, tgtRegion, align, isTgtRegionVisible) {
+@@ -986,8 +986,15 @@ function doAlign(el, tgtRegion, align, isTgtRegionVisible) {
    var newOverflowCfg = {};
    var fail = 0;
    var alwaysByViewport = !!(overflow && overflow.alwaysByViewport);
 +  var viewportOffset = align.viewportOffset || [0, 0, 0, 0];
    // 当前节点可以被放置的显示区域
    var visibleRect = getVisibleRectForElement(source, alwaysByViewport);
-+  visibleRect.top += viewportOffset[0];
-+  visibleRect.right += viewportOffset[1];
-+  visibleRect.bottom += viewportOffset[2];
-+  visibleRect.left += viewportOffset[3];
++  if (visibleRect) {
++    visibleRect.top += viewportOffset[0];
++    visibleRect.right += viewportOffset[1];
++    visibleRect.bottom += viewportOffset[2];
++    visibleRect.left += viewportOffset[3];
++  }
    // 当前节点所占的区域, left/top/width/height
    var elRegion = getRegion(source);
    // 将 offset 转换成数值，支持百分比

--- a/src/background/service/notification.ts
+++ b/src/background/service/notification.ts
@@ -421,9 +421,25 @@ class NotificationService extends Events {
       winMgr.remove(this.notifiWindowId);
       this.notifiWindowId = null;
     }
-    winMgr.openNotification(winProps).then((winId) => {
-      this.notifiWindowId = winId!;
-    });
+    winMgr
+      .openNotification(winProps)
+      .then((winId) => {
+        if (winId == null) {
+          if (this.notifiWindowId === null) {
+            this.unLock();
+          }
+          return;
+        }
+        this.notifiWindowId = winId;
+      })
+      .catch((e) => {
+        if (this.notifiWindowId === null) {
+          this.unLock();
+        }
+        Sentry.captureException(e, {
+          tags: { function: 'openNotification' },
+        });
+      });
   };
 
   updateNotificationWinProps = (winProps: Windows.UpdateUpdateInfoType) => {

--- a/src/background/webapi/window.ts
+++ b/src/background/webapi/window.ts
@@ -90,6 +90,8 @@ const create = async ({ url, ...rest }): Promise<number | undefined> => {
       }
     }
   }
+  if (!win) return;
+
   // shim firefox
   if (win.left !== left && currentWindow.state !== 'fullscreen') {
     try {

--- a/src/ui/utils/currentTab.ts
+++ b/src/ui/utils/currentTab.ts
@@ -1,0 +1,7 @@
+import browser, { Tabs } from 'webextension-polyfill';
+
+export const getCurrentTab = async (): Promise<Tabs.Tab | undefined> => {
+  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+
+  return tabs[0];
+};

--- a/src/ui/utils/webapi.tsx
+++ b/src/ui/utils/webapi.tsx
@@ -6,22 +6,19 @@ import { getUITypeName, WalletController, WalletControllerType } from './index';
 import { getOriginFromUrl } from '@/utils';
 import Modal from '../component/Modal';
 import { ReactComponent as ExternalLinkAlert } from 'ui/assets/component/external-link-alert.svg';
+import { getCurrentTab } from './currentTab';
 
-export const getCurrentTab = async (): Promise<Tabs.Tab> => {
-  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-
-  return tabs[0];
-};
+export { getCurrentTab } from './currentTab';
 
 export const getCurrentConnectSite = async (
   wallet: WalletController | WalletControllerType
 ) => {
-  const { id, url } = await getCurrentTab();
-  if (!id || !url) return null;
+  const tab = await getCurrentTab();
+  if (tab?.id == null || !tab.url) return null;
 
   return (wallet as WalletControllerType).getCurrentConnectedSite(
-    id,
-    getOriginFromUrl(url)
+    tab.id,
+    getOriginFromUrl(tab.url)
   );
 };
 

--- a/src/ui/views/Dashboard/components/CurrentConnection/index.tsx
+++ b/src/ui/views/Dashboard/components/CurrentConnection/index.tsx
@@ -174,7 +174,7 @@ export const CurrentConnection = memo((props: CurrentConnectionProps) => {
 
   const getCurrentSite = useCallback(async () => {
     const tab = await getCurrentTab();
-    if (!tab.id || !tab.url) return;
+    if (tab?.id == null || !tab.url) return;
     const domain = getOriginFromUrl(tab.url);
     const current = await wallet.getCurrentSite(tab.id, domain);
     setSite(current);

--- a/src/ui/views/MetamaskModeDapps/Guide.tsx
+++ b/src/ui/views/MetamaskModeDapps/Guide.tsx
@@ -23,7 +23,7 @@ export const MetamaskModeDappsGuide = () => {
 
   const { data: site, mutate, runAsync } = useRequest(async () => {
     const tab = await getCurrentTab();
-    if (!tab.id || !tab.url) return;
+    if (tab?.id == null || !tab.url) return;
     const domain = getOriginFromUrl(tab.url);
     const current = await wallet.getCurrentSite(tab.id, domain);
     return current;

--- a/src/ui/views/WalletConnect/index.tsx
+++ b/src/ui/views/WalletConnect/index.tsx
@@ -56,7 +56,7 @@ const WalletConnectTemplate: React.FC<{
 
   const getCurrentSite = useCallback(async () => {
     const tab = await getCurrentTab();
-    if (!tab.id || !tab.url) return;
+    if (tab?.id == null || !tab.url) return;
     const domain = getOriginFromUrl(tab.url);
     const current = await wallet.getCurrentSite(tab.id, domain);
     siteRef.current = current;


### PR DESCRIPTION
## Summary

- Prevent notification handling from crashing when window creation returns no window or rejects.
- Unlock pending notification state and report window creation errors to Sentry.
- Guard `dom-align` viewport adjustments when no visible rectangle exists.
- Make current-tab lookups and consumers handle missing active tabs safely.
- Add regression coverage for these edge cases.

## Testing

- Added Jest tests for window creation, notification queue recovery, active-tab lookup, and `dom-align` alignment.