### PR TITLE
fix: open notification windows on Wayland

### DIFF
--- a/__tests__/background/window.test.ts
+++ b/__tests__/background/window.test.ts
@@ -45,4 +45,21 @@ describe('background window manager', () => {
     await expect(winMgr.openNotification()).resolves.toBeUndefined();
     expect(mockUpdateWindow).not.toHaveBeenCalled();
   });
+
+  it('retries invalid bounds without a position', async () => {
+    mockGetLastFocused
+      .mockResolvedValueOnce({ top: 0, left: 0, width: 1200, height: 800 })
+      .mockResolvedValueOnce({ state: 'normal' });
+    mockCreateWindow
+      .mockRejectedValueOnce(
+        new Error(
+          'Invalid value for bounds. Bounds must be at least 50% within visible screen space.'
+        )
+      )
+      .mockResolvedValueOnce({ id: 42, left: 0 });
+
+    await expect(winMgr.openNotification()).resolves.toBe(42);
+    expect(mockCreateWindow.mock.calls[1][0]).not.toHaveProperty('top');
+    expect(mockCreateWindow.mock.calls[1][0]).not.toHaveProperty('left');
+  });
 });

--- a/src/background/webapi/window.ts
+++ b/src/background/webapi/window.ts
@@ -79,8 +79,6 @@ const create = async ({ url, ...rest }): Promise<number | undefined> => {
           focused: true,
           url,
           type: 'popup',
-          top: 0,
-          left: 0,
           ...WINDOW_SIZE,
           ...rest,
           height: finalHeight,


### PR DESCRIPTION
## Summary

- Retry invalid notification popup bounds without fixed coordinates so Wayland can place the window.
- Add regression coverage for the fallback.

## Testing

- `yarn`
- `yarn check`
- `yarn test __tests__/background/window.test.ts --runInBand`
- `yarn build:pro`