### PR TITLE
fix: add weekly candle aggregation and subscription management

### DIFF
--- a/__tests__/ui/perpsCandleSubscriptions.test.ts
+++ b/__tests__/ui/perpsCandleSubscriptions.test.ts
@@ -1,22 +1,27 @@
 import {
-  closeAllCandleSubscriptions,
-  closeCandleSubscription,
-  isCandleForChannel,
-  openCandleSubscription,
   CandleSubscriptionEntry,
+  CandleSubscriptionRegistry,
+  isCandleForChannel,
 } from '@/ui/views/Perps/candleSubscriptions';
 
+type MockCandle = {
+  s?: string;
+  i?: string;
+  close: number;
+};
+
 /**
- * Stands in for the SDK's WebSocketClient. The behaviour that matters here is
- * that a candle channel is keyed by coin+interval and is *not* refcounted:
- * unsubscribe() tells the server to stop pushing the whole channel, however
- * many callbacks are still attached to it.
+ * Mirrors the SDK behavior relevant to candles:
+ *
+ * - the server channel is keyed by coin+interval and is not refcounted;
+ * - callbacks are dispatched by channel type, so every candle callback sees
+ *   every candle frame and has to filter by `s`/`i` itself.
  */
 const createMockSdkWs = () => {
   const frames: string[] = [];
   const openChannels = new Set<string>();
-  const callbacks = new Map<string, Set<(bar: number) => void>>();
-
+  const listeners = new Set<(candle: MockCandle) => void>();
+  const allListeners = new Set<(candle: MockCandle) => void>();
   const keyOf = (coin: string, interval: string) => `${coin}:${interval}`;
 
   return {
@@ -27,281 +32,270 @@ const createMockSdkWs = () => {
     subscribeToCandles(
       coin: string,
       interval: string,
-      callback: (bar: number) => void
+      callback: (candle: MockCandle) => void
     ) {
       const key = keyOf(coin, interval);
       frames.push(`subscribe ${key}`);
       openChannels.add(key);
-      const attached = callbacks.get(key) || new Set();
-      attached.add(callback);
-      callbacks.set(key, attached);
+      listeners.add(callback);
+      allListeners.add(callback);
 
       return {
         unsubscribe: () => {
           frames.push(`unsubscribe ${key}`);
-          // No refcount: the server stops pushing the channel outright.
           openChannels.delete(key);
-          callbacks.get(key)?.delete(callback);
+          listeners.delete(callback);
         },
       };
     },
 
-    /** Server push. Only reaches listeners while the channel is open. */
-    push(coin: string, interval: string, bar: number) {
-      const key = keyOf(coin, interval);
-      if (!openChannels.has(key)) return;
-      callbacks.get(key)?.forEach((callback) => callback(bar));
+    push(coin: string, interval: string, close: number) {
+      if (!openChannels.has(keyOf(coin, interval))) return;
+      [...listeners].forEach((listener) =>
+        listener({ s: coin, i: interval, close })
+      );
+    },
+
+    emitLate(coin: string, interval: string, close: number) {
+      [...allListeners].forEach((listener) =>
+        listener({ s: coin, i: interval, close })
+      );
     },
   };
 };
 
+type Registry = CandleSubscriptionRegistry<
+  MockCandle,
+  CandleSubscriptionEntry<MockCandle>
+>;
 type Ws = ReturnType<typeof createMockSdkWs>;
 
-const BTC_15M = { symbol: 'BTC', subscribeInterval: '15m' };
-
 const subscribe = (
+  registry: Registry,
   ws: Ws,
-  subscriptions: Map<string, CandleSubscriptionEntry>,
   subscriberUID: string,
-  received: Map<string, number[]>,
-  channel = BTC_15M
-) => {
-  received.set(subscriberUID, []);
-  return openCandleSubscription(
-    subscriptions,
+  symbol: string,
+  interval: string,
+  received: number[]
+) =>
+  registry.subscribe(
     subscriberUID,
-    channel,
-    () => {
-      const subscription = ws.subscribeToCandles(
-        channel.symbol,
-        channel.subscribeInterval,
-        (bar) => received.get(subscriberUID)?.push(bar)
-      );
-      return { ...channel, unsubscribe: subscription.unsubscribe };
-    }
+    {
+      symbol,
+      subscribeInterval: interval,
+      onCandle: (candle) => received.push(candle.close),
+    },
+    (onCandle) => ws.subscribeToCandles(symbol, interval, onCandle)
   );
-};
 
-describe('openCandleSubscription', () => {
-  it('keeps the live subscription when the superseded UID is retired late', () => {
+describe('CandleSubscriptionRegistry', () => {
+  it('multiplexes daily and weekly series over one physical daily channel', () => {
     const ws = createMockSdkWs();
-    const subscriptions = new Map<string, CandleSubscriptionEntry>();
-    const received = new Map<string, number[]>();
+    const registry = new CandleSubscriptionRegistry<MockCandle>();
+    const daily: number[] = [];
+    const weekly: number[] = [];
 
-    subscribe(ws, subscriptions, 'uid-old', received);
-    // TradingView opens the replacement before it retires the previous UID...
-    subscribe(ws, subscriptions, 'uid-new', received);
-    // ...and only then unsubscribes the old one.
-    closeCandleSubscription(subscriptions, 'uid-old');
+    subscribe(registry, ws, 'BTC_#_1D', 'BTC', '1d', daily);
+    subscribe(registry, ws, 'BTC_#_1W', 'BTC', '1d', weekly);
+    ws.push('BTC', '1d', 101);
 
-    ws.push('BTC', '15m', 42);
-
-    expect(ws.isChannelOpen('BTC', '15m')).toBe(true);
-    expect(received.get('uid-new')).toEqual([42]);
-    expect(subscriptions.size).toBe(1);
+    expect(ws.frames).toEqual(['subscribe BTC:1d']);
+    expect(daily).toEqual([101]);
+    expect(weekly).toEqual([101]);
+    expect(registry.subscriberCount).toBe(2);
+    expect(registry.channelCount).toBe(1);
   });
 
-  it('orders the frames unsubscribe-then-subscribe when replacing a channel', () => {
+  it('keeps both cached series live when TradingView revisits without subscribing again', () => {
     const ws = createMockSdkWs();
-    const subscriptions = new Map<string, CandleSubscriptionEntry>();
-    const received = new Map<string, number[]>();
+    const registry = new CandleSubscriptionRegistry<MockCandle>();
+    const daily: number[] = [];
+    const weekly: number[] = [];
 
-    subscribe(ws, subscriptions, 'uid-old', received);
-    subscribe(ws, subscriptions, 'uid-new', received);
+    // TradingView registers each pair once, retains the callbacks while the
+    // symbol remains on screen, and can revisit 1D without another subscribe.
+    subscribe(registry, ws, 'BTC_#_1D', 'BTC', '1d', daily);
+    subscribe(registry, ws, 'BTC_#_1W', 'BTC', '1d', weekly);
+    ws.push('BTC', '1d', 102);
+
+    expect(daily[daily.length - 1]).toBe(102);
+    expect(weekly[weekly.length - 1]).toBe(102);
+    expect(ws.isChannelOpen('BTC', '1d')).toBe(true);
+  });
+
+  it('does not close a shared channel until its last logical subscriber leaves', () => {
+    const ws = createMockSdkWs();
+    const registry = new CandleSubscriptionRegistry<MockCandle>();
+    const daily: number[] = [];
+    const weekly: number[] = [];
+
+    subscribe(registry, ws, 'BTC_#_1D', 'BTC', '1d', daily);
+    subscribe(registry, ws, 'BTC_#_1W', 'BTC', '1d', weekly);
+    registry.unsubscribe('BTC_#_1D');
+    ws.push('BTC', '1d', 103);
+
+    expect(ws.frames).toEqual(['subscribe BTC:1d']);
+    expect(daily).toEqual([]);
+    expect(weekly).toEqual([103]);
+
+    registry.unsubscribe('BTC_#_1W');
+    expect(ws.frames).toEqual(['subscribe BTC:1d', 'unsubscribe BTC:1d']);
+    expect(ws.isChannelOpen('BTC', '1d')).toBe(false);
+  });
+
+  it('replaces a reused UID without bouncing its physical channel', () => {
+    const ws = createMockSdkWs();
+    const registry = new CandleSubscriptionRegistry<MockCandle>();
+    const oldSeries: number[] = [];
+    const liveSeries: number[] = [];
+
+    subscribe(registry, ws, 'BTC_#_15', 'BTC', '15m', oldSeries);
+    subscribe(registry, ws, 'BTC_#_15', 'BTC', '15m', liveSeries);
+    ws.push('BTC', '15m', 104);
+
+    expect(ws.frames).toEqual(['subscribe BTC:15m']);
+    expect(oldSeries).toEqual([]);
+    expect(liveSeries).toEqual([104]);
+    expect(registry.subscriberCount).toBe(1);
+  });
+
+  it('moves a reused UID to a different physical channel', () => {
+    const ws = createMockSdkWs();
+    const registry = new CandleSubscriptionRegistry<MockCandle>();
+    const received: number[] = [];
+
+    subscribe(registry, ws, 'uid-1', 'BTC', '15m', received);
+    subscribe(registry, ws, 'uid-1', 'BTC', '1h', received);
 
     expect(ws.frames).toEqual([
       'subscribe BTC:15m',
+      'subscribe BTC:1h',
       'unsubscribe BTC:15m',
-      'subscribe BTC:15m',
     ]);
+    expect(ws.isChannelOpen('BTC', '15m')).toBe(false);
+    expect(ws.isChannelOpen('BTC', '1h')).toBe(true);
   });
 
-  it('stops feeding a superseded UID', () => {
+  it('keeps the old channel when opening a replacement throws', () => {
     const ws = createMockSdkWs();
-    const subscriptions = new Map<string, CandleSubscriptionEntry>();
-    const received = new Map<string, number[]>();
+    const registry = new CandleSubscriptionRegistry<MockCandle>();
+    const received: number[] = [];
 
-    subscribe(ws, subscriptions, 'uid-old', received);
-    subscribe(ws, subscriptions, 'uid-new', received);
-    ws.push('BTC', '15m', 7);
+    subscribe(registry, ws, 'uid-1', 'BTC', '15m', received);
+    expect(() =>
+      registry.subscribe(
+        'uid-1',
+        {
+          symbol: 'BTC',
+          subscribeInterval: '1h',
+          onCandle: (candle) => received.push(candle.close),
+        },
+        () => {
+          throw new Error('open failed');
+        }
+      )
+    ).toThrow('open failed');
 
-    expect(received.get('uid-old')).toEqual([]);
-  });
-
-  it('leaves subscriptions on other channels alone', () => {
-    const ws = createMockSdkWs();
-    const subscriptions = new Map<string, CandleSubscriptionEntry>();
-    const received = new Map<string, number[]>();
-
-    subscribe(ws, subscriptions, 'uid-eth', received, {
-      symbol: 'ETH',
-      subscribeInterval: '15m',
-    });
-    subscribe(ws, subscriptions, 'uid-btc-1h', received, {
-      symbol: 'BTC',
-      subscribeInterval: '1h',
-    });
-    subscribe(ws, subscriptions, 'uid-btc-15m', received);
-
-    ws.push('ETH', '15m', 1);
-    ws.push('BTC', '1h', 2);
-
-    expect(received.get('uid-eth')).toEqual([1]);
-    expect(received.get('uid-btc-1h')).toEqual([2]);
-    expect(subscriptions.size).toBe(3);
-  });
-
-  it('replaces an entry reusing the same UID', () => {
-    const ws = createMockSdkWs();
-    const subscriptions = new Map<string, CandleSubscriptionEntry>();
-    const received = new Map<string, number[]>();
-
-    subscribe(ws, subscriptions, 'uid-1', received, {
-      symbol: 'BTC',
-      subscribeInterval: '1h',
-    });
-    subscribe(ws, subscriptions, 'uid-1', received);
-
-    expect(ws.isChannelOpen('BTC', '1h')).toBe(false);
+    ws.push('BTC', '15m', 105);
+    expect(received).toEqual([105]);
     expect(ws.isChannelOpen('BTC', '15m')).toBe(true);
-    expect(subscriptions.size).toBe(1);
-  });
-});
-
-describe('closeCandleSubscription', () => {
-  it('is a no-op for a UID that was already superseded', () => {
-    const ws = createMockSdkWs();
-    const subscriptions = new Map<string, CandleSubscriptionEntry>();
-    const received = new Map<string, number[]>();
-
-    subscribe(ws, subscriptions, 'uid-old', received);
-    subscribe(ws, subscriptions, 'uid-new', received);
-    const framesBefore = [...ws.frames];
-
-    closeCandleSubscription(subscriptions, 'uid-old');
-
-    expect(ws.frames).toEqual(framesBefore);
+    expect(registry.subscriberCount).toBe(1);
+    expect(registry.channelCount).toBe(1);
   });
 
-  it('retires the channel when the live UID is unsubscribed', () => {
+  it('filters the SDK type-level fanout to the matching physical channel', () => {
     const ws = createMockSdkWs();
-    const subscriptions = new Map<string, CandleSubscriptionEntry>();
-    const received = new Map<string, number[]>();
+    const registry = new CandleSubscriptionRegistry<MockCandle>();
+    const btc: number[] = [];
+    const eth: number[] = [];
 
-    subscribe(ws, subscriptions, 'uid-live', received);
-    closeCandleSubscription(subscriptions, 'uid-live');
-    ws.push('BTC', '15m', 9);
+    subscribe(registry, ws, 'btc', 'BTC', '15m', btc);
+    subscribe(registry, ws, 'eth', 'ETH', '1h', eth);
+    ws.push('BTC', '15m', 105);
+    ws.push('ETH', '1h', 106);
 
-    expect(ws.isChannelOpen('BTC', '15m')).toBe(false);
-    expect(received.get('uid-live')).toEqual([]);
-    expect(subscriptions.size).toBe(0);
+    expect(btc).toEqual([105]);
+    expect(eth).toEqual([106]);
   });
-});
 
-describe('closeAllCandleSubscriptions', () => {
-  it('retires every channel and empties the map', () => {
+  it('clears every physical channel exactly once', () => {
     const ws = createMockSdkWs();
-    const subscriptions = new Map<string, CandleSubscriptionEntry>();
-    const received = new Map<string, number[]>();
+    const registry = new CandleSubscriptionRegistry<MockCandle>();
 
-    subscribe(ws, subscriptions, 'uid-btc', received);
-    subscribe(ws, subscriptions, 'uid-eth', received, {
-      symbol: 'ETH',
-      subscribeInterval: '1h',
-    });
+    subscribe(registry, ws, 'daily', 'BTC', '1d', []);
+    subscribe(registry, ws, 'weekly', 'BTC', '1d', []);
+    subscribe(registry, ws, 'eth', 'ETH', '1h', []);
+    registry.clear();
 
-    closeAllCandleSubscriptions(subscriptions);
+    expect(ws.frames).toEqual([
+      'subscribe BTC:1d',
+      'subscribe ETH:1h',
+      'unsubscribe BTC:1d',
+      'unsubscribe ETH:1h',
+    ]);
+    expect(registry.subscriberCount).toBe(0);
+    expect(registry.channelCount).toBe(0);
+  });
 
-    expect(ws.isChannelOpen('BTC', '15m')).toBe(false);
-    expect(ws.isChannelOpen('ETH', '1h')).toBe(false);
-    expect(subscriptions.size).toBe(0);
+  it('drops a late SDK callback after clear', () => {
+    const ws = createMockSdkWs();
+    const registry = new CandleSubscriptionRegistry<MockCandle>();
+    const received: number[] = [];
+
+    subscribe(registry, ws, 'daily', 'BTC', '1d', received);
+    registry.clear();
+    ws.emitLate('BTC', '1d', 107);
+
+    expect(received).toEqual([]);
+  });
+
+  it('stops an in-flight fanout when a consumer clears the registry', () => {
+    const ws = createMockSdkWs();
+    const registry = new CandleSubscriptionRegistry<MockCandle>();
+    const first: number[] = [];
+    const second: number[] = [];
+
+    registry.subscribe(
+      'first',
+      {
+        symbol: 'BTC',
+        subscribeInterval: '1d',
+        onCandle: (candle) => {
+          first.push(candle.close);
+          registry.clear();
+        },
+      },
+      (onCandle) => ws.subscribeToCandles('BTC', '1d', onCandle)
+    );
+    subscribe(registry, ws, 'second', 'BTC', '1d', second);
+    ws.push('BTC', '1d', 108);
+
+    expect(first).toEqual([108]);
+    expect(second).toEqual([]);
+  });
+
+  it('treats an unknown UID unsubscribe as a no-op', () => {
+    const ws = createMockSdkWs();
+    const registry = new CandleSubscriptionRegistry<MockCandle>();
+
+    subscribe(registry, ws, 'daily', 'BTC', '1d', []);
+    registry.unsubscribe('missing');
+
+    expect(ws.frames).toEqual(['subscribe BTC:1d']);
+    expect(registry.subscriberCount).toBe(1);
   });
 });
 
 describe('isCandleForChannel', () => {
-  const channel = { symbol: 'BTC', subscribeInterval: '15m' };
+  const channel = { symbol: 'BTC', subscribeInterval: '1d' };
 
-  it('accepts a frame from its own channel', () => {
-    expect(isCandleForChannel({ s: 'BTC', i: '15m' }, channel)).toBe(true);
-  });
-
-  it('rejects another coin', () => {
-    expect(isCandleForChannel({ s: 'ETH', i: '15m' }, channel)).toBe(false);
-  });
-
-  it('rejects another interval on the same coin', () => {
+  it('accepts its own channel and rejects another coin or interval', () => {
+    expect(isCandleForChannel({ s: 'BTC', i: '1d' }, channel)).toBe(true);
+    expect(isCandleForChannel({ s: 'ETH', i: '1d' }, channel)).toBe(false);
     expect(isCandleForChannel({ s: 'BTC', i: '1h' }, channel)).toBe(false);
   });
 
-  it('accepts a frame that carries no channel metadata', () => {
-    // Starving the listener would freeze the chart — the failure this guards
-    // against — so an unlabelled frame is let through.
+  it('accepts a frame without channel metadata', () => {
     expect(isCandleForChannel({}, channel)).toBe(true);
-  });
-
-  it('matches the daily channel a weekly subscription rides on', () => {
-    expect(
-      isCandleForChannel(
-        { s: 'BTC', i: '1d' },
-        { symbol: 'BTC', subscribeInterval: '1d' }
-      )
-    ).toBe(true);
-  });
-});
-
-/**
- * The SDK fans candle frames out by channel *type*: while two channels overlap,
- * both listeners see both channels' bars. This mirrors that dispatch so the
- * guard is exercised the way it runs in production.
- */
-const createTypeFanoutSdkWs = () => {
-  const listeners: Array<(candle: { s: string; i: string; c: string }) => void> = [];
-  const openChannels = new Set<string>();
-
-  return {
-    subscribeToCandles(
-      coin: string,
-      interval: string,
-      callback: (candle: { s: string; i: string; c: string }) => void
-    ) {
-      openChannels.add(`${coin}:${interval}`);
-      listeners.push(callback);
-      return {
-        unsubscribe: () => {
-          openChannels.delete(`${coin}:${interval}`);
-          const index = listeners.indexOf(callback);
-          if (index >= 0) listeners.splice(index, 1);
-        },
-      };
-    },
-
-    push(coin: string, interval: string, close: string) {
-      if (!openChannels.has(`${coin}:${interval}`)) return;
-      // No per-channel routing: every candle listener gets the frame.
-      [...listeners].forEach((listener) =>
-        listener({ s: coin, i: interval, c: close })
-      );
-    },
-  };
-};
-
-describe('overlapping channels', () => {
-  it('does not forward another channel bars while both are open', () => {
-    const ws = createTypeFanoutSdkWs();
-    const forwarded: string[] = [];
-    const channel = { symbol: 'BTC', subscribeInterval: '1h' };
-
-    // A superseded 15m listener is still attached...
-    ws.subscribeToCandles('BTC', '15m', () => undefined);
-    // ...while the chart now rides the 1h channel.
-    ws.subscribeToCandles('BTC', '1h', (candle) => {
-      if (!isCandleForChannel(candle, channel)) return;
-      forwarded.push(candle.c);
-    });
-
-    ws.push('BTC', '15m', '100');
-    ws.push('BTC', '1h', '200');
-
-    expect(forwarded).toEqual(['200']);
   });
 });

--- a/__tests__/ui/perpsWeeklyCandles.test.ts
+++ b/__tests__/ui/perpsWeeklyCandles.test.ts
@@ -1,0 +1,167 @@
+import {
+  aggregateDailyToWeeklyBars,
+  CandleBar,
+  cloneWeeklyHistoryState,
+  getLatestWeeklyHistoryState,
+  getMondayUtc,
+  seedWeeklyCandleStateFromHistory,
+  shouldReplaceWeeklyHistoryState,
+  updateWeeklyCandle,
+  WeeklyCandleState,
+} from '@/ui/views/Perps/weeklyCandles';
+
+const utc = (value: string) => new Date(`${value}T00:00:00.000Z`).getTime();
+
+const bar = (
+  date: string,
+  open: number,
+  high: number,
+  low: number,
+  close: number,
+  volume: number
+): CandleBar => ({
+  time: utc(date),
+  open,
+  high,
+  low,
+  close,
+  volume,
+});
+
+describe('weekly candle aggregation', () => {
+  it('groups 24x7 daily bars on Monday UTC boundaries', () => {
+    const daily = [
+      bar('2026-08-23', 90, 100, 80, 95, 3), // Sunday, prior week
+      bar('2026-08-24', 100, 110, 95, 105, 4),
+      bar('2026-08-25', 105, 120, 101, 115, 6),
+    ];
+
+    expect(aggregateDailyToWeeklyBars(daily)).toEqual([
+      bar('2026-08-17', 90, 100, 80, 95, 3),
+      bar('2026-08-24', 100, 120, 95, 115, 10),
+    ]);
+    expect(getMondayUtc(utc('2026-08-23'))).toBe(utc('2026-08-17'));
+  });
+
+  it('replaces the current daily volume contribution on realtime updates', () => {
+    const state: WeeklyCandleState = {
+      currentWeekBar: bar('2026-08-24', 100, 120, 90, 110, 15),
+      lastDailyVolume: {
+        time: utc('2026-08-26'),
+        value: 5,
+      },
+    };
+
+    const result = updateWeeklyCandle(
+      state,
+      bar('2026-08-26', 108, 125, 104, 122, 8)
+    );
+
+    expect(result).toEqual(bar('2026-08-24', 100, 125, 90, 122, 18));
+  });
+
+  it('seeds a live partial week when history is unavailable', () => {
+    const state: WeeklyCandleState = {
+      currentWeekBar: null,
+      lastDailyVolume: null,
+    };
+
+    const result = updateWeeklyCandle(
+      state,
+      bar('2026-08-26', 108, 125, 104, 122, 8)
+    );
+
+    expect(result).toEqual(bar('2026-08-24', 108, 125, 104, 122, 8));
+    expect(state.lastDailyVolume).toEqual({
+      time: utc('2026-08-26'),
+      value: 8,
+    });
+  });
+
+  it('rolls over to a new week instead of mutating the previous one', () => {
+    const state: WeeklyCandleState = {
+      currentWeekBar: bar('2026-08-17', 100, 130, 90, 120, 50),
+      lastDailyVolume: {
+        time: utc('2026-08-23'),
+        value: 9,
+      },
+    };
+
+    const result = updateWeeklyCandle(
+      state,
+      bar('2026-08-24', 121, 124, 118, 123, 2)
+    );
+
+    expect(result).toEqual(bar('2026-08-24', 121, 124, 118, 123, 2));
+  });
+
+  it('seeds realtime volume from the latest daily bar in history', () => {
+    const daily = [
+      bar('2026-08-24', 100, 110, 95, 105, 4),
+      bar('2026-08-25', 105, 120, 101, 115, 6),
+    ];
+    const weekly = aggregateDailyToWeeklyBars(daily);
+
+    expect(getLatestWeeklyHistoryState(weekly, daily)).toEqual({
+      currentWeekBar: bar('2026-08-24', 100, 120, 95, 115, 10),
+      lastDailyVolume: {
+        time: utc('2026-08-25'),
+        value: 6,
+      },
+    });
+  });
+
+  it('does not replace a complete same-week seed with a narrower page', () => {
+    const complete = {
+      currentWeekBar: bar('2026-08-24', 100, 125, 95, 120, 20),
+      lastDailyVolume: { time: utc('2026-08-26'), value: 8 },
+    };
+    const narrow = {
+      currentWeekBar: bar('2026-08-24', 110, 123, 108, 119, 7),
+      lastDailyVolume: { time: utc('2026-08-26'), value: 7 },
+    };
+    const refreshed = {
+      currentWeekBar: bar('2026-08-24', 100, 128, 95, 124, 24),
+      lastDailyVolume: { time: utc('2026-08-27'), value: 4 },
+    };
+
+    expect(shouldReplaceWeeklyHistoryState(complete, narrow)).toBe(false);
+    expect(shouldReplaceWeeklyHistoryState(complete, refreshed)).toBe(true);
+  });
+
+  it('hydrates a partial realtime state from same-week history by value', () => {
+    const state: WeeklyCandleState = {
+      currentWeekBar: bar('2026-08-24', 110, 123, 108, 119, 7),
+      lastDailyVolume: { time: utc('2026-08-26'), value: 7 },
+    };
+    const history = {
+      currentWeekBar: bar('2026-08-24', 100, 125, 95, 120, 20),
+      lastDailyVolume: { time: utc('2026-08-26'), value: 8 },
+    };
+
+    expect(
+      seedWeeklyCandleStateFromHistory(state, history, utc('2026-08-26'))
+    ).toBe(true);
+    expect(state).toEqual(history);
+    expect(state.currentWeekBar).not.toBe(history.currentWeekBar);
+    expect(state.lastDailyVolume).not.toBe(history.lastDailyVolume);
+
+    expect(
+      seedWeeklyCandleStateFromHistory(state, history, utc('2026-09-02'))
+    ).toBe(false);
+  });
+
+  it('clones weekly history without sharing mutable nested values', () => {
+    const history = {
+      currentWeekBar: bar('2026-08-24', 100, 125, 95, 120, 20),
+      lastDailyVolume: { time: utc('2026-08-26'), value: 8 },
+    };
+    const clone = cloneWeeklyHistoryState(history)!;
+
+    clone.currentWeekBar.close = 130;
+    clone.lastDailyVolume!.value = 9;
+
+    expect(history.currentWeekBar.close).toBe(120);
+    expect(history.lastDailyVolume.value).toBe(8);
+  });
+});

--- a/src/ui/views/Perps/candleSubscriptions.ts
+++ b/src/ui/views/Perps/candleSubscriptions.ts
@@ -1,17 +1,16 @@
 /**
- * Bookkeeping for the TradingView datafeed's candle subscriptions.
+ * Bookkeeping for the TradingView datafeed's logical candle subscriptions.
  *
- * The Hyperliquid SDK keys its candle channels by coin+interval and does not
- * refcount them: every unsubscribe() sends an unsubscribe frame that stops the
- * server pushing that channel to *every* listener on it. TradingView, meanwhile,
- * does not guarantee it retires the outgoing subscriberUID before it opens the
- * replacement, so two UIDs can briefly share one channel — and the late
- * unsubscribe then silences the live one, leaving the chart with a subscriber
- * that never receives another bar.
+ * TradingView identifies a series by symbol+display resolution, while the
+ * Hyperliquid channel is symbol+SDK interval. Those identities are not
+ * one-to-one: Rabby's weekly series is aggregated from the daily channel, so
+ * `BTC/1D` and `BTC/1W` both ride `BTC/1d`.
  *
- * These helpers keep at most one entry per channel, and retire a collision
- * *before* its replacement is opened so the frames reach the server in
- * unsubscribe → subscribe order.
+ * The SDK cannot safely open that physical channel twice. Its active channel
+ * map is not refcounted, and either duplicate's unsubscribe frame stops the
+ * server stream for both. The registry below therefore owns exactly one SDK
+ * subscription per physical channel and fans each candle out to every logical
+ * TradingView subscriber riding it.
  */
 
 export interface CandleChannel {
@@ -20,23 +19,33 @@ export interface CandleChannel {
   subscribeInterval: string;
 }
 
-export interface CandleSubscriptionEntry extends CandleChannel {
+export interface CandleSubscriptionEntry<TCandle> extends CandleChannel {
+  onCandle: (candle: TCandle) => void;
+}
+
+interface PhysicalCandleSubscription<
+  TCandle,
+  TEntry extends CandleSubscriptionEntry<TCandle>
+> extends CandleChannel {
+  subscribers: Map<string, TEntry>;
+  active: boolean;
   unsubscribe: () => void;
 }
 
-export const sharesCandleChannel = (a: CandleChannel, b: CandleChannel) =>
-  a.symbol === b.symbol && a.subscribeInterval === b.subscribeInterval;
+const getCandleChannelKey = (channel: CandleChannel) =>
+  JSON.stringify([channel.symbol, channel.subscribeInterval]);
+
+const sharesCandleChannel = (a: CandleChannel, b: CandleChannel) =>
+  getCandleChannelKey(a) === getCandleChannelKey(b);
 
 /**
- * The SDK dispatches candle frames by channel *type*, so every candle listener
- * sees every subscribed channel's bars. While two channels overlap — the
- * outgoing interval has not been retired yet and its replacement is already
- * open — a listener would otherwise forward the other channel's bar as its own.
+ * The SDK dispatches candle frames by channel *type*, so every physical candle
+ * listener sees every subscribed channel's bars. Only forward a frame to the
+ * listener for the channel named by its metadata.
  *
- * Frames that do not carry `s`/`i` are let through: a listener starved by
- * missing metadata would freeze the chart, which is the very failure this
- * guards against. Only a frame that positively names another channel is
- * dropped.
+ * Frames without `s`/`i` are let through. Hyperliquid candle frames currently
+ * carry both fields, but accepting an unlabelled frame preserves liveness if a
+ * compatible SDK version omits them.
  */
 export const isCandleForChannel = (
   candle: { s?: string; i?: string },
@@ -49,49 +58,137 @@ export const isCandleForChannel = (
 };
 
 /**
- * Retire whatever already holds `channel` (or `subscriberUID`), then open the
- * replacement through `open` and register it. `open` runs after the teardown so
- * that a replacement on the same channel re-subscribes behind its own
- * unsubscribe frame instead of being cancelled by it.
+ * Multiplexes logical TradingView subscribers over physical SDK channels.
+ *
+ * Replacing the same UID on the same channel only replaces its consumer; it
+ * must not bounce the SDK channel, because a late teardown for the old series
+ * can otherwise silence the replacement. Moving a UID to a different channel
+ * releases its old physical channel when no other logical subscriber uses it.
  */
-export const openCandleSubscription = <T extends CandleSubscriptionEntry>(
-  subscriptions: Map<string, T>,
-  subscriberUID: string,
-  channel: CandleChannel,
-  open: () => T
-): T => {
-  subscriptions.forEach((entry, uid) => {
-    if (uid !== subscriberUID && !sharesCandleChannel(entry, channel)) return;
+export class CandleSubscriptionRegistry<
+  TCandle extends { s?: string; i?: string },
+  TEntry extends CandleSubscriptionEntry<TCandle> = CandleSubscriptionEntry<TCandle>
+> {
+  private readonly subscribers = new Map<string, TEntry>();
 
-    entry.unsubscribe();
-    subscriptions.delete(uid);
-  });
+  private readonly channels = new Map<
+    string,
+    PhysicalCandleSubscription<TCandle, TEntry>
+  >();
 
-  const entry = open();
-  subscriptions.set(subscriberUID, entry);
-  return entry;
-};
+  get subscriberCount() {
+    return this.subscribers.size;
+  }
 
-/**
- * Retire one subscriberUID. A UID already superseded by
- * {@link openCandleSubscription} is gone from the map, so this is a no-op for it
- * — which is the point: unsubscribing it again would close the channel its
- * replacement is still listening on.
- */
-export const closeCandleSubscription = <T extends CandleSubscriptionEntry>(
-  subscriptions: Map<string, T>,
-  subscriberUID: string
-): void => {
-  const entry = subscriptions.get(subscriberUID);
-  if (!entry) return;
+  get channelCount() {
+    return this.channels.size;
+  }
 
-  entry.unsubscribe();
-  subscriptions.delete(subscriberUID);
-};
+  subscribe(
+    subscriberUID: string,
+    entry: TEntry,
+    openChannel: (
+      onCandle: (candle: TCandle) => void
+    ) => { unsubscribe: () => void }
+  ): TEntry {
+    const current = this.subscribers.get(subscriberUID);
+    if (current && sharesCandleChannel(current, entry)) {
+      const currentPhysical = this.channels.get(getCandleChannelKey(current));
+      if (currentPhysical) {
+        currentPhysical.subscribers.set(subscriberUID, entry);
+        this.subscribers.set(subscriberUID, entry);
+        return entry;
+      }
+    }
 
-export const closeAllCandleSubscriptions = <T extends CandleSubscriptionEntry>(
-  subscriptions: Map<string, T>
-): void => {
-  subscriptions.forEach((entry) => entry.unsubscribe());
-  subscriptions.clear();
-};
+    const channelKey = getCandleChannelKey(entry);
+    let physical = this.channels.get(channelKey);
+    if (!physical) {
+      physical = {
+        symbol: entry.symbol,
+        subscribeInterval: entry.subscribeInterval,
+        subscribers: new Map(),
+        active: true,
+        unsubscribe: () => undefined,
+      };
+      this.channels.set(channelKey, physical);
+
+      try {
+        const subscription = openChannel((candle) => {
+          if (!physical?.active || !isCandleForChannel(candle, physical)) {
+            return;
+          }
+
+          // Snapshot entries so one consumer can unsubscribe itself without
+          // skipping peers. A full registry clear marks the physical channel
+          // inactive and stops the rest of this in-flight dispatch.
+          for (const [uid, subscriber] of Array.from(
+            physical.subscribers.entries()
+          )) {
+            if (!physical.active) break;
+            if (physical.subscribers.get(uid) !== subscriber) continue;
+            subscriber.onCandle(candle);
+          }
+        });
+        physical.unsubscribe = subscription.unsubscribe;
+      } catch (error) {
+        physical.active = false;
+        physical.subscribers.clear();
+        this.channels.delete(channelKey);
+        throw error;
+      }
+    }
+
+    // Opening the destination is transactional: only detach the current entry
+    // after the new physical channel exists. A synchronous open failure leaves
+    // the UID riding its original channel instead of losing both registrations.
+    if (current && !sharesCandleChannel(current, entry)) {
+      const currentChannelKey = getCandleChannelKey(current);
+      const currentPhysical = this.channels.get(currentChannelKey);
+      currentPhysical?.subscribers.delete(subscriberUID);
+      if (currentPhysical && currentPhysical.subscribers.size === 0) {
+        currentPhysical.active = false;
+        currentPhysical.subscribers.clear();
+        this.channels.delete(currentChannelKey);
+        currentPhysical.unsubscribe();
+      }
+    }
+
+    physical.subscribers.set(subscriberUID, entry);
+    this.subscribers.set(subscriberUID, entry);
+    return entry;
+  }
+
+  unsubscribe(subscriberUID: string): void {
+    const entry = this.subscribers.get(subscriberUID);
+    if (!entry) return;
+
+    this.subscribers.delete(subscriberUID);
+    const channelKey = getCandleChannelKey(entry);
+    const physical = this.channels.get(channelKey);
+    if (!physical) return;
+
+    physical.subscribers.delete(subscriberUID);
+    if (physical.subscribers.size > 0) return;
+
+    physical.active = false;
+    physical.subscribers.clear();
+    this.channels.delete(channelKey);
+    physical.unsubscribe();
+  }
+
+  forEachSubscriber(callback: (entry: TEntry, subscriberUID: string) => void) {
+    this.subscribers.forEach(callback);
+  }
+
+  clear(): void {
+    const physicalSubscriptions = Array.from(this.channels.values());
+    physicalSubscriptions.forEach((physical) => {
+      physical.active = false;
+      physical.subscribers.clear();
+    });
+    this.channels.clear();
+    this.subscribers.clear();
+    physicalSubscriptions.forEach((physical) => physical.unsubscribe());
+  }
+}

--- a/src/ui/views/Perps/components/TradingViewIframeChart.tsx
+++ b/src/ui/views/Perps/components/TradingViewIframeChart.tsx
@@ -1,13 +1,23 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import browser from 'webextension-polyfill';
 import type { Candle, CandleSnapshot } from '@rabby-wallet/hyperliquid-sdk';
 import { getPerpsSDK } from '../sdkManager';
+import { CandleSubscriptionRegistry } from '../candleSubscriptions';
+import type { CandleBar as TVBar, WeeklyHistoryState } from '../weeklyCandles';
 import {
-  closeAllCandleSubscriptions,
-  closeCandleSubscription,
-  isCandleForChannel,
-  openCandleSubscription,
-} from '../candleSubscriptions';
+  aggregateDailyToWeeklyBars,
+  getLatestWeeklyHistoryState,
+  getMondayUtc,
+  seedWeeklyCandleStateFromHistory,
+  shouldReplaceWeeklyHistoryState,
+  updateWeeklyCandle,
+} from '../weeklyCandles';
 
 const BRIDGE_CHANNEL = 'rabby-tradingview-bridge-v1';
 const DEFAULT_TRADINGVIEW_URL = process.env.DEBUG
@@ -34,15 +44,6 @@ type PerpsInterval =
   | '8h'
   | '1d'
   | '1w';
-
-type TVBar = {
-  time: number;
-  open: number;
-  high: number;
-  low: number;
-  close: number;
-  volume: number;
-};
 
 type BridgeMessage =
   | {
@@ -77,15 +78,11 @@ type BarSubscription = {
   symbol: string;
   resolution: string;
   subscribeInterval: PerpsInterval;
-  unsubscribe: () => void;
+  onCandle: (snapshot: Candle) => void;
   currentWeekBar: TVBar | null;
   lastDailyVolume: { time: number; value: number } | null;
   isWeekly: boolean;
-};
-
-type WeeklyHistoryState = {
-  currentWeekBar: TVBar;
-  lastDailyVolume: { time: number; value: number } | null;
+  hasWeeklyHistorySeed: boolean;
 };
 
 export interface TradingViewHoverData {
@@ -262,15 +259,6 @@ const getTimeRange = (interval: PerpsInterval) => {
   return { start, end };
 };
 
-const getMondayUtc = (utcMs: number): number => {
-  const date = new Date(utcMs);
-  const day = date.getUTCDay();
-  const diffDays = day === 0 ? -6 : 1 - day;
-  date.setUTCDate(date.getUTCDate() + diffDays);
-  date.setUTCHours(0, 0, 0, 0);
-  return date.getTime();
-};
-
 const parseBars = (data: CandleSnapshot): TVBar[] => {
   if (!data?.length) {
     return [];
@@ -286,72 +274,8 @@ const parseBars = (data: CandleSnapshot): TVBar[] => {
   }));
 };
 
-const aggregateDailyToWeeklyBars = (dailyBars: TVBar[]): TVBar[] => {
-  if (!dailyBars.length) return [];
-
-  const weeks = new Map<number, TVBar>();
-
-  for (const bar of dailyBars) {
-    const mondayTs = getMondayUtc(bar.time);
-    const existing = weeks.get(mondayTs);
-    if (existing) {
-      existing.high = Math.max(existing.high, bar.high);
-      existing.low = Math.min(existing.low, bar.low);
-      existing.close = bar.close;
-      existing.volume += bar.volume;
-    } else {
-      weeks.set(mondayTs, {
-        time: mondayTs,
-        open: bar.open,
-        high: bar.high,
-        low: bar.low,
-        close: bar.close,
-        volume: bar.volume,
-      });
-    }
-  }
-
-  return Array.from(weeks.values()).sort((a, b) => a.time - b.time);
-};
-
 const getWeeklyHistoryKey = (symbol: string, resolution: string) =>
   `${symbol.toLowerCase()}:${resolution}`;
-
-const getLatestWeeklyHistoryState = (
-  weeklyBars: TVBar[],
-  dailyBars: TVBar[]
-): WeeklyHistoryState | null => {
-  const currentWeekBar = weeklyBars[weeklyBars.length - 1];
-  if (!currentWeekBar) return null;
-
-  const lastDailyBar = dailyBars
-    .slice()
-    .reverse()
-    .find((bar) => getMondayUtc(bar.time) === currentWeekBar.time);
-
-  return {
-    currentWeekBar: { ...currentWeekBar },
-    lastDailyVolume: lastDailyBar
-      ? {
-          time: lastDailyBar.time,
-          value: lastDailyBar.volume,
-        }
-      : null,
-  };
-};
-
-const cloneWeeklyHistoryState = (
-  historyState: WeeklyHistoryState | null | undefined
-): WeeklyHistoryState | null => {
-  if (!historyState) return null;
-
-  return {
-    currentWeekBar: { ...historyState.currentWeekBar },
-    lastDailyVolume: historyState.lastDailyVolume
-      ? { ...historyState.lastDailyVolume }
-      : null,
-  };
-};
 
 const toHoverData = (bar: TVBar): TradingViewHoverData => {
   const delta = bar.close - bar.open;
@@ -423,7 +347,17 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
   onIntervalChange,
 }) => {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const subscriptionsRef = useRef<Map<string, BarSubscription>>(new Map());
+  const chartGenerationRef = useRef(0);
+  const iframeGenerationRef = useRef(-1);
+  const setIframeRef = useCallback((iframe: HTMLIFrameElement | null) => {
+    iframeRef.current = iframe;
+    if (iframe) {
+      iframeGenerationRef.current = chartGenerationRef.current;
+    }
+  }, []);
+  const subscriptionsRef = useRef(
+    new CandleSubscriptionRegistry<Candle, BarSubscription>()
+  );
   const weeklyHistoryRef = useRef<Map<string, WeeklyHistoryState>>(new Map());
   // Bumped to remount the iframe when the chart never came up at all
   const [chartReloadKey, setChartReloadKey] = useState(0);
@@ -525,7 +459,7 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
     let barsLoaded = false;
 
     const cleanupSubscriptions = () => {
-      closeAllCandleSubscriptions(subscriptionsRef.current);
+      subscriptionsRef.current.clear();
     };
 
     const recoverChart = () => {
@@ -537,6 +471,10 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
       // Remounting the iframe is the only way back for both; the host re-reads
       // symbol/interval/theme through its getState handshake.
       if (!bridgeAlive || !barsLoaded) {
+        // Invalidate the old document synchronously. React commits the keyed
+        // iframe replacement later, so source===contentWindow alone leaves a
+        // window in which old messages can revive the liveness flags.
+        chartGenerationRef.current += 1;
         bridgeAlive = false;
         barsLoaded = false;
         cleanupSubscriptions();
@@ -574,21 +512,42 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
     sdk.ws.on('open', handleNetworkRestored);
     window.addEventListener('online', handleNetworkRestored);
 
-    const handleGetBars = async (params: {
-      symbol: string;
-      resolution: string;
-      periodParams?: {
-        from?: number;
-        to?: number;
-      };
-    }) => {
+    const emitLatestBar = (symbol: string, resolution: string, bar: TVBar) => {
+      const current = stateRef.current;
+      if (
+        symbol !== current.coin ||
+        resolutionToInterval(resolution) !== current.interval
+      ) {
+        return;
+      }
+
+      current.onLatestBar?.(toHoverData(bar));
+    };
+
+    const handleGetBars = async (
+      params: {
+        symbol: string;
+        resolution: string;
+        periodParams?: {
+          from?: number;
+          to?: number;
+        };
+      },
+      requestSource: MessageEventSource | null,
+      requestGeneration: number
+    ) => {
       const targetInterval = resolutionToInterval(params.resolution);
       const isWeekly = targetInterval === '1w';
       const fetchInterval: PerpsInterval = isWeekly ? '1d' : targetInterval;
       const fallbackRange = getTimeRange(targetInterval);
-      const start = params.periodParams?.from
+      const requestedStart = params.periodParams?.from
         ? params.periodParams.from * 1000
         : fallbackRange.start;
+      // A TradingView range can start mid-week. Fetch from that week's Monday
+      // so the first weekly candle is never cached with a mid-week open/volume.
+      const start = isWeekly
+        ? Math.max(0, getMondayUtc(requestedStart))
+        : requestedStart;
       const end = params.periodParams?.to
         ? params.periodParams.to * 1000
         : fallbackRange.end;
@@ -599,6 +558,18 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
         start,
         end
       );
+      // chartReloadKey replaces the iframe without replacing this effect. An
+      // HTTP request from the detached document can therefore finish after the
+      // new bridge has started and reuse one of its request ids. Do not let the
+      // old request mutate weekly state or answer the new document.
+      if (
+        requestGeneration !== chartGenerationRef.current ||
+        requestGeneration !== iframeGenerationRef.current ||
+        requestSource !== iframeRef.current?.contentWindow
+      ) {
+        return null;
+      }
+
       const dailyBars = parseBars(snapshot);
       const bars = isWeekly ? aggregateDailyToWeeklyBars(dailyBars) : dailyBars;
       if (isWeekly) {
@@ -607,22 +578,27 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
           params.symbol,
           params.resolution
         );
-        if (historyState) {
+        const cachedHistoryState = weeklyHistoryRef.current.get(historyKey);
+        // TradingView can paginate older ranges after loading the latest bars,
+        // and those requests may finish out of order. Never let an older/empty
+        // page evict the current-week seed needed by the realtime aggregator.
+        if (
+          historyState &&
+          shouldReplaceWeeklyHistoryState(cachedHistoryState, historyState)
+        ) {
           weeklyHistoryRef.current.set(historyKey, historyState);
-        } else {
-          weeklyHistoryRef.current.delete(historyKey);
         }
 
         // resetData() reloads TradingView history without replacing the SDK
         // subscription object. Keep the mutable weekly aggregation state in
         // sync so the next daily candle cannot overwrite refreshed history
         // with the pre-disconnect week snapshot.
-        const nextState = cloneWeeklyHistoryState(historyState);
+        const historySeed = weeklyHistoryRef.current.get(historyKey);
         const currentWeekStart = getMondayUtc(Date.now());
-        subscriptionsRef.current.forEach((subscription) => {
+        subscriptionsRef.current.forEachSubscriber((subscription) => {
           if (
-            !nextState ||
-            nextState.currentWeekBar.time !== currentWeekStart ||
+            !historySeed ||
+            historySeed.currentWeekBar.time !== currentWeekStart ||
             !subscription.isWeekly ||
             getWeeklyHistoryKey(
               subscription.symbol,
@@ -632,12 +608,15 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
             return;
           }
 
-          subscription.currentWeekBar = nextState.currentWeekBar;
-          subscription.lastDailyVolume = nextState.lastDailyVolume;
+          subscription.hasWeeklyHistorySeed = seedWeeklyCandleStateFromHistory(
+            subscription,
+            historySeed,
+            currentWeekStart
+          );
         });
       }
       if (bars.length) {
-        stateRef.current.onLatestBar?.(toHoverData(bars[bars.length - 1]));
+        emitLatestBar(params.symbol, params.resolution, bars[bars.length - 1]);
       }
       barsLoaded = true;
       return {
@@ -662,110 +641,70 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
         symbol: params.symbol,
         resolution: params.resolution,
         subscribeInterval,
-        unsubscribe: () => undefined,
         currentWeekBar: null,
         lastDailyVolume: null,
         isWeekly,
-      };
+        hasWeeklyHistorySeed: false,
+        onCandle: (snapshot) => {
+          const parsed = parseBars([snapshot]);
+          if (!parsed.length) return;
+          const dayBar = parsed[0];
 
-      const openSubscription = () => {
-        const subscription = sdk.ws.subscribeToCandles(
-          params.symbol,
-          subscribeInterval,
-          (snapshot) => {
-            if (
-              !isCandleForChannel(snapshot, {
-                symbol: params.symbol,
-                subscribeInterval,
-              })
-            ) {
-              return;
-            }
-
-            const parsed = parseBars([snapshot]);
-            if (!parsed.length) return;
-            const dayBar = parsed[0];
-
-            if (!state.isWeekly) {
-              postToIframe({
-                channel: BRIDGE_CHANNEL,
-                kind: 'event',
-                event: 'realtimeBar',
-                payload: {
-                  subscriberUID: params.subscriberUID,
-                  bar: dayBar,
-                },
-              });
-              stateRef.current.onLatestBar?.(toHoverData(dayBar));
-              return;
-            }
-
-            const mondayTs = getMondayUtc(dayBar.time);
-            if (!state.currentWeekBar) {
-              const historyState = cloneWeeklyHistoryState(
-                weeklyHistoryRef.current.get(weeklyHistoryKey)
-              );
-              if (!historyState) {
-                return;
-              }
-              state.currentWeekBar = historyState.currentWeekBar;
-              state.lastDailyVolume = historyState.lastDailyVolume;
-            }
-
-            const currentWeekBar = state.currentWeekBar;
-            if (currentWeekBar && currentWeekBar.time === mondayTs) {
-              currentWeekBar.high = Math.max(currentWeekBar.high, dayBar.high);
-              currentWeekBar.low = Math.min(currentWeekBar.low, dayBar.low);
-              currentWeekBar.close = dayBar.close;
-
-              const prevDayVolume =
-                state.lastDailyVolume?.time === dayBar.time
-                  ? state.lastDailyVolume.value
-                  : 0;
-              currentWeekBar.volume =
-                currentWeekBar.volume - prevDayVolume + dayBar.volume;
-            } else {
-              state.currentWeekBar = {
-                ...dayBar,
-                time: mondayTs,
-              };
-            }
-
-            state.lastDailyVolume = {
-              time: dayBar.time,
-              value: dayBar.volume,
-            };
-
-            if (state.currentWeekBar) {
-              postToIframe({
-                channel: BRIDGE_CHANNEL,
-                kind: 'event',
-                event: 'realtimeBar',
-                payload: {
-                  subscriberUID: params.subscriberUID,
-                  bar: state.currentWeekBar,
-                },
-              });
-              stateRef.current.onLatestBar?.(toHoverData(state.currentWeekBar));
-            }
+          if (!state.isWeekly) {
+            postToIframe({
+              channel: BRIDGE_CHANNEL,
+              kind: 'event',
+              event: 'realtimeBar',
+              payload: {
+                subscriberUID: params.subscriberUID,
+                bar: dayBar,
+              },
+            });
+            emitLatestBar(state.symbol, state.resolution, dayBar);
+            return;
           }
-        );
 
-        state.unsubscribe = subscription.unsubscribe;
-        return state;
+          const currentWeekStart = getMondayUtc(dayBar.time);
+          if (state.currentWeekBar?.time !== currentWeekStart) {
+            state.hasWeeklyHistorySeed = false;
+          }
+          if (!state.currentWeekBar || !state.hasWeeklyHistorySeed) {
+            state.hasWeeklyHistorySeed = seedWeeklyCandleStateFromHistory(
+              state,
+              weeklyHistoryRef.current.get(weeklyHistoryKey),
+              dayBar.time
+            );
+          }
+
+          // History and subscribeBars are independent bridge requests. If the
+          // seed is missing or an older pagination request won the race,
+          // updateWeeklyCandle starts a partial current-week bar rather than
+          // freezing latest-price updates while waiting for history forever.
+          const currentWeekBar = updateWeeklyCandle(state, dayBar);
+          postToIframe({
+            channel: BRIDGE_CHANNEL,
+            kind: 'event',
+            event: 'realtimeBar',
+            payload: {
+              subscriberUID: params.subscriberUID,
+              bar: currentWeekBar,
+            },
+          });
+          emitLatestBar(state.symbol, state.resolution, currentWeekBar);
+        },
       };
 
-      openCandleSubscription(
-        subscriptionsRef.current,
+      subscriptionsRef.current.subscribe(
         params.subscriberUID,
-        { symbol: params.symbol, subscribeInterval },
-        openSubscription
+        state,
+        (onCandle) =>
+          sdk.ws.subscribeToCandles(params.symbol, subscribeInterval, onCandle)
       );
       return { ok: true };
     };
 
     const handleUnsubscribeBars = (params: { subscriberUID: string }) => {
-      closeCandleSubscription(subscriptionsRef.current, params.subscriberUID);
+      subscriptionsRef.current.unsubscribe(params.subscriberUID);
       return { ok: true };
     };
 
@@ -774,6 +713,8 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
       if (!message || message.channel !== BRIDGE_CHANNEL) return;
       if (event.source !== iframeRef.current?.contentWindow) return;
       if (iframeOrigin !== '*' && event.origin !== iframeOrigin) return;
+      const messageGeneration = chartGenerationRef.current;
+      if (iframeGenerationRef.current !== messageGeneration) return;
 
       bridgeAlive = true;
 
@@ -802,15 +743,19 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
 
       if (message.kind !== 'request') return;
 
+      const responseTarget = event.source as Window | null;
       const respond = (ok: boolean, result?: any, error?: string) => {
-        postToIframe({
-          channel: BRIDGE_CHANNEL,
-          kind: 'response',
-          id: message.id,
-          ok,
-          result,
-          error,
-        });
+        responseTarget?.postMessage(
+          {
+            channel: BRIDGE_CHANNEL,
+            kind: 'response',
+            id: message.id,
+            ok,
+            result,
+            error,
+          },
+          iframeOrigin
+        );
       };
 
       try {
@@ -858,7 +803,18 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
             });
             break;
           case 'getBars':
-            respond(true, await handleGetBars(message.params as any));
+            {
+              const result = await handleGetBars(
+                message.params as any,
+                event.source,
+                messageGeneration
+              );
+              if (result) {
+                respond(true, result);
+              } else {
+                respond(false, undefined, 'Stale chart request');
+              }
+            }
             break;
           case 'subscribeBars':
             respond(true, handleSubscribeBars(message.params as any));
@@ -896,8 +852,9 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
     // issued while a load is in flight), and any such record would then be
     // wrong forever, suppressing the command that would recover the chart.
     // The iframe drops a command matching what it already shows, so a repeat
-    // costs nothing; TradingView retires the superseded series itself through
-    // unsubscribeBars, and openCandleSubscription clears whatever survives.
+    // costs nothing. If TradingView does reopen the logical series, the candle
+    // registry replaces the same UID without bouncing its physical channel and
+    // refcounts any 1D/1W channel shared by different UIDs.
     postToIframe({
       channel: BRIDGE_CHANNEL,
       kind: 'command',
@@ -974,7 +931,7 @@ export const TradingViewIframeChart: React.FC<TradingViewIframeChartProps> = ({
   return (
     <iframe
       key={chartReloadKey}
-      ref={iframeRef}
+      ref={setIframeRef}
       src={iframeUrl}
       className={className}
       title="tradingview-advanced-chart"

--- a/src/ui/views/Perps/weeklyCandles.ts
+++ b/src/ui/views/Perps/weeklyCandles.ts
@@ -1,0 +1,175 @@
+export type CandleBar = {
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+};
+
+export type WeeklyCandleState = {
+  currentWeekBar: CandleBar | null;
+  lastDailyVolume: { time: number; value: number } | null;
+};
+
+export type WeeklyHistoryState = {
+  currentWeekBar: CandleBar;
+  lastDailyVolume: { time: number; value: number } | null;
+};
+
+export const getMondayUtc = (utcMs: number): number => {
+  const date = new Date(utcMs);
+  const day = date.getUTCDay();
+  const diffDays = day === 0 ? -6 : 1 - day;
+  date.setUTCDate(date.getUTCDate() + diffDays);
+  date.setUTCHours(0, 0, 0, 0);
+  return date.getTime();
+};
+
+export const aggregateDailyToWeeklyBars = (
+  dailyBars: CandleBar[]
+): CandleBar[] => {
+  if (!dailyBars.length) return [];
+
+  const weeks = new Map<number, CandleBar>();
+
+  for (const bar of dailyBars) {
+    const mondayTs = getMondayUtc(bar.time);
+    const existing = weeks.get(mondayTs);
+    if (existing) {
+      existing.high = Math.max(existing.high, bar.high);
+      existing.low = Math.min(existing.low, bar.low);
+      existing.close = bar.close;
+      existing.volume += bar.volume;
+    } else {
+      weeks.set(mondayTs, {
+        time: mondayTs,
+        open: bar.open,
+        high: bar.high,
+        low: bar.low,
+        close: bar.close,
+        volume: bar.volume,
+      });
+    }
+  }
+
+  return Array.from(weeks.values()).sort((a, b) => a.time - b.time);
+};
+
+export const getLatestWeeklyHistoryState = (
+  weeklyBars: CandleBar[],
+  dailyBars: CandleBar[]
+): WeeklyHistoryState | null => {
+  const currentWeekBar = weeklyBars[weeklyBars.length - 1];
+  if (!currentWeekBar) return null;
+
+  const lastDailyBar = dailyBars
+    .slice()
+    .reverse()
+    .find((bar) => getMondayUtc(bar.time) === currentWeekBar.time);
+
+  return {
+    currentWeekBar: { ...currentWeekBar },
+    lastDailyVolume: lastDailyBar
+      ? {
+          time: lastDailyBar.time,
+          value: lastDailyBar.volume,
+        }
+      : null,
+  };
+};
+
+export const cloneWeeklyHistoryState = (
+  historyState: WeeklyHistoryState | null | undefined
+): WeeklyHistoryState | null => {
+  if (!historyState) return null;
+
+  return {
+    currentWeekBar: { ...historyState.currentWeekBar },
+    lastDailyVolume: historyState.lastDailyVolume
+      ? { ...historyState.lastDailyVolume }
+      : null,
+  };
+};
+
+/**
+ * Prefer a later week, or a same-week snapshot that covers at least as much
+ * cumulative time and volume. This prevents a narrower same-week getBars page
+ * from replacing the complete seed used by realtime aggregation.
+ */
+export const shouldReplaceWeeklyHistoryState = (
+  current: WeeklyHistoryState | null | undefined,
+  next: WeeklyHistoryState
+): boolean => {
+  if (!current) return true;
+
+  const currentWeek = current.currentWeekBar;
+  const nextWeek = next.currentWeekBar;
+  if (nextWeek.time !== currentWeek.time) {
+    return nextWeek.time > currentWeek.time;
+  }
+
+  const currentLastDay = current.lastDailyVolume?.time ?? -Infinity;
+  const nextLastDay = next.lastDailyVolume?.time ?? -Infinity;
+  return nextLastDay >= currentLastDay && nextWeek.volume >= currentWeek.volume;
+};
+
+/** Seed a mutable realtime state only when history belongs to the same week. */
+export const seedWeeklyCandleStateFromHistory = (
+  state: WeeklyCandleState,
+  historyState: WeeklyHistoryState | null | undefined,
+  dailyTime: number
+): boolean => {
+  if (
+    !historyState ||
+    historyState.currentWeekBar.time !== getMondayUtc(dailyTime)
+  ) {
+    return false;
+  }
+
+  const seed = cloneWeeklyHistoryState(historyState)!;
+  state.currentWeekBar = seed.currentWeekBar;
+  state.lastDailyVolume = seed.lastDailyVolume;
+  return true;
+};
+
+/**
+ * Merge a cumulative daily candle into a cumulative weekly candle.
+ *
+ * Hyperliquid repeatedly sends the current day's full volume, so replace that
+ * day's previous contribution instead of adding it again. With no history seed
+ * the daily candle becomes a partial current-week bar; that keeps the latest
+ * price live until the next history refresh fills in earlier days.
+ */
+export const updateWeeklyCandle = (
+  state: WeeklyCandleState,
+  dayBar: CandleBar
+): CandleBar => {
+  const mondayTs = getMondayUtc(dayBar.time);
+  const currentWeekBar = state.currentWeekBar;
+
+  if (!currentWeekBar || currentWeekBar.time !== mondayTs) {
+    state.currentWeekBar = {
+      ...dayBar,
+      time: mondayTs,
+    };
+  } else {
+    currentWeekBar.high = Math.max(currentWeekBar.high, dayBar.high);
+    currentWeekBar.low = Math.min(currentWeekBar.low, dayBar.low);
+    currentWeekBar.close = dayBar.close;
+
+    const prevDayVolume =
+      state.lastDailyVolume?.time === dayBar.time
+        ? state.lastDailyVolume.value
+        : 0;
+    currentWeekBar.volume =
+      currentWeekBar.volume - prevDayVolume + dayBar.volume;
+  }
+
+  state.lastDailyVolume = {
+    time: dayBar.time,
+    value: dayBar.volume,
+  };
+
+  return state.currentWeekBar!;
+};


### PR DESCRIPTION
This pull request refactors and improves the candle subscription logic for TradingView charts in the Perps UI. The main change is the introduction of a new `CandleSubscriptionRegistry` class, which manages logical TradingView subscriptions and multiplexes them over physical SDK channels. This prevents duplicate subscriptions to the same channel, fixes edge cases where unsubscribing could inadvertently silence active listeners, and simplifies the handling of weekly candle aggregation. The update also cleans up and modularizes related code, and adds comprehensive unit tests for weekly candle logic.

Key changes include:

**Candle Subscription System Refactor:**

- Introduced the `CandleSubscriptionRegistry` class to manage logical TradingView subscribers and ensure only one SDK subscription per physical channel, preventing duplicate unsubscribes from breaking live data feeds. This class provides transactional subscription management, proper resource cleanup, and exposes subscriber/channel counts for diagnostics. [[1]](diffhunk://#diff-e89a00719eb58e1d1637894ab67c64582d3ed77a40df221093afb930ea0583e5L2-R13) [[2]](diffhunk://#diff-e89a00719eb58e1d1637894ab67c64582d3ed77a40df221093afb930ea0583e5L52-R194)
- Updated the TradingView chart component (`TradingViewIframeChart.tsx`) to use the new registry for all candle subscription management, replacing the previous Map-based and helper-function approach. [[1]](diffhunk://#diff-819e457a33a6e6d6974468560d6dd33eb9a6792028c9f5951ae26dbdf71c2d80L1-R20) [[2]](diffhunk://#diff-819e457a33a6e6d6974468560d6dd33eb9a6792028c9f5951ae26dbdf71c2d80L426-R360) [[3]](diffhunk://#diff-819e457a33a6e6d6974468560d6dd33eb9a6792028c9f5951ae26dbdf71c2d80L528-R462)

**Weekly Candle Aggregation and State Management:**

- Refactored weekly candle aggregation logic into a separate module (`weeklyCandles`), and updated the chart component to import and use these helpers for consistent and testable weekly bar calculation. [[1]](diffhunk://#diff-819e457a33a6e6d6974468560d6dd33eb9a6792028c9f5951ae26dbdf71c2d80L1-R20) [[2]](diffhunk://#diff-819e457a33a6e6d6974468560d6dd33eb9a6792028c9f5951ae26dbdf71c2d80L265-L273) [[3]](diffhunk://#diff-819e457a33a6e6d6974468560d6dd33eb9a6792028c9f5951ae26dbdf71c2d80L289-L355)
- Improved the handling and seeding of partial weekly candle state, ensuring correct rollover and volume attribution for real-time updates.

**Testing Improvements:**

- Added comprehensive unit tests for weekly candle aggregation, state seeding, rollover, and cloning to ensure correctness and prevent regressions.

**Documentation and Code Comments:**

- Enhanced code comments and documentation throughout the subscription and aggregation logic to clarify the relationship between logical TradingView subscriptions and physical SDK channels, and to explain the rationale behind the new architecture. [[1]](diffhunk://#diff-e89a00719eb58e1d1637894ab67c64582d3ed77a40df221093afb930ea0583e5L2-R13) [[2]](diffhunk://#diff-e89a00719eb58e1d1637894ab67c64582d3ed77a40df221093afb930ea0583e5L23-R48)

**Internal API Cleanups:**

- Removed redundant code and moved utility functions (such as `getMondayUtc` and aggregation helpers) to the dedicated weekly candle module, reducing duplication and improving maintainability. [[1]](diffhunk://#diff-819e457a33a6e6d6974468560d6dd33eb9a6792028c9f5951ae26dbdf71c2d80L265-L273) [[2]](diffhunk://#diff-819e457a33a6e6d6974468560d6dd33eb9a6792028c9f5951ae26dbdf71c2d80L289-L355)

These changes collectively make the charting infrastructure more robust, easier to extend, and less prone to subtle bugs related to subscription management and weekly candle aggregation.