### PR TITLE
Enhance trading logic and improve UI components

### DIFF
--- a/__tests__/utils/perpsLiquidation.test.ts
+++ b/__tests__/utils/perpsLiquidation.test.ts
@@ -182,32 +182,50 @@ describe('resolveProjectedLiquidationPrice (parity with rabby-mobile)', () => {
     ).toBe(expectedFrom(100, 30, 'Long', 2, 200, 20));
   });
 
-  // An existing position's margin is already real, so the floor is the margin
-  // this order *adds*. Both cases below sit between the added margin (2 @ 100
-  // at 10x = 20) and the merged one (3 @ 100 at 10x = 30), which is the only
-  // window where the two floors disagree.
+  // Growing an existing 1 @ 80 long by 2 @ 100 at 10x. The order adds 20 of
+  // margin; the existing leg keeps 1*100/(2*20) = 2.5 of maintenance margin
+  // locked, which cross adds back on top of whatever the free balance is.
   const growth = {
     marginMode: 'cross' as const,
     currentPosition: { entryPx: '80', marginUsed: '8', szi: '1' },
     assumeSufficientMargin: true,
   };
 
-  it('assumeSufficientMargin leaves a balance that covers the added margin alone', () => {
-    // backingMargin = 22.5 + 1*100/(2*20) = 25, above the 20 it must fund.
+  it('assumeSufficientMargin leaves a free balance that covers the added margin', () => {
+    // 22.5 free already funds the 20, so the estimate keeps the real balance:
+    // 22.5 + 2.5 = 25. Never lowered, never raised.
     expect(
       resolve({ ...growth, crossMarginAvailableAfterMaintenance: 22.5 })
         ?.liquidationPrice
     ).toBe(expectedFrom(100, 25, 'Long', 3, 300, 20));
   });
 
-  it('assumeSufficientMargin floors growth at the added margin, not the merged one', () => {
-    // backingMargin = 2.5 + 2.5 = 5: funded up to the order's own 20, never to
-    // the merged position's 30 — that would quote a safer price than the
-    // account can actually hold.
+  it('assumeSufficientMargin floors growth on the free balance, under the maintenance add-back', () => {
+    // 18 free cannot fund the 20: the account has to be topped up to 20 before
+    // the 2.5 of still-locked maintenance is added back, giving 22.5.
+    //
+    // The interval matters — 18 is chosen so that every wrong floor is a
+    // different number: flooring the *sum* leaves 18 + 2.5 = 20.5 untouched
+    // (the add-back masks the deficit outright), and flooring at the merged
+    // position's margin (3 @ 100 at 10x = 30) invents margin for the existing
+    // leg the balance already carries.
     expect(
-      resolve({ ...growth, crossMarginAvailableAfterMaintenance: 2.5 })
+      resolve({ ...growth, crossMarginAvailableAfterMaintenance: 18 })
         ?.liquidationPrice
-    ).toBe(expectedFrom(100, 20, 'Long', 3, 300, 20));
+    ).toBe(expectedFrom(100, 22.5, 'Long', 3, 300, 20));
+  });
+
+  it('assumeSufficientMargin floors a flip on the balance the closed leg releases', () => {
+    // Flipping a 1 @ 80 long with a 2 @ 100 sell leaves a 1 short needing 10.
+    // The old leg is closed, so its 2.5 of maintenance is released and spendable
+    // — 8 free plus 2.5 backs the new leg with 10.5 and needs no top-up.
+    expect(
+      resolve({
+        ...growth,
+        side: 'sell',
+        crossMarginAvailableAfterMaintenance: 8,
+      })?.liquidationPrice
+    ).toBe(expectedFrom(100, 10.5, 'Short', 1, 100, 20));
   });
 
   it('assumeSufficientMargin still fails closed on an unavailable balance', () => {

--- a/__tests__/utils/perpsLiquidation.test.ts
+++ b/__tests__/utils/perpsLiquidation.test.ts
@@ -159,6 +159,39 @@ describe('resolveProjectedLiquidationPrice (parity with rabby-mobile)', () => {
     ).toBe('779.48');
   });
 
+  it('assumeSufficientMargin floors a deficient cross balance at the order margin', () => {
+    // A 5 balance cannot fund the 20 order margin: unflagged the estimate is
+    // hidden (margin_available <= 0), flagged it matches the isolated one.
+    const facts = {
+      marginMode: 'cross' as const,
+      crossMarginAvailableAfterMaintenance: 5,
+    };
+    expect(resolve(facts)).toBeNull();
+    expect(
+      resolve({ ...facts, assumeSufficientMargin: true })?.liquidationPrice
+    ).toBe(expectedFrom(100, 20, 'Long', 2, 200, 20));
+  });
+
+  it('assumeSufficientMargin never lowers a sufficient cross balance', () => {
+    expect(
+      resolve({
+        marginMode: 'cross',
+        crossMarginAvailableAfterMaintenance: 30,
+        assumeSufficientMargin: true,
+      })?.liquidationPrice
+    ).toBe(expectedFrom(100, 30, 'Long', 2, 200, 20));
+  });
+
+  it('assumeSufficientMargin still fails closed on an unavailable balance', () => {
+    expect(
+      resolve({
+        marginMode: 'cross',
+        crossMarginAvailableAfterMaintenance: null,
+        assumeSufficientMargin: true,
+      })
+    ).toBeNull();
+  });
+
   it('distinguishes the MSFT unpriced long from its finite short', () => {
     const msft = {
       crossMarginAvailableAfterMaintenance: 36.2449065,

--- a/__tests__/utils/perpsLiquidation.test.ts
+++ b/__tests__/utils/perpsLiquidation.test.ts
@@ -182,6 +182,34 @@ describe('resolveProjectedLiquidationPrice (parity with rabby-mobile)', () => {
     ).toBe(expectedFrom(100, 30, 'Long', 2, 200, 20));
   });
 
+  // An existing position's margin is already real, so the floor is the margin
+  // this order *adds*. Both cases below sit between the added margin (2 @ 100
+  // at 10x = 20) and the merged one (3 @ 100 at 10x = 30), which is the only
+  // window where the two floors disagree.
+  const growth = {
+    marginMode: 'cross' as const,
+    currentPosition: { entryPx: '80', marginUsed: '8', szi: '1' },
+    assumeSufficientMargin: true,
+  };
+
+  it('assumeSufficientMargin leaves a balance that covers the added margin alone', () => {
+    // backingMargin = 22.5 + 1*100/(2*20) = 25, above the 20 it must fund.
+    expect(
+      resolve({ ...growth, crossMarginAvailableAfterMaintenance: 22.5 })
+        ?.liquidationPrice
+    ).toBe(expectedFrom(100, 25, 'Long', 3, 300, 20));
+  });
+
+  it('assumeSufficientMargin floors growth at the added margin, not the merged one', () => {
+    // backingMargin = 2.5 + 2.5 = 5: funded up to the order's own 20, never to
+    // the merged position's 30 — that would quote a safer price than the
+    // account can actually hold.
+    expect(
+      resolve({ ...growth, crossMarginAvailableAfterMaintenance: 2.5 })
+        ?.liquidationPrice
+    ).toBe(expectedFrom(100, 20, 'Long', 3, 300, 20));
+  });
+
   it('assumeSufficientMargin still fails closed on an unavailable balance', () => {
     expect(
       resolve({

--- a/src/ui/views/DesktopPerps/components/TradingPanel/containers/LimitTradingContainer.tsx
+++ b/src/ui/views/DesktopPerps/components/TradingPanel/containers/LimitTradingContainer.tsx
@@ -32,6 +32,7 @@ import stats from '@/stats';
 import { formatPerpsCoin, getStatsReportSide } from '../../../utils';
 import { resolveTriggerComparator } from '../../../tpslTrigger';
 import { calcAmountFromPercentage } from '../utils';
+import { useDirectionMaxGate } from '../hooks/useDirectionMaxGate';
 import { PerpsDropdown } from '../components';
 import { LimitOrderTypeSelector } from '../components/LimitOrderTypeSelector';
 import perpsToast from '../../PerpsToast';
@@ -321,7 +322,8 @@ export const LimitTradingContainer: React.FC<TradingContainerProps> = () => {
     };
   }, [wsActiveAssetCtx, markPrice, selectedCoin]);
 
-  // Form validation (direction-agnostic, ALO check moved to button click)
+  // Form validation (direction-agnostic, ALO check moved to button click;
+  // the per-side max gate lives at the buttons)
   const validation = React.useMemo(() => {
     let error: string = '';
     const tradeSize = Number(positionSize.amount) || 0;
@@ -341,22 +343,6 @@ export const LimitTradingContainer: React.FC<TradingContainerProps> = () => {
       return { isValid: false, error };
     }
 
-    // Check max trade size (shared: use max of both directions)
-    const effectiveMaxTradeSize = reduceOnly
-      ? Number(
-          (currentPosition?.side === 'Long'
-            ? limitMaxSellTradeSize
-            : limitMaxBuyTradeSize) || 0
-        )
-      : Math.max(
-          Number(limitMaxBuyTradeSize || 0),
-          Number(limitMaxSellTradeSize || 0)
-        );
-    if (effectiveMaxTradeSize && tradeSize > effectiveMaxTradeSize) {
-      error = t('page.perpsPro.tradingPanel.insufficientBalance');
-      return { isValid: false, error };
-    }
-
     // Check maximum position size
     const maxUsdValue = Number(currentMarketData?.maxUsdValueSize || 1000000);
     if (notionalNum > maxUsdValue) {
@@ -373,18 +359,20 @@ export const LimitTradingContainer: React.FC<TradingContainerProps> = () => {
     };
   }, [
     positionSize.amount,
-    reduceOnly,
     bboEnabled,
     buyLimitPrice,
     sellLimitPrice,
     limitPrice,
     percentage,
     currentMarketData,
-    currentPosition,
-    limitMaxBuyTradeSize,
-    limitMaxSellTradeSize,
     t,
   ]);
+
+  const checkDirectionMax = useDirectionMaxGate({
+    positionSize,
+    maxBuyTradeSize: limitMaxBuyTradeSize,
+    maxSellTradeSize: limitMaxSellTradeSize,
+  });
 
   // ALO validation is deferred to button click (see openOrder)
 
@@ -784,6 +772,7 @@ export const LimitTradingContainer: React.FC<TradingContainerProps> = () => {
   );
 
   const handleOrderClick = useMemoizedFn((isBuy: boolean) => {
+    if (!checkDirectionMax(isBuy)) return;
     // Keep the direction-specific checks ahead of the dialog: otherwise the
     // user would confirm an order that can only fail validation.
     if (!validateDirection(isBuy)) return;

--- a/src/ui/views/DesktopPerps/components/TradingPanel/containers/LimitTradingContainer.tsx
+++ b/src/ui/views/DesktopPerps/components/TradingPanel/containers/LimitTradingContainer.tsx
@@ -188,9 +188,15 @@ export const LimitTradingContainer: React.FC<TradingContainerProps> = () => {
   const buyLimitPrice = bboEnabled ? bboBuyPrice : limitPrice;
   const sellLimitPrice = bboEnabled ? bboSellPrice : limitPrice;
 
-  // Estimated price: BBO mode → midPrice, manual → use limitPrice as-is
-  const estBuyPrice = bboEnabled ? midPrice : Number(limitPrice) || midPrice;
-  const estSellPrice = bboEnabled ? midPrice : Number(limitPrice) || midPrice;
+  // Estimated fill price: the book level a BBO order will rest at (per
+  // direction), or the typed limit price; mid while neither is available.
+  // Liquidation, cost and the balance-based max all derive from it.
+  const estBuyPrice = bboEnabled
+    ? Number(bboBuyPrice) || midPrice
+    : Number(limitPrice) || midPrice;
+  const estSellPrice = bboEnabled
+    ? Number(bboSellPrice) || midPrice
+    : Number(limitPrice) || midPrice;
 
   const priceForCalculation = useMemo(() => {
     return bboEnabled ? midPrice : Number(limitPrice) || midPrice;

--- a/src/ui/views/DesktopPerps/components/TradingPanel/containers/MarketTradingContainer.tsx
+++ b/src/ui/views/DesktopPerps/components/TradingPanel/containers/MarketTradingContainer.tsx
@@ -18,6 +18,7 @@ import stats from '@/stats';
 import { formatPerpsCoin, getStatsReportSide } from '../../../utils';
 import { resolveTpSlTrigger } from '../../../tpslTrigger';
 import { calcAmountFromPercentage } from '../utils';
+import { useDirectionMaxGate } from '../hooks/useDirectionMaxGate';
 import { perpsToast } from '../../PerpsToast';
 import { useOrderConfirm } from '../../../modal/OrderConfirmProvider';
 import type { OrderConfirmContent } from '../../../modal/OrderConfirmProvider';
@@ -94,7 +95,7 @@ export const MarketTradingContainer: React.FC<TradingContainerProps> = () => {
 
   const [slippageVisible, setSlippageVisible] = React.useState(false);
 
-  // Form validation (direction-agnostic)
+  // Form validation (direction-agnostic; the per-side max gate lives at the buttons)
   const validation = React.useMemo(() => {
     let error: string = '';
     const size = Number(positionSize.amount) || 0;
@@ -107,20 +108,6 @@ export const MarketTradingContainer: React.FC<TradingContainerProps> = () => {
     // Check minimum order size ($10)
     if (notionalNum < 10) {
       error = t('page.perpsPro.tradingPanel.minimumOrderSize');
-      return { isValid: false, error };
-    }
-
-    // Check max trade size
-    // reduceOnly: check against the opposite direction's max (position size)
-    const effectiveMaxTradeSize = reduceOnly
-      ? Number(
-          (currentPosition?.side === 'Long'
-            ? maxSellTradeSize
-            : maxBuyTradeSize) || 0
-        )
-      : Math.max(Number(maxBuyTradeSize || 0), Number(maxSellTradeSize || 0));
-    if (effectiveMaxTradeSize > 0 && size > effectiveMaxTradeSize) {
-      error = t('page.perpsPro.tradingPanel.insufficientBalance');
       return { isValid: false, error };
     }
 
@@ -141,9 +128,6 @@ export const MarketTradingContainer: React.FC<TradingContainerProps> = () => {
   }, [
     markPrice,
     positionSize.amount,
-    maxBuyTradeSize,
-    maxSellTradeSize,
-    reduceOnly,
     tradeSize,
     currentMarketData,
     percentage,
@@ -500,7 +484,14 @@ export const MarketTradingContainer: React.FC<TradingContainerProps> = () => {
     }
   );
 
+  const checkDirectionMax = useDirectionMaxGate({
+    positionSize,
+    maxBuyTradeSize,
+    maxSellTradeSize,
+  });
+
   const handleSubmitClick = useMemoizedFn((isBuy: boolean) => {
+    if (!checkDirectionMax(isBuy)) return;
     // Keep the direction-specific TP/SL check ahead of the dialog: otherwise the
     // user would confirm an order that can only fail validation.
     if (!validateTpslForDirection(isBuy)) return;

--- a/src/ui/views/DesktopPerps/components/TradingPanel/containers/TWAPTradingContainer.tsx
+++ b/src/ui/views/DesktopPerps/components/TradingPanel/containers/TWAPTradingContainer.tsx
@@ -14,6 +14,7 @@ import stats from '@/stats';
 import { formatPerpsCoin, getStatsReportSide } from '../../../utils';
 import { BigNumber } from 'bignumber.js';
 import { calcAmountFromPercentage } from '../utils';
+import { useDirectionMaxGate } from '../hooks/useDirectionMaxGate';
 import clsx from 'clsx';
 import { splitNumberByStep } from '@/ui/utils';
 import {
@@ -160,7 +161,7 @@ export const TWAPTradingContainer: React.FC<TradingContainerProps> = () => {
     return { ...info, max: maxSellTradeSize || '0' };
   }, [calcDirectionInfo, sellTradeSize, maxSellTradeSize]);
 
-  // Shared validation (direction-agnostic)
+  // Shared validation (direction-agnostic; the per-side max gate lives at the buttons)
   const validation = useMemo(() => {
     const size = Number(positionSize.amount) || 0;
     const notionalNum = size * midPrice;
@@ -197,22 +198,6 @@ export const TWAPTradingContainer: React.FC<TradingContainerProps> = () => {
       };
     }
 
-    // Max trade size - use max of both directions (shared check)
-    const effectiveMaxTradeSize = reduceOnly
-      ? Number(
-          (currentPosition?.side === 'Long'
-            ? maxSellTradeSize
-            : maxBuyTradeSize) || 0
-        )
-      : Math.max(Number(maxBuyTradeSize || 0), Number(maxSellTradeSize || 0));
-
-    if (effectiveMaxTradeSize > 0 && size > effectiveMaxTradeSize) {
-      return {
-        isValid: false,
-        error: t('page.perpsPro.tradingPanel.insufficientBalance'),
-      };
-    }
-
     const maxUsdValue = Number(currentMarketData?.maxUsdValueSize || 1000000);
     if (notionalNum > maxUsdValue) {
       return {
@@ -230,13 +215,15 @@ export const TWAPTradingContainer: React.FC<TradingContainerProps> = () => {
     midPrice,
     allMinsDuration,
     sizePerSuborder,
-    maxBuyTradeSize,
-    maxSellTradeSize,
-    reduceOnly,
-    currentPosition,
     currentMarketData,
     t,
   ]);
+
+  const checkDirectionMax = useDirectionMaxGate({
+    positionSize,
+    maxBuyTradeSize,
+    maxSellTradeSize,
+  });
 
   const {
     handleOpenTWAPOrder,
@@ -400,6 +387,7 @@ export const TWAPTradingContainer: React.FC<TradingContainerProps> = () => {
   );
 
   const handleOrderClick = useMemoizedFn((isBuy: boolean) => {
+    if (!checkDirectionMax(isBuy)) return;
     const order = buildOrder(isBuy);
     // The submit request reports its own failures, so drop the rejection here.
     Promise.resolve(

--- a/src/ui/views/DesktopPerps/components/TradingPanel/containers/TakeOrStopLimitTradingContainer.tsx
+++ b/src/ui/views/DesktopPerps/components/TradingPanel/containers/TakeOrStopLimitTradingContainer.tsx
@@ -18,6 +18,7 @@ import { BigNumber } from 'bignumber.js';
 import stats from '@/stats';
 import { getStatsReportSide } from '../../../utils';
 import { calcAmountFromPercentage } from '../utils';
+import { useDirectionMaxGate } from '../hooks/useDirectionMaxGate';
 import perpsToast from '../../PerpsToast';
 import { splitNumberByStep } from '@/ui/utils';
 import { useOrderConfirm } from '../../../modal/OrderConfirmProvider';
@@ -206,7 +207,8 @@ export const TakeOrStopLimitTradingContainer: React.FC<TakeOrStopLimitTradingCon
 
   const isStopLoss = takeOrStop === 'sl';
 
-  // Form validation (direction-agnostic, trigger price direction check moved to button click)
+  // Form validation (direction-agnostic, trigger price direction check moved to
+  // button click; the per-side max gate lives at the buttons)
   const validation = useMemo(() => {
     const tradeSize = Number(positionSize.amount) || 0;
     const notionalNum = tradeSize * estPrice;
@@ -231,25 +233,6 @@ export const TakeOrStopLimitTradingContainer: React.FC<TakeOrStopLimitTradingCon
       };
     }
 
-    // Max trade size check - use limitMax values with reduceOnly awareness
-    const effectiveMaxTradeSize = reduceOnly
-      ? Number(
-          (currentPosition?.side === 'Long'
-            ? limitMaxSellTradeSize
-            : limitMaxBuyTradeSize) || 0
-        )
-      : Math.max(
-          Number(limitMaxBuyTradeSize || 0),
-          Number(limitMaxSellTradeSize || 0)
-        );
-
-    if (effectiveMaxTradeSize > 0 && tradeSize > effectiveMaxTradeSize) {
-      return {
-        isValid: false,
-        error: t('page.perpsPro.tradingPanel.insufficientBalance'),
-      };
-    }
-
     // Max USD value check
     const maxUsdValue = Number(currentMarketData?.maxUsdValueSize || 1000000);
     if (notionalNum > maxUsdValue) {
@@ -268,13 +251,15 @@ export const TakeOrStopLimitTradingContainer: React.FC<TakeOrStopLimitTradingCon
     limitPrice,
     triggerPrice,
     estPrice,
-    limitMaxBuyTradeSize,
-    limitMaxSellTradeSize,
-    reduceOnly,
-    currentPosition,
     currentMarketData,
     t,
   ]);
+
+  const checkDirectionMax = useDirectionMaxGate({
+    positionSize,
+    maxBuyTradeSize: limitMaxBuyTradeSize,
+    maxSellTradeSize: limitMaxSellTradeSize,
+  });
 
   const {
     handleOpenTPSlLimitOrder,
@@ -418,6 +403,7 @@ export const TakeOrStopLimitTradingContainer: React.FC<TakeOrStopLimitTradingCon
   const requestConfirm = useOrderConfirm();
 
   const handlePlaceOrder = useMemoizedFn((isBuy: boolean) => {
+    if (!checkDirectionMax(isBuy)) return;
     const order = buildOrder(isBuy);
     if (!checkTriggerDirection(isBuy, order.triggerPx)) return;
     // The entry is the limit price the user typed, so the liquidation price is

--- a/src/ui/views/DesktopPerps/components/TradingPanel/containers/TakeOrStopMarketTradingContainer.tsx
+++ b/src/ui/views/DesktopPerps/components/TradingPanel/containers/TakeOrStopMarketTradingContainer.tsx
@@ -17,6 +17,7 @@ import stats from '@/stats';
 import { getStatsReportSide } from '../../../utils';
 import { BigNumber } from 'bignumber.js';
 import { calcAmountFromPercentage } from '../utils';
+import { useDirectionMaxGate } from '../hooks/useDirectionMaxGate';
 import perpsToast from '../../PerpsToast';
 import { useOrderConfirm } from '../../../modal/OrderConfirmProvider';
 import { LiveLiquidation } from '../../../modal/OrderConfirmLiveValues';
@@ -86,7 +87,7 @@ export const TakeOrStopMarketTradingContainer: React.FC<TakeOrStopMarketTradingC
 
   const isStopLoss = takeOrStop === 'sl';
 
-  // Form validation (direction-agnostic)
+  // Form validation (direction-agnostic; the per-side max gate lives at the buttons)
   const validation = useMemo(() => {
     const tradeSize = Number(positionSize.amount) || 0;
     const notionalNum = tradeSize * Number(markPrice || 0);
@@ -107,22 +108,6 @@ export const TakeOrStopMarketTradingContainer: React.FC<TakeOrStopMarketTradingC
       };
     }
 
-    // Check max trade size with reduceOnly awareness
-    const effectiveMaxTradeSize = reduceOnly
-      ? Number(
-          (currentPosition?.side === 'Long'
-            ? maxSellTradeSize
-            : maxBuyTradeSize) || 0
-        )
-      : Math.max(Number(maxBuyTradeSize || 0), Number(maxSellTradeSize || 0));
-
-    if (effectiveMaxTradeSize > 0 && tradeSize > effectiveMaxTradeSize) {
-      return {
-        isValid: false,
-        error: t('page.perpsPro.tradingPanel.insufficientBalance'),
-      };
-    }
-
     // Check maximum position size
     const maxUsdValue = Number(currentMarketData?.maxUsdValueSize || 1000000);
     if (notionalNum > maxUsdValue) {
@@ -136,17 +121,13 @@ export const TakeOrStopMarketTradingContainer: React.FC<TakeOrStopMarketTradingC
     }
 
     return { isValid: true, error: '' };
-  }, [
-    positionSize.amount,
-    markPrice,
+  }, [positionSize.amount, markPrice, currentMarketData, triggerPrice, t]);
+
+  const checkDirectionMax = useDirectionMaxGate({
+    positionSize,
     maxBuyTradeSize,
     maxSellTradeSize,
-    reduceOnly,
-    currentPosition,
-    currentMarketData,
-    triggerPrice,
-    t,
-  ]);
+  });
 
   const {
     handleOpenTPSlMarketOrder,
@@ -268,6 +249,7 @@ export const TakeOrStopMarketTradingContainer: React.FC<TakeOrStopMarketTradingC
   const requestConfirm = useOrderConfirm();
 
   const handlePlaceOrder = useMemoizedFn((isBuy: boolean) => {
+    if (!checkDirectionMax(isBuy)) return;
     const order = buildOrder(isBuy);
     if (!checkTriggerDirection(isBuy, order.triggerPx)) return;
     // Whether the liquidation rows exist is settled at click time — the panel

--- a/src/ui/views/DesktopPerps/components/TradingPanel/hooks/useDirectionMaxGate.ts
+++ b/src/ui/views/DesktopPerps/components/TradingPanel/hooks/useDirectionMaxGate.ts
@@ -1,0 +1,40 @@
+import { useMemoizedFn } from 'ahooks';
+import { useTranslation } from 'react-i18next';
+import type { PositionSize } from '../../../types';
+import perpsToast from '../../PerpsToast';
+import { exceedsDirectionMax } from '../utils';
+
+/**
+ * Click-time gate for the per-direction max trade size.
+ *
+ * With a position open the closing direction's max includes the closable size,
+ * so buy and sell gate on different maxes. Enforced with a toast at click time
+ * instead of disabling the button — a disabled pair plus the shared banner
+ * would read as "neither side affordable" when only one side exceeds its max.
+ *
+ * Returns a checker for the click handler: `false` means the order was blocked
+ * and toasted, `true` means proceed.
+ */
+export const useDirectionMaxGate = ({
+  positionSize,
+  maxBuyTradeSize,
+  maxSellTradeSize,
+}: {
+  positionSize: PositionSize;
+  maxBuyTradeSize: string | number | undefined;
+  maxSellTradeSize: string | number | undefined;
+}) => {
+  const { t } = useTranslation();
+  const buyMaxExceeded = exceedsDirectionMax(positionSize, maxBuyTradeSize);
+  const sellMaxExceeded = exceedsDirectionMax(positionSize, maxSellTradeSize);
+  return useMemoizedFn((isBuy: boolean) => {
+    if (isBuy ? buyMaxExceeded : sellMaxExceeded) {
+      perpsToast.error({
+        title: t('page.perps.toast.orderError'),
+        description: t('page.perpsPro.tradingPanel.insufficientBalance'),
+      });
+      return false;
+    }
+    return true;
+  });
+};

--- a/src/ui/views/DesktopPerps/components/TradingPanel/utils.ts
+++ b/src/ui/views/DesktopPerps/components/TradingPanel/utils.ts
@@ -1,5 +1,6 @@
 import { formatUsdValue } from '@/ui/utils/number';
 import { BigNumber } from 'bignumber.js';
+import type { PositionSize } from '../../types';
 
 export const calcAssetAmountByNotional = (
   notional: string | number,
@@ -63,6 +64,24 @@ export const calcAmountFromPercentage = (
     .div(100)
     .toFixed(szDecimals, BigNumber.ROUND_DOWN);
   return Number(amount) > 0 ? amount : '0';
+};
+
+/**
+ * Whether the typed size exceeds one direction's max trade size.
+ *
+ * With a position open the closing direction's max includes the closable
+ * size, so buy and sell gate on different limits — each button must check
+ * its own side. Slider input is exempt: its per-direction size is derived
+ * from that side's max and can never exceed it. A max of 0 means "unknown
+ * or not tradable" and is left to other gates (e.g. the reduce-only locks).
+ */
+export const exceedsDirectionMax = (
+  positionSize: PositionSize,
+  directionMax: string | number | undefined
+): boolean => {
+  if (positionSize.inputSource === 'slider') return false;
+  const max = Number(directionMax || 0);
+  return max > 0 && (Number(positionSize.amount) || 0) > max;
 };
 
 export function removeTrailingZeros(value: string): string {

--- a/src/ui/views/DesktopPerps/components/UserInfoHistory/Assets/index.tsx
+++ b/src/ui/views/DesktopPerps/components/UserInfoHistory/Assets/index.tsx
@@ -28,7 +28,11 @@ interface AssetRow {
 
 export const Assets: React.FC = () => {
   const { t } = useTranslation();
-  const { isUnifiedAccount, spotBalancesMap } = usePerpsAccount();
+  const {
+    isUnifiedAccount,
+    isPortfolioMargin,
+    spotBalancesMap,
+  } = usePerpsAccount();
   const clearinghouseState = useRabbySelector(
     (s) => s.perps.clearinghouseState
   );
@@ -41,7 +45,7 @@ export const Assets: React.FC = () => {
   const { openPerpsPopup } = usePerpsPopupNav();
 
   const rows = useMemo<AssetRow[]>(() => {
-    if (!isUnifiedAccount) {
+    if (!isUnifiedAccount && !isPortfolioMargin) {
       const spotUsdc = rawSpotBalancesMap[getSpotBalanceKey('USDC')];
       const spotTotal = Number(spotUsdc?.total || 0);
       const spotAvailable = Number(spotUsdc?.available || 0);

--- a/src/ui/views/DesktopPerps/components/UserInfoHistory/Assets/index.tsx
+++ b/src/ui/views/DesktopPerps/components/UserInfoHistory/Assets/index.tsx
@@ -87,6 +87,7 @@ export const Assets: React.FC = () => {
     });
   }, [
     isUnifiedAccount,
+    isPortfolioMargin,
     spotBalancesMap,
     rawSpotBalancesMap,
     clearinghouseState,

--- a/src/ui/views/DesktopPerps/hooks/usePerpsTradingState.ts
+++ b/src/ui/views/DesktopPerps/hooks/usePerpsTradingState.ts
@@ -303,6 +303,10 @@ export const usePerpsTradingState = ({ readOnly = false } = {}) => {
         maxLeverage,
         pxDecimals,
         side: direction === 'Long' ? 'buy' : 'sell',
+        // The pro panel keeps quoting while the typed size exceeds what the
+        // balance can fund (submission is blocked elsewhere), so price the
+        // order as if the margin were there instead of showing `-`.
+        assumeSufficientMargin: true,
       });
       if (!projected) {
         return { liqPrice: '-', liqPriceNum: null, cost };

--- a/src/ui/views/DesktopPerps/modal/ClosePositionModal.tsx
+++ b/src/ui/views/DesktopPerps/modal/ClosePositionModal.tsx
@@ -1,11 +1,11 @@
 import { MarketData } from '@/ui/models/perps';
 import { useRabbyDispatch, useRabbySelector } from '@/ui/store';
 import { formatUsdValue, splitNumberByStep } from '@/ui/utils';
-import { useMemoizedFn, useRequest } from 'ahooks';
+import { useMemoizedFn } from 'ahooks';
 import { Button, Modal } from 'antd';
 import BigNumber from 'bignumber.js';
 import clsx from 'clsx';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as RcIconCloseCC } from 'ui/assets/component/close-cc.svg';
 import { DesktopPerpsInput } from '../components/DesktopPerpsInput';
@@ -227,13 +227,39 @@ const ClosePositionModalContent: React.FC<Omit<Props, 'visible'>> = ({
     }
   });
 
-  const { loading, runAsync: runSubmit } = useRequest(doSubmit, {
-    manual: true,
-    onSuccess: () => {
+  const inFlightRef = useRef(false);
+  const [loading, setLoading] = useState(false);
+
+  /**
+   * The single submit path for both buttons, and the only in-flight guard.
+   *
+   * Deliberately not `useRequest`: ahooks cancels an in-flight `runAsync` when
+   * this content unmounts (a WS position update can remove the position — and
+   * with it this modal — before the order response returns), and a cancelled
+   * `runAsync` returns a promise that never settles, deadlocking the confirm
+   * dialog in its submitting state.
+   *
+   * The ref matters because the dialog is not always there to block a second
+   * click: when the user has opted out of the confirmation for this order
+   * type, `requestConfirm` submits immediately with no dialog and no mask, so
+   * without it a double click sends two close orders.
+   */
+  const runSubmit = useMemoizedFn(async () => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setLoading(true);
+    try {
+      await doSubmit();
       // ClearinghouseState is refreshed inside the handlers (single-dex path).
       dispatch.perps.fetchUserHistoricalOrders();
       onConfirm?.();
-    },
+    } catch (e) {
+      // Swallowed on purpose: the handlers report their own failures, and the
+      // confirm dialog's `await` has to settle either way.
+    } finally {
+      inFlightRef.current = false;
+      setLoading(false);
+    }
   });
 
   const handleMidClick = () => {
@@ -371,17 +397,9 @@ const ClosePositionModalContent: React.FC<Omit<Props, 'visible'>> = ({
         orderType: t(`page.perpsPro.orderConfirm.orderTypeName.${confirmType}`),
       }),
       // Returned so the dialog can show loading while the order is in flight.
-      // Not `runSubmit`: ahooks cancels an in-flight `runAsync` when this
-      // content unmounts (a WS position update can remove the position — and
-      // with it this modal — before the order response returns), and a
-      // cancelled `runAsync` returns a promise that never settles, deadlocking
-      // the confirm dialog in its submitting state. A plain call always
-      // settles; `dispatch` and the parent's `onConfirm` survive the unmount.
-      submit: async () => {
-        await doSubmit();
-        dispatch.perps.fetchUserHistoricalOrders();
-        onConfirm?.();
-      },
+      // `runSubmit` always settles and carries the in-flight guard the
+      // opted-out (no-dialog) path has nothing else to fall back on.
+      submit: () => runSubmit(),
     });
   });
 

--- a/src/ui/views/DesktopPerps/modal/ClosePositionModal.tsx
+++ b/src/ui/views/DesktopPerps/modal/ClosePositionModal.tsx
@@ -138,106 +138,103 @@ const ClosePositionModalContent: React.FC<Omit<Props, 'visible'>> = ({
     handleCloseWithMarketOrder,
   } = usePerpsProPosition();
 
-  const { loading, runAsync: runSubmit } = useRequest(
-    async () => {
-      const isBuy = position.direction === 'Short';
-      const size = new BigNumber(positionSize.amount).toFixed(
-        marketData.szDecimals
-      );
-      if (type === 'limit') {
-        const price = new BigNumber(limitPrice).toFixed(marketData.pxDecimals);
-        await handleOpenLimitOrder({
-          coin: position.coin,
-          dex: marketData.dexId ?? '',
-          isBuy,
-          size,
-          limitPx: price,
-          reduceOnly: true,
-        });
+  const doSubmit = useMemoizedFn(async () => {
+    const isBuy = position.direction === 'Short';
+    const size = new BigNumber(positionSize.amount).toFixed(
+      marketData.szDecimals
+    );
+    if (type === 'limit') {
+      const price = new BigNumber(limitPrice).toFixed(marketData.pxDecimals);
+      await handleOpenLimitOrder({
+        coin: position.coin,
+        dex: marketData.dexId ?? '',
+        isBuy,
+        size,
+        limitPx: price,
+        reduceOnly: true,
+      });
+      stats.report('perpsTradeHistory', {
+        created_at: new Date().getTime(),
+        user_addr: currentPerpsAccount?.address || '',
+        trade_type: 'close limit',
+        leverage: position.leverage.toString(),
+        trade_side: getStatsReportSide(isBuy, true),
+        margin_mode: position.type === 'cross' ? 'cross' : 'isolated',
+        coin: position.coin,
+        size,
+        price,
+        trade_usd_value: new BigNumber(price).times(size).toFixed(2),
+        service_provider: 'hyperliquid',
+        app_version: process.env.release || '0',
+        address_type: currentPerpsAccount?.type || '',
+      });
+    } else if (type === 'market') {
+      const res = await handleCloseWithMarketOrder({
+        coin: position.coin,
+        dex: marketData.dexId ?? '',
+        isBuy,
+        size: new BigNumber(positionSize.amount).toFixed(marketData.szDecimals),
+        midPx: marketPrice,
+        reduceOnly: true,
+      });
+      if (res) {
+        const { totalSz, avgPx } = res;
         stats.report('perpsTradeHistory', {
           created_at: new Date().getTime(),
           user_addr: currentPerpsAccount?.address || '',
-          trade_type: 'close limit',
+          trade_type: 'close market',
           leverage: position.leverage.toString(),
           trade_side: getStatsReportSide(isBuy, true),
           margin_mode: position.type === 'cross' ? 'cross' : 'isolated',
           coin: position.coin,
-          size,
-          price,
-          trade_usd_value: new BigNumber(price).times(size).toFixed(2),
+          size: totalSz,
+          price: avgPx,
+          trade_usd_value: new BigNumber(avgPx).times(totalSz).toFixed(2),
           service_provider: 'hyperliquid',
           app_version: process.env.release || '0',
           address_type: currentPerpsAccount?.type || '',
         });
-      } else if (type === 'market') {
-        const res = await handleCloseWithMarketOrder({
-          coin: position.coin,
-          dex: marketData.dexId ?? '',
-          isBuy,
-          size: new BigNumber(positionSize.amount).toFixed(
-            marketData.szDecimals
-          ),
-          midPx: marketPrice,
-          reduceOnly: true,
-        });
-        if (res) {
-          const { totalSz, avgPx } = res;
-          stats.report('perpsTradeHistory', {
-            created_at: new Date().getTime(),
-            user_addr: currentPerpsAccount?.address || '',
-            trade_type: 'close market',
-            leverage: position.leverage.toString(),
-            trade_side: getStatsReportSide(isBuy, true),
-            margin_mode: position.type === 'cross' ? 'cross' : 'isolated',
-            coin: position.coin,
-            size: totalSz,
-            price: avgPx,
-            trade_usd_value: new BigNumber(avgPx).times(totalSz).toFixed(2),
-            service_provider: 'hyperliquid',
-            app_version: process.env.release || '0',
-            address_type: currentPerpsAccount?.type || '',
-          });
-        }
-      } else if (type === 'reverse') {
-        const res = await handleCloseWithMarketOrder({
-          coin: position.coin,
-          dex: marketData.dexId ?? '',
-          isBuy,
-          size: new BigNumber(position.size || 0)
-            .times(2)
-            .toFixed(marketData.szDecimals),
-          midPx: marketPrice,
-          reduceOnly: false,
-        });
-        if (res) {
-          const { totalSz, avgPx } = res;
-          stats.report('perpsTradeHistory', {
-            created_at: new Date().getTime(),
-            user_addr: currentPerpsAccount?.address || '',
-            trade_type: 'reverse market',
-            leverage: position.leverage.toString(),
-            trade_side: getStatsReportSide(isBuy, false),
-            margin_mode: position.type === 'cross' ? 'cross' : 'isolated',
-            coin: position.coin,
-            size: totalSz,
-            price: avgPx,
-            trade_usd_value: new BigNumber(avgPx).times(totalSz).toFixed(2),
-            service_provider: 'hyperliquid',
-            app_version: process.env.release || '0',
-            address_type: currentPerpsAccount?.type || '',
-          });
-        }
       }
-    },
-    {
-      manual: true,
-      onSuccess: () => {
-        // ClearinghouseState is refreshed inside the handlers (single-dex path).
-        dispatch.perps.fetchUserHistoricalOrders();
-        onConfirm?.();
-      },
+    } else if (type === 'reverse') {
+      const res = await handleCloseWithMarketOrder({
+        coin: position.coin,
+        dex: marketData.dexId ?? '',
+        isBuy,
+        size: new BigNumber(position.size || 0)
+          .times(2)
+          .toFixed(marketData.szDecimals),
+        midPx: marketPrice,
+        reduceOnly: false,
+      });
+      if (res) {
+        const { totalSz, avgPx } = res;
+        stats.report('perpsTradeHistory', {
+          created_at: new Date().getTime(),
+          user_addr: currentPerpsAccount?.address || '',
+          trade_type: 'reverse market',
+          leverage: position.leverage.toString(),
+          trade_side: getStatsReportSide(isBuy, false),
+          margin_mode: position.type === 'cross' ? 'cross' : 'isolated',
+          coin: position.coin,
+          size: totalSz,
+          price: avgPx,
+          trade_usd_value: new BigNumber(avgPx).times(totalSz).toFixed(2),
+          service_provider: 'hyperliquid',
+          app_version: process.env.release || '0',
+          address_type: currentPerpsAccount?.type || '',
+        });
+      }
     }
-  );
+  });
+
+  const { loading, runAsync: runSubmit } = useRequest(doSubmit, {
+    manual: true,
+    onSuccess: () => {
+      // ClearinghouseState is refreshed inside the handlers (single-dex path).
+      dispatch.perps.fetchUserHistoricalOrders();
+      onConfirm?.();
+    },
+  });
 
   const handleMidClick = () => {
     setLimitPrice(
@@ -374,7 +371,17 @@ const ClosePositionModalContent: React.FC<Omit<Props, 'visible'>> = ({
         orderType: t(`page.perpsPro.orderConfirm.orderTypeName.${confirmType}`),
       }),
       // Returned so the dialog can show loading while the order is in flight.
-      submit: () => runSubmit(),
+      // Not `runSubmit`: ahooks cancels an in-flight `runAsync` when this
+      // content unmounts (a WS position update can remove the position — and
+      // with it this modal — before the order response returns), and a
+      // cancelled `runAsync` returns a promise that never settles, deadlocking
+      // the confirm dialog in its submitting state. A plain call always
+      // settles; `dispatch` and the parent's `onConfirm` survive the unmount.
+      submit: async () => {
+        await doSubmit();
+        dispatch.perps.fetchUserHistoricalOrders();
+        onConfirm?.();
+      },
     });
   });
 

--- a/src/ui/views/DesktopPerps/modal/TransferToPerpsModal.tsx
+++ b/src/ui/views/DesktopPerps/modal/TransferToPerpsModal.tsx
@@ -59,7 +59,6 @@ export const TransferToPerpsModal: React.FC<TransferToPerpsModalProps> = ({
   const balanceBN = useMemo(() => new BigNumber(spotUsdc?.available || 0), [
     spotUsdc?.available,
   ]);
-  const balanceNum = useMemo(() => balanceBN.toNumber(), [balanceBN]);
 
   const amountBN = useMemo(() => new BigNumber(amount || 0), [amount]);
 
@@ -236,7 +235,9 @@ export const TransferToPerpsModal: React.FC<TransferToPerpsModalProps> = ({
               </span>
               <span className="text-rb-neutral-foot text-13">
                 {t('page.perps.PerpsTransferToPerps.balance')}:
-                {balanceNum.toFixed(2)} USDC
+                {/* Floored, not rounded: a rounded-up balance reads as an
+                    amount the account cannot actually transfer. */}
+                {balanceBN.toFixed(2, BigNumber.ROUND_DOWN)} USDC
               </span>
             </div>
             <div className="bg-rb-neutral-bg-2 rounded-[12px] px-16 py-14 mb-16">

--- a/src/ui/views/DesktopProfile/components/TokensTabPane/ProtocolList.tsx
+++ b/src/ui/views/DesktopProfile/components/TokensTabPane/ProtocolList.tsx
@@ -14,7 +14,6 @@ import { useCurrentAccount } from '@/ui/hooks/backgroundState/useAccount';
 import { ReactComponent as RcIconDropdown } from '@/ui/assets/dashboard/dropdown-cc.svg';
 import * as PortfolioTemplate from './Protocols/template';
 import { RcIconExternal1CC } from '@/ui/assets/desktop/common';
-import { useRabbyDispatch } from '@/ui/store';
 import { useRequest } from 'ahooks';
 import { checkPerpsReference } from '@/ui/views/Perps/utils';
 import { useSticky } from '@/ui/hooks/useSticky';
@@ -132,7 +131,6 @@ const ProtocolItem = ({
   const { t } = useTranslation();
   const currentAccount = useCurrentAccount();
   const wallet = useWallet();
-  const dispatch = useRabbyDispatch();
   const [
     realTimeProtocol,
     setRealTimeProtocol,
@@ -205,10 +203,14 @@ const ProtocolItem = ({
             onClick={(evt) => {
               evt.stopPropagation();
               if (protocol.id === 'hyperliquid') {
-                dispatch.perps.resetProAccountInfo();
-                dispatch.perps.setCurrentPerpsAccount(currentAccount);
+                // The Perps page lives in its own desktop tab with its own
+                // store, so it learns the account through the background
+                // (`switchDesktopPerpsAccount` broadcasts it) — dispatching
+                // into this tab's perps slice would only reset the page the
+                // user is leaving behind.
+                if (!currentAccount) return;
                 wallet.setPerpsCurrentAccount(currentAccount);
-                wallet.switchDesktopPerpsAccount(currentAccount!);
+                wallet.switchDesktopPerpsAccount(currentAccount);
                 wallet.openInDesktop('/desktop/perps');
               } else {
                 openInTab(protocol.site_url, false);

--- a/src/ui/views/DesktopProfile/components/TokensTabPane/ProtocolList.tsx
+++ b/src/ui/views/DesktopProfile/components/TokensTabPane/ProtocolList.tsx
@@ -14,7 +14,7 @@ import { useCurrentAccount } from '@/ui/hooks/backgroundState/useAccount';
 import { ReactComponent as RcIconDropdown } from '@/ui/assets/dashboard/dropdown-cc.svg';
 import * as PortfolioTemplate from './Protocols/template';
 import { RcIconExternal1CC } from '@/ui/assets/desktop/common';
-import { PERPS_INVITE_URL } from '@/ui/views/Perps/constants';
+import { useRabbyDispatch } from '@/ui/store';
 import { useRequest } from 'ahooks';
 import { checkPerpsReference } from '@/ui/views/Perps/utils';
 import { useSticky } from '@/ui/hooks/useSticky';
@@ -132,6 +132,7 @@ const ProtocolItem = ({
   const { t } = useTranslation();
   const currentAccount = useCurrentAccount();
   const wallet = useWallet();
+  const dispatch = useRabbyDispatch();
   const [
     realTimeProtocol,
     setRealTimeProtocol,
@@ -203,12 +204,15 @@ const ProtocolItem = ({
             className="ml-[10px] flex items-center"
             onClick={(evt) => {
               evt.stopPropagation();
-              openInTab(
-                protocol.id === 'hyperliquid' && isShowPerpsInvite
-                  ? PERPS_INVITE_URL
-                  : protocol.site_url,
-                false
-              );
+              if (protocol.id === 'hyperliquid') {
+                dispatch.perps.resetProAccountInfo();
+                dispatch.perps.setCurrentPerpsAccount(currentAccount);
+                wallet.setPerpsCurrentAccount(currentAccount);
+                wallet.switchDesktopPerpsAccount(currentAccount!);
+                wallet.openInDesktop('/desktop/perps');
+              } else {
+                openInTab(protocol.site_url, false);
+              }
             }}
           >
             {protocol.id === 'hyperliquid' && isShowPerpsInvite ? (

--- a/src/ui/views/Perps/components/PositionItem.tsx
+++ b/src/ui/views/Perps/components/PositionItem.tsx
@@ -125,7 +125,7 @@ export const PositionItem: React.FC<{
               className="text-15 ml-4 font-medium"
             />
           </div>
-          <div className="flex items-center gap-6">
+          <div className="flex items-center gap-6 relative">
             <span
               className={clsx(
                 'text-[12px] font-medium px-4 h-[18px] flex items-center justify-center rounded-[4px]',

--- a/src/ui/views/Perps/components/SelectAddressList.tsx
+++ b/src/ui/views/Perps/components/SelectAddressList.tsx
@@ -321,7 +321,7 @@ function AccountItem(props: {
       );
     }
     return (
-      <div className="flex flex-col gap-[4px] items-end ml-auto">
+      <div className="flex flex-col gap-[4px] items-end ml-auto flex-shrink-0">
         <div className="text-[13px] leading-[16px] text-r-neutral-body font-medium">
           {info ? formatUsdValue(Number(info?.withdrawable || 0)) : ''}
         </div>
@@ -360,16 +360,16 @@ function AccountItem(props: {
         />
       }
     >
-      <div className="ml-10">
+      <div className="ml-10 flex-1 min-w-0">
         <div className="flex items-center gap-[4px]">
           <div
             className={clsx(
-              'text-r-neutral-title1 font-medium leading-[16px] text-[13px]'
+              'text-r-neutral-title1 font-medium leading-[16px] text-[13px] truncate'
             )}
           >
             {alias}
           </div>
-          <div>
+          <div className="flex-shrink-0">
             {isCurrent ? (
               <RcIconChecked className="text-r-green-default w-[16px] h-[16px]" />
             ) : isLogin ? null : isLastUsed ? (

--- a/src/ui/views/Perps/liquidation.ts
+++ b/src/ui/views/Perps/liquidation.ts
@@ -132,6 +132,7 @@ export const resolveProjectedLiquidationPrice = ({
   maxLeverage,
   pxDecimals,
   side,
+  assumeSufficientMargin,
 }: {
   /** Order size in the base asset. */
   baseSize: string;
@@ -144,6 +145,16 @@ export const resolveProjectedLiquidationPrice = ({
   maxLeverage: number;
   pxDecimals: number;
   side: 'buy' | 'sell';
+  /**
+   * Floor the cross balance at the projected position's own initial margin
+   * (notional / leverage). With a balance shortfall the real balance prices
+   * liquidation on top of the entry, or hides the estimate entirely; with this
+   * flag the estimate is the one the order would have if it were affordable —
+   * for surfaces that keep quoting while the order is unaffordable. A
+   * sufficient balance is never lowered, an unavailable one (null) still fails
+   * closed, and isolated margin already charges the order's own margin.
+   */
+  assumeSufficientMargin?: boolean;
 }): { liquidationPrice: string; liquidationPriceNum: number } | null => {
   const entry = positiveBn(entryPrice);
   const orderSize = positiveBn(baseSize);
@@ -189,7 +200,7 @@ export const resolveProjectedLiquidationPrice = ({
   const basePrice = isCross ? entry : projectedEntry;
   const baseNotional = isCross ? projectedSize.multipliedBy(entry) : notional;
 
-  const margin = isCross
+  const backingMargin = isCross
     ? // The cross balance already has the existing position's maintenance
       // margin deducted, and `baseNotional` covers that same position — so the
       // formula would charge it a second time. Add it back to charge it once.
@@ -203,6 +214,12 @@ export const resolveProjectedLiquidationPrice = ({
         orderSize.multipliedBy(entry).dividedBy(leverageValue)
       )
     : notional.dividedBy(leverageValue);
+  // `isFinite` keeps the null-balance case failing closed: the floor only
+  // raises a real deficit, never invents a balance that couldn't be resolved.
+  const margin =
+    isCross && assumeSufficientMargin && backingMargin.isFinite()
+      ? BigNumber.maximum(backingMargin, baseNotional.dividedBy(leverageValue))
+      : backingMargin;
   if (!margin.isFinite() || margin.lte(0)) return null;
 
   const liquidation = calLiquidationPrice(

--- a/src/ui/views/Perps/liquidation.ts
+++ b/src/ui/views/Perps/liquidation.ts
@@ -146,13 +146,19 @@ export const resolveProjectedLiquidationPrice = ({
   pxDecimals: number;
   side: 'buy' | 'sell';
   /**
-   * Floor the cross balance at the projected position's own initial margin
-   * (notional / leverage). With a balance shortfall the real balance prices
-   * liquidation on top of the entry, or hides the estimate entirely; with this
-   * flag the estimate is the one the order would have if it were affordable —
-   * for surfaces that keep quoting while the order is unaffordable. A
-   * sufficient balance is never lowered, an unavailable one (null) still fails
-   * closed, and isolated margin already charges the order's own margin.
+   * Floor the cross balance at the initial margin of the size this order
+   * actually adds (net new size / leverage). With a balance shortfall the real
+   * balance prices liquidation on top of the entry, or hides the estimate
+   * entirely; with this flag the estimate is the one the order would have if it
+   * were affordable — for surfaces that keep quoting while the order is
+   * unaffordable. A sufficient balance is never lowered, an unavailable one
+   * (null) still fails closed, and isolated margin already charges the order's
+   * own margin.
+   *
+   * The floor is the *added* margin, not the merged position's: an existing
+   * position's margin is already real and carried by the cross balance, so
+   * flooring at the merged notional would invent margin for it too and quote a
+   * liquidation price far safer than the account's.
    */
   assumeSufficientMargin?: boolean;
 }): { liquidationPrice: string; liquidationPriceNum: number } | null => {
@@ -214,11 +220,20 @@ export const resolveProjectedLiquidationPrice = ({
         orderSize.multipliedBy(entry).dividedBy(leverageValue)
       )
     : notional.dividedBy(leverageValue);
+  // Only the size this order adds needs margin invented for it: growing a
+  // position adds `orderSize`, flipping one adds the whole post-flip position
+  // (`projectedSize`) since the old leg is closed out, and with no position the
+  // two are the same. Charging `baseNotional` instead would also fabricate
+  // margin for the existing leg, which the cross balance already backs.
+  const netNewSize = sameDirection ? orderSize : projectedSize;
   // `isFinite` keeps the null-balance case failing closed: the floor only
   // raises a real deficit, never invents a balance that couldn't be resolved.
   const margin =
     isCross && assumeSufficientMargin && backingMargin.isFinite()
-      ? BigNumber.maximum(backingMargin, baseNotional.dividedBy(leverageValue))
+      ? BigNumber.maximum(
+          backingMargin,
+          netNewSize.multipliedBy(entry).dividedBy(leverageValue)
+        )
       : backingMargin;
   if (!margin.isFinite() || margin.lte(0)) return null;
 

--- a/src/ui/views/Perps/liquidation.ts
+++ b/src/ui/views/Perps/liquidation.ts
@@ -158,7 +158,9 @@ export const resolveProjectedLiquidationPrice = ({
    * The floor is the *added* margin, not the merged position's: an existing
    * position's margin is already real and carried by the cross balance, so
    * flooring at the merged notional would invent margin for it too and quote a
-   * liquidation price far safer than the account's.
+   * liquidation price far safer than the account's. It is applied to the free
+   * balance before the existing leg's maintenance margin is added back, since
+   * that add-back is locked by the old leg and cannot fund this order.
    */
   assumeSufficientMargin?: boolean;
 }): { liquidationPrice: string; liquidationPriceNum: number } | null => {
@@ -206,35 +208,51 @@ export const resolveProjectedLiquidationPrice = ({
   const basePrice = isCross ? entry : projectedEntry;
   const baseNotional = isCross ? projectedSize.multipliedBy(entry) : notional;
 
-  const backingMargin = isCross
-    ? // The cross balance already has the existing position's maintenance
-      // margin deducted, and `baseNotional` covers that same position — so the
-      // formula would charge it a second time. Add it back to charge it once.
-      new BigNumber(crossMarginAvailableAfterMaintenance ?? Number.NaN).plus(
-        currentSize
-          .multipliedBy(entry)
-          .multipliedBy(new BigNumber(1).dividedBy(maxLeverage).dividedBy(2))
-      )
-    : sameDirection
-    ? new BigNumber(currentPosition?.marginUsed ?? 0).plus(
-        orderSize.multipliedBy(entry).dividedBy(leverageValue)
-      )
-    : notional.dividedBy(leverageValue);
+  const crossFree = new BigNumber(
+    crossMarginAvailableAfterMaintenance ?? Number.NaN
+  );
+  // The cross balance already has the existing position's maintenance margin
+  // deducted, and `baseNotional` covers that same position — so the formula
+  // would charge it a second time. Add it back to charge it once.
+  const crossMaintenanceAddBack = currentSize
+    .multipliedBy(entry)
+    .multipliedBy(new BigNumber(1).dividedBy(maxLeverage).dividedBy(2));
   // Only the size this order adds needs margin invented for it: growing a
   // position adds `orderSize`, flipping one adds the whole post-flip position
   // (`projectedSize`) since the old leg is closed out, and with no position the
   // two are the same. Charging `baseNotional` instead would also fabricate
   // margin for the existing leg, which the cross balance already backs.
-  const netNewSize = sameDirection ? orderSize : projectedSize;
+  const addedMargin = (sameDirection ? orderSize : projectedSize)
+    .multipliedBy(entry)
+    .dividedBy(leverageValue);
   // `isFinite` keeps the null-balance case failing closed: the floor only
   // raises a real deficit, never invents a balance that couldn't be resolved.
-  const margin =
-    isCross && assumeSufficientMargin && backingMargin.isFinite()
-      ? BigNumber.maximum(
-          backingMargin,
-          netNewSize.multipliedBy(entry).dividedBy(leverageValue)
-        )
-      : backingMargin;
+  const floorCross = assumeSufficientMargin && crossFree.isFinite();
+
+  // Flipping closes the old leg and releases its maintenance margin back into
+  // the balance, so the whole sum genuinely backs the new position.
+  const crossAfterRelease = crossFree.plus(crossMaintenanceAddBack);
+  const crossBacking = sameDirection
+    ? // Growing instead leaves that maintenance margin locked by the existing
+      // leg, where this order cannot spend it — so the floor has to land on the
+      // free balance underneath it. Flooring the sum would let a large enough
+      // add-back mask a deficit outright: 18 free against a 20 order reads as
+      // 20.5 and is never topped up.
+      (floorCross
+        ? BigNumber.maximum(crossFree, addedMargin)
+        : crossFree
+      ).plus(crossMaintenanceAddBack)
+    : floorCross
+    ? BigNumber.maximum(crossAfterRelease, addedMargin)
+    : crossAfterRelease;
+
+  const margin = isCross
+    ? crossBacking
+    : sameDirection
+    ? new BigNumber(currentPosition?.marginUsed ?? 0).plus(
+        orderSize.multipliedBy(entry).dividedBy(leverageValue)
+      )
+    : notional.dividedBy(leverageValue);
   if (!margin.isFinite() || margin.lte(0)) return null;
 
   const liquidation = calLiquidationPrice(

--- a/src/ui/views/Perps/liquidation.ts
+++ b/src/ui/views/Perps/liquidation.ts
@@ -238,10 +238,9 @@ export const resolveProjectedLiquidationPrice = ({
       // free balance underneath it. Flooring the sum would let a large enough
       // add-back mask a deficit outright: 18 free against a 20 order reads as
       // 20.5 and is never topped up.
-      (floorCross
-        ? BigNumber.maximum(crossFree, addedMargin)
-        : crossFree
-      ).plus(crossMaintenanceAddBack)
+      (floorCross ? BigNumber.maximum(crossFree, addedMargin) : crossFree).plus(
+        crossMaintenanceAddBack
+      )
     : floorCross
     ? BigNumber.maximum(crossAfterRelease, addedMargin)
     : crossAfterRelease;


### PR DESCRIPTION
This pull request refactors how maximum trade size checks are handled across the perps trading UI, moving from shared, direction-agnostic validation logic to per-direction checks that are applied at the point of order submission. The main change is the adoption of a new `useDirectionMaxGate` hook, which enforces buy/sell-specific maximum trade size limits directly within each trading container's order placement handler. This results in cleaner validation logic and more accurate enforcement of trading constraints for each order direction.

**Trading logic improvements:**

- Replaced shared max trade size checks in form validation with per-direction checks using the new `useDirectionMaxGate` hook in all trading containers, including Limit, Market, TWAP, Take/Stop Limit, and Take/Stop Market. The hook is now imported and called in each relevant file, and the old validation logic that used a single effective max value has been removed. [[1]](diffhunk://#diff-5800c74efd60587593df3ec8cc90ff992dc062f94c9d232d665d27f2bdb8e32dR35) [[2]](diffhunk://#diff-d6f5bc716198dba279e6d2d9e8e52fe574d009fa54817075d3d847b1e70b8030R21) [[3]](diffhunk://#diff-78f583a9821895684044110596af23a700d557f9c8b7c00e9f996db2b6d0f634R17) [[4]](diffhunk://#diff-ecdec10db35ad667ba3914521f96119fb899ac6e7eeee16594c04d514e1c142cR21) [[5]](diffhunk://#diff-a0e180780b08933d5cd5103df32badd675548e6a0c9009b7f0f8dc16d5add6bcR20)

- Updated order submission handlers (e.g., `handleOrderClick`, `handleSubmitClick`, etc.) in each trading container to call `checkDirectionMax(isBuy)` before proceeding, ensuring that direction-specific trade size limits are enforced right before order confirmation. [[1]](diffhunk://#diff-5800c74efd60587593df3ec8cc90ff992dc062f94c9d232d665d27f2bdb8e32dR781) [[2]](diffhunk://#diff-d6f5bc716198dba279e6d2d9e8e52fe574d009fa54817075d3d847b1e70b8030R487-R494) [[3]](diffhunk://#diff-78f583a9821895684044110596af23a700d557f9c8b7c00e9f996db2b6d0f634R390) [[4]](diffhunk://#diff-ecdec10db35ad667ba3914521f96119fb899ac6e7eeee16594c04d514e1c142cR406)

**Validation logic cleanup:**

- Removed the old direction-agnostic max trade size checks from the shared form validation logic in each container, simplifying the validation code and delegating responsibility to the new per-direction gate. [[1]](diffhunk://#diff-5800c74efd60587593df3ec8cc90ff992dc062f94c9d232d665d27f2bdb8e32dL344-L359) [[2]](diffhunk://#diff-d6f5bc716198dba279e6d2d9e8e52fe574d009fa54817075d3d847b1e70b8030L113-L126) [[3]](diffhunk://#diff-78f583a9821895684044110596af23a700d557f9c8b7c00e9f996db2b6d0f634L200-L215) [[4]](diffhunk://#diff-ecdec10db35ad667ba3914521f96119fb899ac6e7eeee16594c04d514e1c142cL234-L252)

- Updated the dependency arrays for validation-related `useMemo` hooks to remove now-unnecessary dependencies on max trade size and reduceOnly flags. [[1]](diffhunk://#diff-5800c74efd60587593df3ec8cc90ff992dc062f94c9d232d665d27f2bdb8e32dL376-R382) [[2]](diffhunk://#diff-d6f5bc716198dba279e6d2d9e8e52fe574d009fa54817075d3d847b1e70b8030L144-L146) [[3]](diffhunk://#diff-78f583a9821895684044110596af23a700d557f9c8b7c00e9f996db2b6d0f634L233-R227) [[4]](diffhunk://#diff-ecdec10db35ad667ba3914521f96119fb899ac6e7eeee16594c04d514e1c142cL271-R263)

**Documentation and comments:**

- Updated comments throughout the affected files to clarify that the per-direction max gate now lives at the order button handlers, and that the form validation logic is direction-agnostic. [[1]](diffhunk://#diff-5800c74efd60587593df3ec8cc90ff992dc062f94c9d232d665d27f2bdb8e32dL324-R332) [[2]](diffhunk://#diff-d6f5bc716198dba279e6d2d9e8e52fe574d009fa54817075d3d847b1e70b8030L97-R98) [[3]](diffhunk://#diff-78f583a9821895684044110596af23a700d557f9c8b7c00e9f996db2b6d0f634L163-R164) [[4]](diffhunk://#diff-ecdec10db35ad667ba3914521f96119fb899ac6e7eeee16594c04d514e1c142cL209-R211) [[5]](diffhunk://#diff-a0e180780b08933d5cd5103df32badd675548e6a0c9009b7f0f8dc16d5add6bcL89-R90)

**Testing:**

- Added new tests to ensure that the `assumeSufficientMargin` logic for cross margin orders floors or preserves balances as expected, and that the new validation logic behaves correctly in edge cases.

This refactor improves maintainability and correctness by ensuring that buy and sell trade size limits are enforced precisely where they matter, and by reducing duplicated validation logic across the codebase.