### PR TITLE
fix: add noopener to gas account history explorer link

### DIFF
--- a/src/ui/views/GasAccount/components/History.tsx
+++ b/src/ui/views/GasAccount/components/History.tsx
@@ -43,7 +43,7 @@ const HistoryItem = ({
 
   const gotoTxDetail = () => {
     if (txDetailUrl) {
-      window.open(txDetailUrl);
+      window.open(txDetailUrl, '_blank', 'noopener,noreferrer');
     }
   };
 


### PR DESCRIPTION
* window.open 打开跨域 https 页面，如果不指定 noopener，跨域页面可以用 opener.location.href="" 将插件页面导向其它页面，保险起见加一下