### PR TITLE
fix: pin broadcast target chain to approvalRes.chainId

### DIFF
--- a/src/background/controller/provider/controller.ts
+++ b/src/background/controller/provider/controller.ts
@@ -857,12 +857,10 @@ class ProviderController extends BaseController {
         console.log(e);
       }
     }
-    const chain =
-      permissionService.isInternalOrigin(origin) || isSpeedUp || isCancel
-        ? (findChain({
-            id: approvalRes.chainId,
-          })?.enum as CHAINS_ENUM)
-        : permissionService.getConnectedSite(origin)!.chain;
+    // Pin the broadcast chain to the approved transaction's chain; the
+    // connected site's chain is attacker-mutable mid-approval.
+    const chain = (findChain({ id: approvalRes.chainId })?.enum ??
+      permissionService.getConnectedSite(origin)?.chain) as CHAINS_ENUM;
 
     const approvingTx = transactionHistoryService.getSigningTx(signingTxId!);
 


### PR DESCRIPTION
* 绑定交易广播时的目标链到审批时的链，而不重新获取 dapp 当前链