### PR TITLE
feat: add swap/bridge quote refresh countdown on the switch button

### DIFF
--- a/src/ui/views/Bridge/Component/BridgeContent.tsx
+++ b/src/ui/views/Bridge/Component/BridgeContent.tsx
@@ -121,6 +121,7 @@ export const BridgeContent = () => {
     isSlippageHigh,
     isSlippageLow,
     setQuoteRefreshLocked,
+    resumeQuoteRefresh,
 
     autoSlippage,
     isCustomSlippage,
@@ -158,11 +159,6 @@ export const BridgeContent = () => {
   const setVisible = useSetQuoteVisible();
 
   const refresh = useSetRefreshId();
-
-  const resumeQuoteRefresh = useCallback(() => {
-    setQuoteRefreshLocked(false);
-    refresh((id) => id + 1);
-  }, [refresh, setQuoteRefreshLocked]);
 
   const { t } = useTranslation();
 

--- a/src/ui/views/Bridge/Component/BridgeContent.tsx
+++ b/src/ui/views/Bridge/Component/BridgeContent.tsx
@@ -103,6 +103,7 @@ export const BridgeContent = () => {
 
     openQuotesList,
     quoteLoading,
+    quoteRefreshCountdown,
     allQuotesLoaded,
     quoteRequestId,
     quoteList,
@@ -1171,7 +1172,11 @@ export const BridgeContent = () => {
             getContainer={getContainer}
           />
           <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-            <BridgeSwitchBtn onClick={switchToken} loading={quoteLoading} />
+            <BridgeSwitchBtn
+              onClick={switchToken}
+              loading={quoteLoading}
+              refreshCountdown={quoteRefreshCountdown}
+            />
           </div>
         </div>
         {showExternalDappTips ? (

--- a/src/ui/views/Bridge/Component/BridgeSwitchButton.tsx
+++ b/src/ui/views/Bridge/Component/BridgeSwitchButton.tsx
@@ -1,8 +1,78 @@
 import clsx from 'clsx';
-import React from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { ReactComponent as RcIconSwitchCC } from 'ui/assets/bridge/switch-arrow-cc.svg';
 import { ReactComponent as RcIconLoading } from 'ui/assets/swap/quote-circle-loading-cc.svg';
+
+const PROGRESS_SIZE = 36;
+const PROGRESS_STROKE_WIDTH = 3;
+const PROGRESS_RADIUS = (PROGRESS_SIZE - PROGRESS_STROKE_WIDTH) / 2;
+const PROGRESS_CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RADIUS;
+
+type RefreshCountdown = {
+  startedAt: number;
+  deadline: number;
+  expired?: boolean;
+  frozen?: boolean;
+};
+
+const QuoteRefreshProgress = ({
+  startedAt,
+  deadline,
+  frozen,
+}: RefreshCountdown) => {
+  const circleRef = useRef<SVGCircleElement>(null);
+
+  useLayoutEffect(() => {
+    const circle = circleRef.current;
+    if (!circle) {
+      return;
+    }
+
+    if (frozen) {
+      circle.style.strokeDashoffset = '0';
+      return () => {
+        circle.style.strokeDashoffset = '';
+      };
+    }
+
+    const duration = deadline - startedAt;
+    const remaining = Math.max(deadline - Date.now(), 0);
+    const progress =
+      duration > 0 ? Math.min(Math.max(1 - remaining / duration, 0), 1) : 1;
+    const animation = circle.animate(
+      [
+        { strokeDashoffset: -PROGRESS_CIRCUMFERENCE * progress },
+        { strokeDashoffset: -PROGRESS_CIRCUMFERENCE },
+      ],
+      { duration: remaining, easing: 'linear', fill: 'forwards' }
+    );
+
+    return () => animation.cancel();
+  }, [startedAt, deadline, frozen]);
+
+  return (
+    <svg
+      viewBox={`0 0 ${PROGRESS_SIZE} ${PROGRESS_SIZE}`}
+      className="absolute w-[32px] h-[32px] left-0 top-0 text-r-blue-default pointer-events-none"
+      aria-hidden="true"
+    >
+      <circle
+        ref={circleRef}
+        cx={PROGRESS_SIZE / 2}
+        cy={PROGRESS_SIZE / 2}
+        r={PROGRESS_RADIUS}
+        transform={`rotate(-90 ${PROGRESS_SIZE / 2} ${PROGRESS_SIZE / 2})`}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={PROGRESS_STROKE_WIDTH}
+        strokeLinecap="round"
+        strokeDasharray={PROGRESS_CIRCUMFERENCE}
+        strokeDashoffset={frozen ? 0 : -PROGRESS_CIRCUMFERENCE}
+      />
+    </svg>
+  );
+};
 
 const Wrapper = styled.div`
   @keyframes loading-spin {
@@ -18,8 +88,14 @@ const Wrapper = styled.div`
 export const BridgeSwitchBtn = ({
   className,
   loading,
+  refreshCountdown,
   ...others
-}: React.HTMLAttributes<HTMLDivElement> & { loading?: boolean }) => {
+}: React.HTMLAttributes<HTMLDivElement> & {
+  loading?: boolean;
+  refreshCountdown?: RefreshCountdown | null;
+}) => {
+  const refreshing = Boolean(loading || refreshCountdown?.expired);
+
   return (
     <Wrapper
       className={clsx(
@@ -33,6 +109,13 @@ export const BridgeSwitchBtn = ({
       {...others}
     >
       <RcIconSwitchCC className="w-16 h-16" viewBox="0 0 16 16" />
+      {!refreshing && refreshCountdown && (
+        <QuoteRefreshProgress
+          startedAt={refreshCountdown.startedAt}
+          deadline={refreshCountdown.deadline}
+          frozen={refreshCountdown.frozen}
+        />
+      )}
       <RcIconLoading
         viewBox="0 0 49 49"
         style={{
@@ -41,7 +124,7 @@ export const BridgeSwitchBtn = ({
         className={clsx(
           'text-r-blue-default',
           'absolute w-[32px] h-[32px] left-0 top-0 transition-opacity ',
-          loading ? 'opacity-100 loading-spin' : 'opacity-0'
+          refreshing ? 'opacity-100 loading-spin' : 'opacity-0'
         )}
       />
     </Wrapper>

--- a/src/ui/views/Bridge/Component/BridgeSwitchButton.tsx
+++ b/src/ui/views/Bridge/Component/BridgeSwitchButton.tsx
@@ -103,7 +103,10 @@ export const BridgeSwitchBtn = ({
         'w-[32px] h-[32px] rounded-[900px]',
         'bg-r-neutral-bg-1 text-rabby-neutral-foot',
         'border-[0.5px] border-solid border-rabby-neutral-line',
-        'hover:border-rabby-blue-default hover:bg-rabby-blue-light1 hover:text-rabby-blue-default',
+        'hover:bg-rabby-blue-light1 hover:text-rabby-blue-default',
+        !refreshing && refreshCountdown
+          ? 'hover:border-transparent'
+          : 'hover:border-rabby-blue-default',
         className
       )}
       {...others}

--- a/src/ui/views/Bridge/hooks/token.tsx
+++ b/src/ui/views/Bridge/hooks/token.tsx
@@ -486,6 +486,10 @@ export const useBridge = () => {
     { loading: quoteLoading, error: quotesError },
     getQuoteList,
   ] = useAsyncFn(async () => {
+    if (expiredTimer.current) {
+      clearTimeout(expiredTimer.current);
+      expiredTimer.current = undefined;
+    }
     if (depositFlowActiveRef.current || quoteRefreshLockedRef.current) {
       setPending(false);
       return;
@@ -695,6 +699,10 @@ export const useBridge = () => {
 
   useEffect(() => {
     if (canRunQuoteRequest && !quoteRefreshLockedRef.current) {
+      if (expiredTimer.current) {
+        clearTimeout(expiredTimer.current);
+        expiredTimer.current = undefined;
+      }
       setPending(true);
     } else {
       setPending(false);

--- a/src/ui/views/Bridge/hooks/token.tsx
+++ b/src/ui/views/Bridge/hooks/token.tsx
@@ -232,6 +232,13 @@ export const useBridge = () => {
   >();
 
   const expiredTimer = useRef<NodeJS.Timeout>();
+  const quoteFetchingRef = useRef(false);
+  const [quoteRefreshCountdown, setQuoteRefreshCountdown] = useState<{
+    startedAt: number;
+    deadline: number;
+    expired?: boolean;
+    frozen?: boolean;
+  } | null>(null);
   const depositFlowActiveRef = useRef(depositFlowActive);
   const previousDepositFlowActiveRef = useRef(depositFlowActive);
 
@@ -406,21 +413,45 @@ export const useBridge = () => {
       return;
     }
 
+    if (quoteFetchingRef.current) {
+      setOriSelectedBridgeQuote(quote);
+      if (quote && !quote.manualClick && !depositFlowActiveRef.current) {
+        setQuoteRefreshCountdown((prev) => {
+          if (prev?.expired || prev?.frozen) {
+            return prev;
+          }
+          return { startedAt: 0, deadline: 0, frozen: true };
+        });
+      } else if (!quote) {
+        setQuoteRefreshCountdown((prev) => (prev?.expired ? prev : null));
+      }
+      return;
+    }
+
     if (expiredTimer.current) {
       clearTimeout(expiredTimer.current);
       expiredTimer.current = undefined;
     }
+    setQuoteRefreshCountdown(null);
     if (
       !quote?.manualClick &&
       quote &&
       !depositFlowActiveRef.current &&
       !quoteRefreshLockedRef.current
     ) {
+      const startedAt = Date.now();
+      const delay = 1000 * 30;
+      setQuoteRefreshCountdown({ startedAt, deadline: startedAt + delay });
       expiredTimer.current = setTimeout(() => {
+        expiredTimer.current = undefined;
+        setQuoteRefreshCountdown((prev) =>
+          prev ? { ...prev, expired: true } : null
+        );
         if (!depositFlowActiveRef.current && !quoteRefreshLockedRef.current) {
+          setPending(true);
           setRefreshId((e) => e + 1);
         }
-      }, 1000 * 30);
+      }, delay);
     }
     setOriSelectedBridgeQuote(quote);
   }, []);
@@ -441,6 +472,11 @@ export const useBridge = () => {
     );
     setRecommendFromToken(undefined);
     if (shouldResetQuote) {
+      setQuoteRefreshCountdown(null);
+      if (expiredTimer.current) {
+        clearTimeout(expiredTimer.current);
+        expiredTimer.current = undefined;
+      }
       setSelectedBridgeQuote(undefined);
     }
     setPending(canRunQuoteRequest);
@@ -684,6 +720,7 @@ export const useBridge = () => {
       fetchIdRef.current += 1;
       setPending(false);
       cancelDebounce();
+      setQuoteRefreshCountdown(null);
       if (expiredTimer.current) {
         clearTimeout(expiredTimer.current);
         expiredTimer.current = undefined;
@@ -694,6 +731,7 @@ export const useBridge = () => {
 
   useEffect(() => {
     if (depositFlowActive) {
+      setQuoteRefreshCountdown(null);
       if (expiredTimer.current) {
         clearTimeout(expiredTimer.current);
         expiredTimer.current = undefined;
@@ -722,6 +760,7 @@ export const useBridge = () => {
   }, []);
 
   const rawQuoteLoading = quoteLoading || pending;
+  quoteFetchingRef.current = rawQuoteLoading;
   const allQuotesLoaded = !rawQuoteLoading;
   const quoteListForDisplay = useMemo(() => {
     if (allQuotesLoaded || !fromToken || !toToken) {
@@ -821,6 +860,7 @@ export const useBridge = () => {
 
   useEffect(() => {
     return () => {
+      fetchIdRef.current += 1;
       clearExpiredTimer();
     };
   }, [clearExpiredTimer]);
@@ -964,6 +1004,7 @@ export const useBridge = () => {
 
     openQuotesList,
     quoteLoading: displayQuoteLoading,
+    quoteRefreshCountdown,
     allQuotesLoaded,
     quoteRequestId,
     setQuotesList,

--- a/src/ui/views/Bridge/hooks/token.tsx
+++ b/src/ui/views/Bridge/hooks/token.tsx
@@ -729,6 +729,15 @@ export const useBridge = () => {
     [cancelDebounce]
   );
 
+  const resumeQuoteRefresh = useCallback(() => {
+    setQuoteRefreshLocked(false);
+    if (canRunQuoteRequest && !depositFlowActiveRef.current) {
+      setQuoteRefreshCountdown({ startedAt: 0, deadline: 0, expired: true });
+      setPending(true);
+    }
+    setRefreshId((id) => id + 1);
+  }, [canRunQuoteRequest, setQuoteRefreshLocked, setRefreshId]);
+
   useEffect(() => {
     if (depositFlowActive) {
       setQuoteRefreshCountdown(null);
@@ -981,6 +990,7 @@ export const useBridge = () => {
 
   return {
     setQuoteRefreshLocked,
+    resumeQuoteRefresh,
 
     fromChain,
     fromToken,

--- a/src/ui/views/Swap/Component/Main.tsx
+++ b/src/ui/views/Swap/Component/Main.tsx
@@ -140,6 +140,7 @@ export const Main = () => {
 
     openQuotesList,
     quoteLoading,
+    quoteRefreshCountdown,
     allQuotesLoaded,
     quoteRequestId,
     quoteList,
@@ -1262,6 +1263,7 @@ export const Main = () => {
             <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
               <BridgeSwitchBtn
                 onClick={exchangeToken}
+                refreshCountdown={quoteRefreshCountdown}
                 loading={
                   quoteLoading &&
                   amountAvailable &&

--- a/src/ui/views/Swap/Component/Main.tsx
+++ b/src/ui/views/Swap/Component/Main.tsx
@@ -160,6 +160,7 @@ export const Main = () => {
     showMoreVisible,
     inSufficientCanGetQuote,
     setQuoteRefreshLocked,
+    resumeQuoteRefresh,
 
     autoSuggestSlippage,
     setAutoSuggestSlippage,
@@ -183,10 +184,6 @@ export const Main = () => {
   const mevProtection = useSwapStore((s) => s.mevProtection ?? true);
   const setMEVProtection = useSwapStore((s) => s.setMEVProtection);
   const setRecentSwapToToken = useSwapStore((s) => s.setRecentSwapToToken);
-  const resumeQuoteRefresh = useCallback(() => {
-    setQuoteRefreshLocked(false);
-    refresh((id) => id + 1);
-  }, [refresh, setQuoteRefreshLocked]);
 
   const switchPreferMEV = useCallback(
     (bool: boolean) => {

--- a/src/ui/views/Swap/Component/Quotes.tsx
+++ b/src/ui/views/Swap/Component/Quotes.tsx
@@ -151,7 +151,7 @@ export const Quotes = ({
         !noPadding && 'px-20'
       )}
     >
-      <div className="flex flex-col gap-12">
+      <div className="flex flex-col gap-12 mb-24">
         {sortedList.map((params, idx) => {
           const { name, data, isDex } = params;
           if (!isDex) return null;
@@ -180,7 +180,7 @@ export const Quotes = ({
       </div>
       <div
         className={clsx(
-          'flex items-center justify-center my-8 mt-24 cursor-pointer gap-4',
+          'flex items-center justify-center my-8 cursor-pointer gap-4',
           errorQuoteDEXs.length === 0 ||
             errorQuoteDEXs?.length === dexListLength
             ? 'hidden'

--- a/src/ui/views/Swap/hooks/token.tsx
+++ b/src/ui/views/Swap/hooks/token.tsx
@@ -774,6 +774,10 @@ export const useTokenPair = (userAddress: string) => {
     { loading: quoteLoading, error: quotesError },
     getQuotes,
   ] = useAsyncFn(async () => {
+    if (expiredTimer.current) {
+      clearTimeout(expiredTimer.current);
+      expiredTimer.current = undefined;
+    }
     if (depositFlowActiveRef.current || quoteRefreshLockedRef.current) {
       setPending(false);
       return;
@@ -857,6 +861,10 @@ export const useTokenPair = (userAddress: string) => {
 
   useEffect(() => {
     if (canRunQuoteRequest && !quoteRefreshLockedRef.current) {
+      if (expiredTimer.current) {
+        clearTimeout(expiredTimer.current);
+        expiredTimer.current = undefined;
+      }
       setPending(true);
     } else {
       setPending(false);

--- a/src/ui/views/Swap/hooks/token.tsx
+++ b/src/ui/views/Swap/hooks/token.tsx
@@ -896,6 +896,15 @@ export const useTokenPair = (userAddress: string) => {
     [cancelQuoteDebounce]
   );
 
+  const resumeQuoteRefresh = useCallback(() => {
+    setQuoteRefreshLocked(false);
+    if (canRunQuoteRequest && !depositFlowActiveRef.current) {
+      setQuoteRefreshCountdown({ startedAt: 0, deadline: 0, expired: true });
+      setPending(true);
+    }
+    setRefreshId((id) => id + 1);
+  }, [canRunQuoteRequest, setQuoteRefreshLocked, setRefreshId]);
+
   useEffect(() => {
     if (depositFlowActive) {
       setQuoteRefreshCountdown(null);
@@ -1257,6 +1266,7 @@ export const useTokenPair = (userAddress: string) => {
 
   return {
     setQuoteRefreshLocked,
+    resumeQuoteRefresh,
     bestQuoteDex,
     gasLevel,
 

--- a/src/ui/views/Swap/hooks/token.tsx
+++ b/src/ui/views/Swap/hooks/token.tsx
@@ -270,17 +270,41 @@ export const useTokenPair = (userAddress: string) => {
       return;
     }
 
+    if (quoteFetchingRef.current) {
+      setOriActiveProvider(p);
+      if (p && !depositFlowActiveRef.current) {
+        setQuoteRefreshCountdown((prev) => {
+          if (prev?.expired || prev?.frozen) {
+            return prev;
+          }
+          return { startedAt: 0, deadline: 0, frozen: true };
+        });
+      } else if (!p) {
+        setQuoteRefreshCountdown((prev) => (prev?.expired ? prev : null));
+      }
+      return;
+    }
+
     if (expiredTimer.current) {
       clearTimeout(expiredTimer.current);
       expiredTimer.current = undefined;
     }
+    setQuoteRefreshCountdown(null);
 
     if (p && !depositFlowActiveRef.current) {
+      const startedAt = Date.now();
+      const delay = 1000 * 20;
+      setQuoteRefreshCountdown({ startedAt, deadline: startedAt + delay });
       expiredTimer.current = setTimeout(() => {
+        expiredTimer.current = undefined;
+        setQuoteRefreshCountdown((prev) =>
+          prev ? { ...prev, expired: true } : null
+        );
         if (!depositFlowActiveRef.current && !quoteRefreshLockedRef.current) {
+          setPending(true);
           setRefreshId((e) => e + 1);
         }
-      }, 1000 * 20);
+      }, delay);
     }
 
     setOriActiveProvider(p);
@@ -399,6 +423,13 @@ export const useTokenPair = (userAddress: string) => {
   >();
 
   const expiredTimer = useRef<NodeJS.Timeout>();
+  const quoteFetchingRef = useRef(false);
+  const [quoteRefreshCountdown, setQuoteRefreshCountdown] = useState<{
+    startedAt: number;
+    deadline: number;
+    expired?: boolean;
+    frozen?: boolean;
+  } | null>(null);
   const depositFlowActiveRef = useRef(depositFlowActive);
   const previousDepositFlowActiveRef = useRef(depositFlowActive);
 
@@ -783,6 +814,10 @@ export const useTokenPair = (userAddress: string) => {
         }
       }
 
+      if (currentFetchId !== fetchIdRef.current) {
+        return;
+      }
+
       return getAllQuotes({
         userAddress,
         payToken,
@@ -852,6 +887,7 @@ export const useTokenPair = (userAddress: string) => {
       fetchIdRef.current += 1;
       setPending(false);
       cancelQuoteDebounce();
+      setQuoteRefreshCountdown(null);
       if (expiredTimer.current) {
         clearTimeout(expiredTimer.current);
         expiredTimer.current = undefined;
@@ -862,6 +898,7 @@ export const useTokenPair = (userAddress: string) => {
 
   useEffect(() => {
     if (depositFlowActive) {
+      setQuoteRefreshCountdown(null);
       if (expiredTimer.current) {
         clearTimeout(expiredTimer.current);
         expiredTimer.current = undefined;
@@ -876,6 +913,7 @@ export const useTokenPair = (userAddress: string) => {
   }, [cancelQuoteDebounce, depositFlowActive, setRefreshId]);
 
   const rawQuoteLoading = quoteLoading || pending;
+  quoteFetchingRef.current = rawQuoteLoading;
   const allQuotesLoaded = !rawQuoteLoading;
   const quoteListForDisplay = useMemo(() => {
     if (allQuotesLoaded || !payToken || !receiveToken) {
@@ -1034,6 +1072,7 @@ export const useTokenPair = (userAddress: string) => {
   }, []);
 
   useEffect(() => {
+    setQuoteRefreshCountdown(null);
     if (expiredTimer.current) {
       clearTimeout(expiredTimer.current);
       expiredTimer.current = undefined;
@@ -1041,6 +1080,7 @@ export const useTokenPair = (userAddress: string) => {
   }, [payToken?.id, receiveToken?.id, chain, inputAmount]);
 
   useEffect(() => {
+    setQuoteRefreshCountdown(null);
     if (expiredTimer.current) {
       clearTimeout(expiredTimer.current);
       expiredTimer.current = undefined;
@@ -1210,6 +1250,7 @@ export const useTokenPair = (userAddress: string) => {
 
   useEffect(() => {
     return () => {
+      fetchIdRef.current += 1;
       clearExpiredTimer();
     };
   }, [clearExpiredTimer]);
@@ -1249,6 +1290,7 @@ export const useTokenPair = (userAddress: string) => {
     //quote
     openQuotesList,
     quoteLoading: displayQuoteLoading,
+    quoteRefreshCountdown,
     allQuotesLoaded,
     quoteRequestId,
     quoteList: quoteListForDisplay,


### PR DESCRIPTION
Show a ring while quotes are valid, keep a full ring until the set is complete, and spin immediately when refresh starts so the next cycle does not restart early.