### PR TITLE
feat: show bridge quote ETA in seconds when under 1 minute

### DIFF
--- a/_raw/locales/en/messages.json
+++ b/_raw/locales/en/messages.json
@@ -2731,6 +2731,7 @@
       "need-to-approve-token-before-bridge": "Need to approve token before bridge",
       "via-bridge": "via {{bridge}}",
       "duration": "{{duration}} min",
+      "duration-sec": "{{duration}} s",
       "estimated-value": "≈ {{value}} ",
       "best": "Best",
       "best-subtitle": "The best quote is determined by a combination of estimated total cost (including gas fees) and delivery speed.",

--- a/src/ui/views/Bridge/Component/BridgeQuoteItem.tsx
+++ b/src/ui/views/Bridge/Component/BridgeQuoteItem.tsx
@@ -111,6 +111,17 @@ export const BridgeQuoteItem = (props: QuoteItemProps) => {
     return Math.max(Math.round(props.duration / 60), 1);
   }, [props.duration]);
 
+  const durationText = useMemo(() => {
+    if (props.duration < 60) {
+      return t('page.bridge.duration-sec', {
+        duration: Math.max(Math.round(props.duration), 1),
+      });
+    }
+    return t('page.bridge.duration', {
+      duration: showMinDuration,
+    });
+  }, [props.duration, showMinDuration, t]);
+
   const durationColor = useMemo(() => {
     if (showMinDuration > 10) {
       return 'text-r-red-default';
@@ -297,11 +308,7 @@ export const BridgeQuoteItem = (props: QuoteItemProps) => {
                 durationColor
               )}
             />
-            <span className={durationColor}>
-              {t('page.bridge.duration', {
-                duration: showMinDuration,
-              })}
-            </span>
+            <span className={durationColor}>{durationText}</span>
           </div>
           <div
             className={clsx(

--- a/src/ui/views/Bridge/Component/BridgeShowMore.tsx
+++ b/src/ui/views/Bridge/Component/BridgeShowMore.tsx
@@ -210,6 +210,17 @@ export const BridgeShowMore = ({
     return Math.max(Math.round((duration || 0) / 60), 1);
   }, [duration]);
 
+  const durationText = useMemo(() => {
+    if ((duration || 0) < 60) {
+      return t('page.bridge.duration-sec', {
+        duration: Math.max(Math.round(duration || 0), 1),
+      });
+    }
+    return t('page.bridge.duration', {
+      duration: showMinDuration,
+    });
+  }, [duration, showMinDuration, t]);
+
   const durationColor = useMemo(() => {
     if (showMinDuration > 10) {
       return 'text-r-red-default';
@@ -277,11 +288,7 @@ export const BridgeShowMore = ({
                   )}
                 >
                   {' · '}
-                  {sourceLogo || sourceName
-                    ? t('page.bridge.duration', {
-                        duration: showMinDuration,
-                      })
-                    : '-'}
+                  {sourceLogo || sourceName ? durationText : '-'}
                 </span>
                 {Boolean(sourceLogo || sourceName) && (
                   <RcInfoRowArrowRight className="h-14 w-14 text-r-neutral-foot" />


### PR DESCRIPTION
Avoid rounding sub-minute estimates up to 1 min so users see the actual quoted wait time.