### PR TITLE
fix: preserve Ledger signing diagnostics

### DIFF
--- a/__tests__/service/ledgerErrorMessage.test.ts
+++ b/__tests__/service/ledgerErrorMessage.test.ts
@@ -153,6 +153,45 @@ describe('getLedgerErrorMessage', () => {
     });
   });
 
+  it('preserves the allowlisted DMK error tag', () => {
+    const keyring = new LedgerBridgeKeyring();
+    const diagnostics = keyring.getLedgerSigningDiagnostics({
+      _tag: 'EthAppCommandError',
+      errorCode: '6985',
+    });
+
+    expect(diagnostics).toMatchObject({
+      provider_code: '0x6985',
+      provider_error_tag: 'EthAppCommandError',
+    });
+    expect(
+      keyring.getLedgerSigningDiagnostics({ _tag: 'UnexpectedError' })
+    ).not.toHaveProperty('provider_error_tag');
+  });
+
+  it('classifies Rabby-generated device readiness errors', () => {
+    const keyring = new LedgerBridgeKeyring();
+
+    expect(
+      keyring.getLedgerSigningDiagnostics(
+        new Error('Ledger: Device is locked 0x5515')
+      )
+    ).toMatchObject({
+      provider_code: '0x5515',
+      error_category: 'device_locked',
+      provider_reason: 'device_locked',
+    });
+
+    expect(
+      keyring.getLedgerSigningDiagnostics(
+        new Error('Ledger: Device disconnected')
+      )
+    ).toMatchObject({
+      error_category: 'disconnected',
+      provider_reason: 'device_disconnected',
+    });
+  });
+
   it('classifies an explicit DMK user rejection as user cancellation', () => {
     const keyring = new LedgerBridgeKeyring();
     const diagnostics = keyring.getLedgerSigningDiagnostics({
@@ -189,7 +228,11 @@ describe('getLedgerErrorMessage', () => {
       undefined,
       secondAttempt
     ) as any;
-    firstState.steps.push('first-attempt');
+    firstState.steps.push(
+      'first-attempt',
+      'signer.eth.steps.blindSignTransactionFallback'
+    );
+    firstState.last_required_user_interaction = 'sign-transaction';
     secondState.steps.push('second-attempt');
 
     const sharedError = new Error('Ledger: Device disconnected');
@@ -200,6 +243,11 @@ describe('getLedgerErrorMessage', () => {
       sharedError,
       firstAttempt
     ).provider_metadata as any;
-    expect(metadata?.device_action_steps).toBe('first-attempt');
+    expect(metadata).toMatchObject({
+      device_action_steps:
+        'first-attempt>signer.eth.steps.blindSignTransactionFallback',
+      last_required_user_interaction: 'sign-transaction',
+      used_fallback: true,
+    });
   });
 });

--- a/__tests__/service/ledgerMakeApp.test.ts
+++ b/__tests__/service/ledgerMakeApp.test.ts
@@ -834,6 +834,40 @@ describe('LedgerBridgeKeyring makeApp', () => {
     }
   });
 
+  it('keeps the device action successful when an optional diagnostic field throws', async () => {
+    const keyring = new LedgerBridgeKeyring();
+    const address = '0x0000000000000000000000000000000000000001';
+    const cancel = jest.fn();
+    const state = {
+      status: 'completed',
+      output: {
+        address,
+        publicKey: 'public-key',
+      },
+    } as any;
+    let shouldThrow = true;
+    Object.defineProperty(state, 'intermediateValue', {
+      get: () => {
+        if (shouldThrow) {
+          shouldThrow = false;
+          throw new Error('diagnostic read failed');
+        }
+        return undefined;
+      },
+    });
+    mockGetAddress.mockReturnValueOnce({
+      observable: of(state),
+      cancel,
+    });
+
+    try {
+      await expect(keyring.unlock("m/44'/60'/0'/0/0")).resolves.toBe(address);
+      expect(cancel).not.toHaveBeenCalled();
+    } finally {
+      await keyring.cleanUp();
+    }
+  });
+
   it('rejects incomplete typed data before touching the device', async () => {
     const keyring = new LedgerBridgeKeyring();
 

--- a/__tests__/service/signing-diagnostics.test.ts
+++ b/__tests__/service/signing-diagnostics.test.ts
@@ -89,7 +89,10 @@ describe('signing diagnostics port', () => {
 
     await expect(
       withSigningDiagnostics(
-        { type: 'Ledger Hardware', signingDiagnosticsProvider: 'tagged-ledger' },
+        {
+          type: 'Ledger Hardware',
+          signingDiagnosticsProvider: 'tagged-ledger',
+        },
         'transaction',
         () => Promise.reject(error)
       )

--- a/__tests__/utils/sentry-config.test.ts
+++ b/__tests__/utils/sentry-config.test.ts
@@ -18,6 +18,11 @@ const attachHardwareSigningContext = (
     operation: string;
     originalError?: unknown;
     error_category?: 'user_cancelled' | 'unknown';
+    provider_code?: string;
+    provider_error_tag?: string;
+    provider_stage?: string;
+    provider_reason?: string;
+    provider_metadata?: Record<string, string | number | boolean>;
   }
 ) =>
   attachSigningContext(error, {
@@ -32,6 +37,11 @@ const attachHardwareSigningContext = (
     outcome: 'failed',
     error_category: context.error_category ?? 'unknown',
     duration_bucket: 'lt_100ms',
+    provider_code: context.provider_code,
+    provider_error_tag: context.provider_error_tag,
+    provider_stage: context.provider_stage,
+    provider_reason: context.provider_reason,
+    provider_metadata: context.provider_metadata,
     originalError: context.originalError,
   });
 
@@ -82,6 +92,48 @@ describe('Sentry configuration', () => {
       type: 'SigningError',
       value: 'unknown',
       stacktrace,
+    });
+  });
+
+  test('uses the safe provider code in the canonical exception and grouping', () => {
+    const error = new Error('device failed');
+    attachHardwareSigningContext(error, {
+      wallet: 'ledger',
+      operation: 'transaction',
+      provider_code: '0x6985',
+      provider_error_tag: 'EthAppCommandError',
+      provider_stage: 'signer.eth.steps.signTransaction',
+      provider_reason: 'condition_not_satisfied',
+      provider_metadata: {
+        status_word: '0x6985',
+        last_required_user_interaction: 'sign-transaction',
+        used_fallback: false,
+      },
+    });
+    const event: any = {
+      exception: { values: [{ type: 'Error', value: error.message }] },
+    };
+
+    applySigningContext(event, error);
+
+    expect(event.exception.values[0]).toMatchObject({
+      type: 'SigningError',
+      value: '0x6985',
+    });
+    expect(event.tags).toMatchObject({
+      signing_provider_code: '0x6985',
+      signing_provider_error_tag: 'EthAppCommandError',
+      signing_provider_stage: 'signer.eth.steps.signTransaction',
+    });
+    expect(event.fingerprint).toContain('0x6985');
+    expect(event.extra).toMatchObject({
+      signing_provider_code: '0x6985',
+      signing_provider_error_tag: 'EthAppCommandError',
+      signing_provider_reason: 'condition_not_satisfied',
+      signing_provider_metadata: {
+        last_required_user_interaction: 'sign-transaction',
+        used_fallback: false,
+      },
     });
   });
 

--- a/src/background/service/keyring/eth-ledger-keyring.ts
+++ b/src/background/service/keyring/eth-ledger-keyring.ts
@@ -123,6 +123,7 @@ type LedgerActionDiagnostics = {
   session_reused: boolean;
   clear_signing_context_errors?: number;
   clear_signing_type?: string;
+  last_required_user_interaction?: string;
 };
 
 type LedgerAttemptState = LedgerActionDiagnostics & {
@@ -282,6 +283,37 @@ const normalizeLedgerStatusWord = (value: unknown) => {
   return /^[0-9a-f]{1,4}$/u.test(normalized) ? normalized : '';
 };
 
+const LEDGER_STATUS_REASONS: Record<string, string> = {
+  '5515': 'device_locked',
+  '6982': 'security_status_not_satisfied',
+  '6985': 'condition_not_satisfied',
+  '6a80': 'invalid_data',
+  '6a84': 'insufficient_memory',
+  '6b00': 'invalid_parameter',
+  '6d00': 'invalid_instruction',
+  '6e00': 'invalid_class',
+  '6f00': 'technical_problem',
+};
+
+const LEDGER_ERROR_TAGS = new Set([
+  'EthAppCommandError',
+  'GlobalCommandError',
+  'InvalidStatusWordError',
+  'InvalidResponseFormatError',
+  'UnknownDeviceExchangeError',
+  'RefusedByUserDAError',
+  'DeviceLockedError',
+  'DeviceBusyError',
+  'UnknownDAError',
+  'DeviceNotOnboardedError',
+  'WebHidSendReportError',
+  'DeviceDisconnectedWhileSendingError',
+  'DisconnectedDeviceDuringOperation',
+  'ConnectionOpeningError',
+  'ActionRefusedError',
+  'DeviceInternalError',
+]);
+
 const getLedgerStatusWord = (err: unknown) => {
   const value = err as any;
   const code = normalizeLedgerStatusWord(
@@ -295,10 +327,38 @@ const getLedgerStatusWord = (err: unknown) => {
   return value?._tag === 'RefusedByUserDAError' ? '6985' : '';
 };
 
+const getLedgerStatusWordFromMessage = (err: unknown) => {
+  const message = (err as { message?: unknown })?.message;
+  return typeof message === 'string' &&
+    /Ledger: Device is locked 0x5515/iu.test(message)
+    ? '5515'
+    : '';
+};
+
+const getLedgerErrorTag = (err: unknown) => {
+  if (!err || typeof err !== 'object') return '';
+  const value = err as { _tag?: unknown; name?: unknown };
+  const tag = value._tag ?? value.name;
+  return typeof tag === 'string' && LEDGER_ERROR_TAGS.has(tag) ? tag : '';
+};
+
+const findLedgerErrorTag = (err: unknown, depth = 0): string => {
+  if (!err || depth > 6 || typeof err !== 'object') return '';
+  return (
+    getLedgerErrorTag(err) ||
+    findLedgerErrorTag((err as { cause?: unknown }).cause, depth + 1) ||
+    findLedgerErrorTag(
+      (err as { originalError?: unknown }).originalError,
+      depth + 1
+    )
+  );
+};
+
 const findLedgerStatusWord = (err: unknown, depth = 0): string => {
   if (!err || depth > 6) return '';
   return (
     getLedgerStatusWord(err) ||
+    getLedgerStatusWordFromMessage(err) ||
     findLedgerStatusWord((err as { cause?: unknown }).cause, depth + 1)
   );
 };
@@ -310,6 +370,38 @@ const isLedgerUserCancellation = (err: unknown, depth = 0): boolean => {
     isLedgerUserCancellation((err as { cause?: unknown }).cause, depth + 1)
   );
 };
+
+const findLedgerMessageReason = (err: unknown, depth = 0): string => {
+  if (!err || depth > 6 || typeof err !== 'object') return '';
+  const message = (err as { message?: unknown }).message;
+  if (typeof message === 'string') {
+    if (
+      /Ledger: (?:Device disconnected|No connected Ledger device found)/iu.test(
+        message
+      )
+    ) {
+      return 'device_disconnected';
+    }
+    if (/Ledger: Device is locked 0x5515/iu.test(message)) {
+      return 'device_locked';
+    }
+    if (/Ledger: Device busy/iu.test(message)) {
+      return 'device_busy';
+    }
+    if (/ConnectionOpeningError/iu.test(message)) {
+      return 'connection_opening';
+    }
+    if (/InvalidStatusWordError/iu.test(message)) {
+      return 'invalid_status_word';
+    }
+  }
+  return findLedgerMessageReason((err as { cause?: unknown }).cause, depth + 1);
+};
+
+const getLedgerErrorReason = (err: unknown, statusWord: string) =>
+  isLedgerUserCancellation(err)
+    ? 'user_rejected'
+    : LEDGER_STATUS_REASONS[statusWord] || findLedgerMessageReason(err);
 
 export const getLedgerErrorMessage = (err: unknown, fallback: string) =>
   [stringifyLedgerErrorValue(err) || fallback, findLedgerStatusWord(err)]
@@ -377,25 +469,35 @@ const runDeviceAction = async <Output>(
     return await firstValueFrom(
       observable.pipe(
         tap((state) => {
-          const step =
-            'intermediateValue' in state
-              ? state.intermediateValue?.step
-              : undefined;
-          if (step && step !== previousStep) {
-            const now = Date.now();
-            trace.slowestGapMs = Math.max(
-              trace.slowestGapMs,
-              now - trace.lastStepAt
-            );
-            trace.lastStepAt = now;
-            if (trace.steps.length < 16) {
-              trace.steps.push(String(step).slice(0, 64));
+          try {
+            const intermediateValue =
+              'intermediateValue' in state
+                ? state.intermediateValue
+                : undefined;
+            const step = intermediateValue?.step;
+            if (intermediateValue?.requiredUserInteraction) {
+              trace.last_required_user_interaction = String(
+                intermediateValue.requiredUserInteraction
+              ).slice(0, 64);
             }
-            console.debug('[Ledger DMK][stage]', {
-              step,
-              timestamp: Date.now(),
-            });
-            previousStep = step;
+            if (step && step !== previousStep) {
+              const now = Date.now();
+              trace.slowestGapMs = Math.max(
+                trace.slowestGapMs,
+                now - trace.lastStepAt
+              );
+              trace.lastStepAt = now;
+              if (trace.steps.length < 16) {
+                trace.steps.push(String(step).slice(0, 64));
+              }
+              console.debug('[Ledger DMK][stage]', {
+                step,
+                timestamp: Date.now(),
+              });
+              previousStep = step;
+            }
+          } catch {
+            // Optional diagnostics must never affect the device action.
           }
         }),
         filter((state) => {
@@ -769,6 +871,8 @@ class LedgerBridgeKeyring {
 
   getLedgerSigningDiagnostics(error: unknown, attempt?: SigningAttempt) {
     const statusWord = findLedgerStatusWord(error);
+    const providerErrorTag = findLedgerErrorTag(error);
+    const providerReason = getLedgerErrorReason(error, statusWord);
     const trace =
       (attempt ? ledgerAttemptBySigningAttempt.get(attempt) : undefined) ??
       (error && typeof error === 'object'
@@ -781,10 +885,14 @@ class LedgerBridgeKeyring {
       error_category:
         statusWord === '6985' && isLedgerUserCancellation(error)
           ? 'user_cancelled'
-          : statusWord === '5515'
+          : statusWord === '5515' || providerReason === 'device_locked'
           ? 'device_locked'
+          : providerReason === 'device_disconnected'
+          ? 'disconnected'
           : 'unknown',
       ...(statusWord ? { provider_code: `0x${statusWord}` } : {}),
+      ...(providerErrorTag ? { provider_error_tag: providerErrorTag } : {}),
+      ...(providerReason ? { provider_reason: providerReason } : {}),
       ...(trace
         ? {
             provider_stage: trace.steps[trace.steps.length - 1],
@@ -804,6 +912,15 @@ class LedgerBridgeKeyring {
               ...(trace.clear_signing_type
                 ? { clear_signing_type: trace.clear_signing_type }
                 : {}),
+              ...(trace.last_required_user_interaction
+                ? {
+                    last_required_user_interaction:
+                      trace.last_required_user_interaction,
+                  }
+                : {}),
+              used_fallback: trace.steps.includes(
+                'signer.eth.steps.blindSignTransactionFallback'
+              ),
             },
           }
         : { provider_metadata: this.hardwareSigningMetadata }),

--- a/src/background/service/keyring/signing-diagnostics.ts
+++ b/src/background/service/keyring/signing-diagnostics.ts
@@ -52,6 +52,7 @@ export type ProviderDiagnostics = {
   transport?: unknown;
   error_category?: unknown;
   provider_code?: unknown;
+  provider_error_tag?: unknown;
   provider_stage?: unknown;
   provider_reason?: unknown;
   provider_metadata?: unknown;
@@ -111,6 +112,7 @@ export type SigningContext = {
   error_category: SigningErrorCategory;
   duration_bucket: 'lt_100ms' | '100ms_1s' | '1s_5s' | 'gte_5s';
   provider_code?: string;
+  provider_error_tag?: string;
   provider_stage?: string;
   provider_reason?: string;
   provider_metadata?: Record<string, string | number | boolean>;
@@ -211,6 +213,7 @@ type NormalizedProviderDiagnostics = Partial<
     | 'transport'
     | 'error_category'
     | 'provider_code'
+    | 'provider_error_tag'
     | 'provider_stage'
     | 'provider_reason'
     | 'provider_metadata'
@@ -235,6 +238,8 @@ const providerMetadataKeys: Record<string, string[]> = {
     'session_reused',
     'clear_signing_context_errors',
     'clear_signing_type',
+    'last_required_user_interaction',
+    'used_fallback',
   ],
   onekey: commonMetadataKeys,
   trezor: commonMetadataKeys,
@@ -247,6 +252,7 @@ const normalizeMetadata = (
   if (!value || typeof value !== 'object') return {};
   const diagnostics = value as ProviderDiagnostics;
   const providerCode = diagnostics.provider_code;
+  const providerErrorTag = diagnostics.provider_error_tag;
   const providerStage = diagnostics.provider_stage;
   const providerReason = diagnostics.provider_reason;
   const providerMetadata = diagnostics.provider_metadata;
@@ -276,6 +282,10 @@ const normalizeMetadata = (
     ...(typeof providerCode === 'string' &&
     /^[a-z0-9_.:-]{1,32}$/i.test(providerCode)
       ? { provider_code: providerCode }
+      : {}),
+    ...(typeof providerErrorTag === 'string' &&
+    /^[a-z0-9_.:-]{1,64}$/i.test(providerErrorTag)
+      ? { provider_error_tag: providerErrorTag }
       : {}),
     ...(typeof providerStage === 'string' &&
     /^[a-z0-9_.:-]{1,32}$/i.test(providerStage)

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -255,6 +255,12 @@ export const applySigningContext = (event: SentryEventLike, error: unknown) => {
   if (!context) return;
 
   const deviceModel = context.provider_metadata?.device_model;
+  const diagnosticValue =
+    context.wallet_provider === 'ledger'
+      ? context.provider_code ??
+        context.provider_error_tag ??
+        context.error_category
+      : context.error_category;
 
   event.tags = {
     ...event.tags,
@@ -267,6 +273,15 @@ export const applySigningContext = (event: SentryEventLike, error: unknown) => {
     sign_outcome: context.outcome,
     error_category: context.error_category,
     duration_bucket: context.duration_bucket,
+    ...(context.wallet_provider === 'ledger' && context.provider_code
+      ? { signing_provider_code: context.provider_code }
+      : {}),
+    ...(context.wallet_provider === 'ledger' && context.provider_error_tag
+      ? { signing_provider_error_tag: context.provider_error_tag }
+      : {}),
+    ...(context.wallet_provider === 'ledger' && context.provider_stage
+      ? { signing_provider_stage: context.provider_stage }
+      : {}),
     ...(typeof deviceModel === 'string'
       ? { signing_device_model: deviceModel }
       : {}),
@@ -276,7 +291,7 @@ export const applySigningContext = (event: SentryEventLike, error: unknown) => {
     context.wallet_family,
     context.wallet_provider,
     context.operation,
-    context.error_category,
+    diagnosticValue,
     '{{ default }}',
   ];
   event.message = `${context.wallet_provider} signing failed`;
@@ -286,13 +301,16 @@ export const applySigningContext = (event: SentryEventLike, error: unknown) => {
       {
         ...originalException,
         type: 'SigningError',
-        value: context.error_category,
+        value: diagnosticValue,
       },
     ],
   };
   event.extra = {
     ...(context.provider_code
       ? { signing_provider_code: context.provider_code }
+      : {}),
+    ...(context.provider_error_tag
+      ? { signing_provider_error_tag: context.provider_error_tag }
       : {}),
     ...(context.provider_stage
       ? { signing_provider_stage: context.provider_stage }


### PR DESCRIPTION
## Summary

- preserve Ledger provider status codes and SDK error tags in signing diagnostics
- group Sentry failures by safe Ledger diagnostics instead of `SigningError unknown`
- keep diagnostics best-effort so malformed optional fields cannot affect device actions

## Validation

- `yarn jest __tests__/utils/sentry-config.test.ts __tests__/utils/sentry.test.ts __tests__/service/ledgerErrorMessage.test.ts __tests__/service/signing-diagnostics.test.ts __tests__/service/ledgerMakeApp.test.ts --runInBand --watchman=false` — 5 suites / 109 tests passed
- targeted ESLint passed
- `git diff --check` passed
- `yarn typecheck` is blocked by the pre-existing missing `@tanstack/react-query` dependency