### PR TITLE
Add Language Support: Azerbaijani

### DIFF
--- a/_raw/locales/az/messages.json
+++ b/_raw/locales/az/messages.json
@@ -1,0 +1,4904 @@
+{
+  "page": {
+    "transactions": {
+      "title": "Tranzaksiyalar",
+      "empty": {
+        "title": "Tranzaksiya yoxdur",
+        "desc": " <1>Dəstəklənən zəncirlərdə</1> tranzaksiya tapılmadı",
+        "noTxInThreeMonth": "Son 90 gündə tranzaksiya tarixçəsi yoxdur",
+        "descThreeMonths": "<2>Dəstəklənən zəncirlərdə</2> son 90 gündə tranzaksiya tarixçəsi yoxdur"
+      },
+      "explain": {
+        "approve": "{{project}} üçün {{amount}} {{symbol}} istifadəsinə icazə ver",
+        "unknown": "Kontraktla qarşılıqlı əlaqə",
+        "cancel": "Gözləyən tranzaksiya ləğv edildi"
+      },
+      "txHistory": {
+        "tipInputData": "Tranzaksiyada mesaj var",
+        "parseInputDataError": "Mesajı təhlil etmək alınmadı",
+        "scamToolTip": "Bu tranzaksiya saxta tokenlər və NFT-lər göndərmək üçün dələduzlar tərəfindən başladılıb. Onunla qarşılıqlı əlaqədən çəkinin."
+      },
+      "modalViewMessage": {
+        "title": "Mesaja bax"
+      },
+      "detail": {
+        "Pending": "Gözləyən",
+        "Failed": "Alınmadı",
+        "Succeeded": "Uğurlu"
+      },
+      "filterScam": {
+        "title": "Dələduzluq tranzaksiyalarını gizlət",
+        "loading": "Yüklənmə bir qədər vaxt apara bilər və məlumatlarda gecikmə mümkündür",
+        "btn": "Dələduzluq tranzaksiyalarını gizlət",
+        "button": "Saxta tranzaksiyaları gizlət"
+      },
+      "hideScamTips": "Dələduzluq tranzaksiyalarını gizlət",
+      "showScamTips": "Dələduzluq tranzaksiyalarını göstər"
+    },
+    "chainList": {
+      "title": "{{count}} zəncir inteqrasiya edilib",
+      "mainnet": "Mainnet-lər",
+      "testnet": "Testnet-lər"
+    },
+    "desktopSmallSwap": {
+      "title": "Kiçik qalıqları çevir",
+      "description": "Aktiv siyahınızı sadələşdirmək üçün az dəyərli tokenləri Gas tokeninə çevirin !",
+      "receiveTitle": "Alacağınız",
+      "expectedToReceive": "Alınması gözlənilən",
+      "completedTitle": "Kiçik qalıqlar çevrildi !",
+      "done": "Tamamla",
+      "conversionProgress": "Çevrilmənin gedişi",
+      "slippageTolerance": "Sürüşmə həddi",
+      "singleTransactionGasLimit": "Tək tranzaksiya üçün Gas limiti",
+      "startConvert": "Çevirməyə başla",
+      "unsupportedWalletType": "Bu ünvan növü dəstəklənmir",
+      "stop": "Dayandır",
+      "selectLowValueTokens": "Az dəyərli tokenləri seç",
+      "tokenColumn": "Token",
+      "amountColumn": "Məbləğ",
+      "valueColumn": "Dəyər",
+      "statusColumn": "Vəziyyət",
+      "noLowValueTokensFound": "Az dəyərli token tapılmadı",
+      "selectedTokens": "Seçilmiş tokenlər",
+      "totalValue": "Ümumi dəyər",
+      "moreChains": "+{{count}} zəncir",
+      "failReason": {
+        "missingRequiredParams": "Tələb olunan parametrlər çatışmır",
+        "quoteUnavailable": "Qiymət təklifini almaq alınmadı",
+        "gasCostTooHigh": "Gas haqqı limiti aşılıb",
+        "priceImpactTooHigh": "Qiymətə yüksək təsir",
+        "buildSwapTxsFailed": "Mübadilə tranzaksiyalarını yaratmaq alınmadı",
+        "sendSwapTxFailed": "Mübadilə tranzaksiyasını göndərmək alınmadı",
+        "transactionFailed": "Tranzaksiya alınmadı",
+        "submitFailed": "Tranzaksiyaları təqdim etmək alınmadı",
+        "gasNotEnough": "Gas kifayət etmir"
+      },
+      "stopTaskModal": {
+        "title": "Cari mübadilələr dayandırılsın?",
+        "description": "İndi dayandırsanız, qalan mübadilələr tamamlanmayacaq. Tamamlanmış mübadilələrin geri qaytarıla bilmədiyini nəzərə alın.",
+        "continueSwap": "Mübadiləyə davam et",
+        "stop": "Mübadiləni dayandır"
+      },
+      "swapFailed": "Mübadilə alınmadı, {{reason}}",
+      "status": {
+        "pending": "Mübadilə edilir",
+        "idle": "Mübadilə gözləyir",
+        "success": "Mübadilə uğurludur"
+      },
+      "completedTips": "Davam edən mübadilənin emalı davam edəcək",
+      "priceImpact": "Qiymətə təsir həddi",
+      "LedgerBtn": {
+        "start": "Ledger ilə başla",
+        "confirm": "Ledger ilə təsdiqləyin",
+        "continue": "Davam et",
+        "send": "İmzalama sorğusu göndərilir"
+      }
+    },
+    "staking": {
+      "title": "Steykinq",
+      "searchToken": "Token axtar",
+      "myHolding": "Aktivlərim",
+      "holding": "Aktivlər",
+      "protocol": "Protokol",
+      "actions": {
+        "deposit": "Yatır",
+        "withdraw": "Çıxar",
+        "claim": "Tələb et",
+        "max": "Maks",
+        "retry": "Yenidən cəhd et"
+      },
+      "filter": {
+        "allProtocol": "Bütün protokollar",
+        "allChains": "Bütün zəncirlər",
+        "selectProtocol": "Protokol seç",
+        "selectChain": "Zəncir seç",
+        "searchByName": "Ada görə axtar",
+        "searchProtocol": "Protokol axtar",
+        "searchChain": "Zəncir axtar",
+        "all": "Hamısı",
+        "clearFilter": "{{filter}} filtrini təmizlə"
+      },
+      "empty": {
+        "noPoolsFound": "Hovuz tapılmadı",
+        "noHoldingsFound": "Hazırda heç bir mövqeyiniz yoxdur.",
+        "noStakingPoolsFound": "Steykinq hovuzu tapılmadı",
+        "noProtocols": "Protokol yoxdur",
+        "noChains": "Zəncir yoxdur"
+      },
+      "error": {
+        "failedLoadData": "Steykinq məlumatlarını yükləmək alınmadı",
+        "failedLoadPools": "Steykinq hovuzlarını yükləmək alınmadı",
+        "failedLoadPool": "Steykinq hovuzunu yükləmək alınmadı",
+        "failedLoadChart": "Steykinq qrafikini yükləmək alınmadı",
+        "failedLoadPosition": "Mövqeni yükləmək alınmadı",
+        "transactionFailed": "Steykinq tranzaksiyası alınmadı"
+      },
+      "metrics": {
+        "tvl": "TVL",
+        "apr": "APR",
+        "apy": "APY",
+        "yield": "Gəlirlilik",
+        "lp": "Likvidlik",
+        "v2": "V2",
+        "v3": "V3"
+      },
+      "tabs": {
+        "portfolio": "Portfel",
+        "about": "Haqqında",
+        "security": "Təhlükəsizlik"
+      },
+      "detail": {
+        "poolNotFound": "Steykinq hovuzu tapılmadı",
+        "unsupportedAction": "Dəstəklənməyən steykinq əməliyyatı.",
+        "noChartData": "Qrafik məlumatı yoxdur"
+      },
+      "about": {
+        "pool": "Hovuz",
+        "address": "Ünvan",
+        "poolAddress": "Hovuz ünvanı",
+        "uptime": "İşləmə müddəti",
+        "days": "{{count}} gün",
+        "token": "Token",
+        "token1": "Token1",
+        "token2": "Token2",
+        "tokenAddress": "Token ünvanı",
+        "token1Address": "Token1 ünvanı",
+        "token2Address": "Token2 ünvanı",
+        "aboutProtocol": "{{protocol}} haqqında",
+        "noDescription": "Protokolun təsviri mövcud deyil.",
+        "showMore": "Daha çox göstər",
+        "showLess": "Daha az göstər",
+        "officialWebsite": "Rəsmi sayt",
+        "twitter": "X(Twitter)"
+      },
+      "security": {
+        "certifications": "Sertifikatlar",
+        "certifiedBy": "Sertifikatı verən",
+        "certifiedOn": "Sertifikat tarixi",
+        "action": "Əməliyyat",
+        "view": "Bax",
+        "noCertificationData": "Sertifikat məlumatı yoxdur"
+      },
+      "portfolio": {
+        "pending": "Gözləyən",
+        "succeed": "Uğurlu",
+        "failed": "Alınmadı",
+        "supplied": "Yatırılmış",
+        "rewards": "Mükafatlar",
+        "rewardsWithCount": "Mükafatlar ({{count}})",
+        "priceRange": "Qiymət aralığı",
+        "noSuppliedAssets": "Yatırılmış aktiv yoxdur",
+        "noRewards": "Hazırda mükafat yoxdur"
+      },
+      "actionModal": {
+        "receive": "Al",
+        "setPriceRange": "Qiymət aralığını təyin et",
+        "range": "Aralıq",
+        "unused": "İstifadə edilməmiş",
+        "unsupportedPool": "Dəstəklənməyən hovuz",
+        "unsupportedErc4626Pool": "Dəstəklənməyən ERC4626 hovuzu",
+        "unsupportedLpPool": "Dəstəklənməyən likvidlik hovuzu",
+        "unsupportedChain": "Dəstəklənməyən zəncir",
+        "unavailable": "Mövcud deyil",
+        "tokenFallback": "token",
+        "insufficientBalance": "{{symbols}} balansı kifayət etmir",
+        "noWithdrawablePosition": "Çıxarıla bilən mövqe yoxdur",
+        "noClaimableRewards": "Tələb edilə bilən mükafat yoxdur",
+        "submitted": "{{action}} təqdim edildi",
+        "submitFailed": "{{action}} sorğusunu təqdim etmək alınmadı",
+        "confirmPoolPriceDifference": "Hovuz qiyməti fərqini təsdiqlə",
+        "poolPriceWarning": "Qiymətə 10% təsir həddi arbitraj riskləri yaradır.",
+        "poolPriceTitle": "Hovuz qiyməti: 1 {{token0}} = {{poolPrice}} {{token1}}; bazar qiyməti: 1 {{token0}} = {{marketPrice}} {{token1}}",
+        "singleAssetDepositOnly": "Bazar qiyməti təyin etdiyiniz qiymət aralığından kənardadır. Yalnız bir aktiv yatırmaq olar.",
+        "failedResolveV2Pool": "V2 hovuzunu müəyyən etmək alınmadı",
+        "failedResolveV3Pool": "V3 hovuzunu müəyyən etmək alınmadı",
+        "noLpPositionToWithdraw": "Çıxarılacaq likvidlik mövqeyi yoxdur",
+        "v2RewardsUnsupported": "V2 mükafatları dəstəklənmir",
+        "selectV3PositionToWithdraw": "Çıxarılacaq V3 mövqeyini seçin"
+      }
+    },
+    "signTx": {
+      "nftIn": "Daxil olan NFT",
+      "gasLimitNotEnough": "Gas limiti 21000-dən azdır. Tranzaksiya təqdim edilə bilməz",
+      "gasLimitLessThanExpect": "Gas limiti aşağıdır. Tranzaksiyanın uğursuz olma ehtimalı 1%-dir.",
+      "gasLimitLessThanGasUsed": "Gas limiti çox aşağıdır. Tranzaksiyanın uğursuz olma ehtimalı 95%-dir.",
+      "nativeTokenNotEngouthForGas": "Gas balansı tranzaksiya üçün kifayət etmir",
+      "nonceLowerThanExpect": "Nonce çox aşağıdır, ən azı {{0}} olmalıdır",
+      "canOnlyUseImportedAddress": "İzləmə ünvanı ilə tranzaksiyaları imzalaya bilməzsiniz.",
+      "multiSigChainNotMatch": "Çoximzalı ünvanlar bu zəncirdə deyil və tranzaksiya başlada bilməz",
+      "safeAddressNotSupportChain": "Cari Safe ünvanı {{0}} zəncirində dəstəklənmir",
+      "noGasRequired": "Gas tələb olunmur",
+      "gasSelectorTitle": "Gas",
+      "failToFetchGasCost": "Gas-ı hesablamaq alınmadı",
+      "gasMoreButton": "Daha çox",
+      "manuallySetGasLimitAlert": "Əl ilə təyin etdiyiniz Gas limiti",
+      "gasNotRequireForSafeTransaction": "Safe tranzaksiyaları üçün Gas haqqı tələb olunmur",
+      "gasPriceTitle": "Gas qiyməti (Gwei)",
+      "maxPriorityFee": "Maksimal prioritet haqqı (Gwei)",
+      "eip1559Desc1": "EIP-1559-u dəstəkləyən zəncirlərdə prioritet haqqı tranzaksiyanızı emal etmək üçün maynerlərə verilən bəxşişdir. Prioritet haqqını azaltmaqla yekun Gas xərcinə qənaət edə bilərsiniz, lakin tranzaksiyanın emalı daha çox vaxt apara bilər.",
+      "eip1559Desc2": "Rabby-də prioritet haqqı (bəxşiş) = maksimal haqq - baza haqqı. Maksimal prioritet haqqını təyin etdikdən sonra baza haqqı ondan çıxılacaq və qalan hissə maynerlərə bəxşiş kimi veriləcək.",
+      "hardwareSupport1559Alert": "Aparat pul kisənizin daxili proqramının EIP 1559-u dəstəkləyən versiyaya yeniləndiyinə əmin olun",
+      "gasLimitTitle": "Gas limiti",
+      "recommendGasLimitTip": "Təx. {{est}}. Cari {{current}}x, tövsiyə edilən ",
+      "nonceTitle": "Nonce",
+      "gasLimitModifyOnlyNecessaryAlert": "Yalnız zəruri olduqda dəyişdirin",
+      "gasPriceMedian": "Zəncirdəki son 100 tranzaksiyanın medianı: ",
+      "myNativeTokenBalance": "Gas balansım: ",
+      "gasLimitEmptyAlert": "Gas limitini daxil edin",
+      "gasLimitMinValueAlert": "Gas limiti 21000-dən çox olmalıdır",
+      "nativeTokenForGas": "Gas haqqını ödəmək üçün {{chainName}} zəncirindəki {{tokenName}} tokenindən istifadə edin",
+      "gasAccountForGas": "Gas haqqını ödəmək üçün Gas hesabımdakı USD-dən istifadə edin",
+      "gasAccount": {
+        "description": "Gas haqları Gas hesabı ilə ödənilir. Ödəniş təfərrüatlarına aşağıda baxın:",
+        "totalCost": "Ümumi xərc: ",
+        "currentTxCost": "Ünvanınıza göndərilən Gas məbləği: ",
+        "gasCost": "Ünvanınıza Gas köçürmək üçün Gas xərci: ",
+        "estimatedGas": "Təxmini Gas: ",
+        "maxGas": "Maksimal Gas: ",
+        "sendGas": "Cari tranzaksiya üçün sizə köçürülən Gas: "
+      },
+      "balanceChange": {
+        "successTitle": "Simulyasiya nəticələri",
+        "failedTitle": "Simulyasiya alınmadı",
+        "noBalanceChange": "Balans dəyişikliyi yoxdur",
+        "tokenOut": "Çıxan token",
+        "tokenIn": "Daxil olan token",
+        "errorTitle": "Balans dəyişikliyini almaq alınmadı",
+        "notSupport": "Simulyasiya dəstəklənmir",
+        "nftOut": "Çıxan NFT"
+      },
+      "enoughSafeSigCollected": "Kifayət qədər imza toplanıb",
+      "moreSafeSigNeeded": "Təsdiqləmək üçün daha {{0}} imza lazımdır",
+      "safeAdminSigned": "İmzalanıb",
+      "customRPCErrorModal": {
+        "title": "Fərdi RPC xətası",
+        "content": "Fərdi RPC-niz hazırda mövcud deyil. Onu söndürüb Rabby-nin rəsmi RPC-si ilə imzalamağa davam edə bilərsiniz",
+        "button": "Fərdi RPC-ni söndür"
+      },
+      "swap": {
+        "title": "Token mübadiləsi",
+        "payToken": "Ödə",
+        "receiveToken": "Al",
+        "failLoadReceiveToken": "Yükləmək alınmadı",
+        "valueDiff": "Dəyər fərqi",
+        "simulationFailed": "Tranzaksiya simulyasiyası alınmadı",
+        "simulationNotSupport": "Bu zəncirdə tranzaksiya simulyasiyası dəstəklənmir",
+        "minReceive": "Alınacaq minimum məbləğ",
+        "slippageFailToLoad": "Yükləmək alınmadı",
+        "slippageTolerance": "Sürüşmə həddi",
+        "receiver": "Alıcı",
+        "notPaymentAddress": "Ödəniş ünvanı deyil",
+        "unknownAddress": "Naməlum ünvan"
+      },
+      "crossChain": {
+        "title": "Zəncirlərarası köçürmə"
+      },
+      "swapAndCross": {
+        "title": "Token mübadiləsi və zəncirlərarası köçürmə"
+      },
+      "wrapToken": "Tokenin bükülməsi",
+      "unwrap": "Tokenin açılması",
+      "transferOwner": {
+        "title": "Aktivlərin mülkiyyətinin ötürülməsi",
+        "description": "Təsvir",
+        "transferTo": "Köçürüləcək ünvan"
+      },
+      "swapLimitPay": {
+        "title": "Token mübadiləsində ödəniş limiti",
+        "maxPay": "Maksimum ödəniş"
+      },
+      "addLiquidity": {
+        "title": "Likvidliyin əlavə edilməsi",
+        "token0": "1-ci tokeni əlavə et",
+        "token1": "2-ci tokeni əlavə et",
+        "poolPrice": "Hovuz qiyməti",
+        "marketPrice": "Bazar qiyməti",
+        "priceDiff": "Qiymət fərqi",
+        "receiver": "Alıcı"
+      },
+      "send": {
+        "title": "Token göndər",
+        "sendToken": "Token göndər",
+        "sendTo": "Göndəriləcək ünvan",
+        "receiverIsTokenAddress": "Token ünvanı",
+        "contractNotOnThisChain": "Bu zəncirdə deyil",
+        "notTopupAddress": "Yatırma ünvanı deyil",
+        "tokenNotSupport": "{{0}} dəstəklənmir",
+        "onMyWhitelist": "Ağ siyahımdadır",
+        "notOnThisChain": "Bu zəncirdə deyil",
+        "cexAddress": "CEX ünvanı",
+        "addressBalanceTitle": "Ünvan balansı",
+        "whitelistTitle": "Ağ siyahı",
+        "notOnWhitelist": "Ağ siyahımda deyil",
+        "scamAddress": "Dələduzluq ünvanı",
+        "fromMySeedPhrase": "Bərpa ifadəmdən",
+        "fromMyPrivateKey": "Şəxsi açarımdan"
+      },
+      "tokenApprove": {
+        "title": "Token icazəsi",
+        "approveToken": "Token istifadəsinə icazə ver",
+        "myBalance": "Balansım",
+        "approveTo": "İcazə verilən ünvan",
+        "eoaAddress": "Xarici hesab",
+        "trustValueLessThan": "≤ {{value}}",
+        "deployTimeLessThan": "< {{value}} gün",
+        "amountPopupTitle": "İcazə məbləği",
+        "flagByRabby": "Rabby tərəfindən işarələnib",
+        "contractTrustValueTip": "Etibar dəyəri bu kontraktın xərclədiyi aktivlərin ümumi dəyəridir. Aşağı etibar dəyəri riskə və ya 180 günlük fəaliyyətsizliyə işarə edir.",
+        "amount": "İcazə məbləği:",
+        "exceed": "Cari balansınızı aşır"
+      },
+      "revokeTokenApprove": {
+        "title": "Token icazəsinin geri alınması",
+        "revokeFrom": "İcazəsi geri alınan ünvan",
+        "revokeToken": "Token icazəsini geri al"
+      },
+      "sendNFT": {
+        "title": "NFT göndərilməsi",
+        "nftNotSupport": "NFT dəstəklənmir"
+      },
+      "nftApprove": {
+        "title": "NFT icazəsi",
+        "approveNFT": "NFT istifadəsinə icazə ver",
+        "nftContractTrustValueTip": "Etibar dəyəri bu kontraktın xərclədiyi ən yüksək NFT dəyəridir. Aşağı etibar dəyəri riskə və ya 180 günlük fəaliyyətsizliyə işarə edir."
+      },
+      "revokeNFTApprove": {
+        "title": "NFT icazəsinin geri alınması",
+        "revokeNFT": "NFT icazəsini geri al"
+      },
+      "nftCollectionApprove": {
+        "title": "NFT kolleksiyasının icazəsi",
+        "approveCollection": "Kolleksiyanın istifadəsinə icazə ver"
+      },
+      "revokeNFTCollectionApprove": {
+        "title": "NFT kolleksiyasının icazəsinin geri alınması",
+        "revokeCollection": "Kolleksiya icazəsini geri al"
+      },
+      "deployContract": {
+        "title": "Kontraktın yerləşdirilməsi",
+        "descriptionTitle": "Təsvir",
+        "description": "Smart kontrakt yerləşdirirsiniz"
+      },
+      "cancelTx": {
+        "title": "Gözləyən tranzaksiyanı ləğv et",
+        "txToBeCanceled": "Ləğv ediləcək tranzaksiya",
+        "gasPriceAlert": "Gözləyən tranzaksiyanı ləğv etmək üçün cari Gas qiymətini {{value}} Gwei-dən yüksək təyin edin"
+      },
+      "submitMultisig": {
+        "title": "Çoximzalı tranzaksiyanın təqdim edilməsi",
+        "multisigAddress": "Çoximzalı ünvan"
+      },
+      "contractCall": {
+        "title": "Kontrakt çağırışı",
+        "operation": "Əməliyyat",
+        "operationABIDesc": "Əməliyyat ikili interfeysdən dekodlaşdırılıb",
+        "operationCantDecode": "Əməliyyat dekodlaşdırılmayıb",
+        "payNativeToken": "{{symbol}} ödə",
+        "suspectedReceiver": "Gözlənilməyən ünvan",
+        "receiver": "Alıcının ünvanı"
+      },
+      "revokePermit2": {
+        "title": "Permit2 icazəsinin geri alınması"
+      },
+      "batchRevokePermit2": {
+        "title": "Permit2 icazələrinin toplu geri alınması"
+      },
+      "revokePermit": {
+        "title": "Permit token icazəsinin geri alınması"
+      },
+      "assetOrder": {
+        "title": "Aktiv sifarişi",
+        "listAsset": "Aktivi satışa çıxar",
+        "receiveAsset": "Aktivi al"
+      },
+      "safeServiceNotAvailable": "Safe xidməti hazırda əlçatan deyil, sonra yenidən cəhd edin",
+      "unknownAction": "Naməlum imza növü",
+      "interactContract": "Kontraktla qarşılıqlı əlaqə",
+      "markAsTrust": "Etibarlı kimi işarələnib",
+      "markAsBlock": "Bloklanmış kimi işarələnib",
+      "interacted": "Əvvəllər qarşılıqlı əlaqə olub",
+      "neverInteracted": "Əvvəllər qarşılıqlı əlaqə olmayıb",
+      "transacted": "Əvvəllər tranzaksiya aparılıb",
+      "neverTransacted": "Əvvəllər tranzaksiya aparılmayıb",
+      "importedAddress": "İdxal edilmiş ünvan",
+      "fakeTokenAlert": "Bu, Rabby tərəfindən işarələnmiş dələduzluq tokenidir",
+      "scamTokenAlert": "Rabby-nin yoxlamasına görə bu token keyfiyyətsiz və dələduzluq məqsədli ola bilər",
+      "trusted": "Etibarlı",
+      "blocked": "Bloklanıb",
+      "noMark": "İşarə yoxdur",
+      "markRemoved": "İşarə silindi",
+      "speedUpTooltip": "Bu sürətləndirilmiş tranzaksiya ilə ilkin tranzaksiyadan yalnız biri tamamlanacaq",
+      "decodedTooltip": "Bu imza Rabby pul kisəsi tərəfindən dekodlaşdırılıb",
+      "signTransactionOnChain": "{{chain}} tranzaksiyasını imzala",
+      "viewRaw": "Xam məlumatlara bax",
+      "chain": "Zəncir",
+      "unknownActionType": "Naməlum əməliyyat növü",
+      "sigCantDecode": "Rabby pul kisəsi bu imzanı dekodlaşdıra bilmir",
+      "nftCollection": "NFT kolleksiyası",
+      "floorPrice": "Minimum qiymət",
+      "contractAddress": "Kontrakt ünvanı",
+      "protocolTitle": "Protokol",
+      "deployTimeTitle": "Yerləşdirilmə vaxtı",
+      "popularity": "Populyarlıq",
+      "contractPopularity": "{{1}} üzrə №{{0}}",
+      "addressNote": "Ünvan qeydi",
+      "myMarkWithContract": "{{chainName}} kontraktındakı işarəm",
+      "myMark": "İşarəm",
+      "collectionTitle": "Kolleksiya",
+      "addressTypeTitle": "Ünvan növü",
+      "firstOnChain": "Zəncirdə ilk fəaliyyət",
+      "trustValue": "Etibar dəyəri",
+      "importedDelegatedAddress": "İdxal edilmiş səlahiyyətli ünvan",
+      "noDelegatedAddress": "İdxal edilmiş səlahiyyətli ünvan yoxdur",
+      "coboSafeNotPermission": "Bu səlahiyyətli ünvanın bu tranzaksiyanı başlatmağa icazəsi yoxdur",
+      "l2GasEstimateTooltip": "L2 zənciri üçün Gas təxmininə L1 Gas haqqı daxil deyil. Faktiki haqq cari təxmindən yüksək olacaq.",
+      "BroadcastMode": {
+        "instant": {
+          "title": "Ani",
+          "desc": "Tranzaksiyalar dərhal şəbəkəyə yayımlanacaq"
+        },
+        "lowGas": {
+          "title": "Gas qənaəti",
+          "desc": "Tranzaksiyalar şəbəkədə Gas qiyməti aşağı olduqda yayımlanacaq"
+        },
+        "mev": {
+          "title": "MEV qoruması",
+          "desc": "Tranzaksiyalar təyin edilmiş MEV qovşağına yayımlanacaq"
+        },
+        "title": "Yayımlama rejimi",
+        "tips": {
+          "walletConnect": "WalletConnect tərəfindən dəstəklənmir",
+          "notSupportChain": "Bu zəncirdə dəstəklənmir",
+          "customRPC": "Xüsusi RPC istifadə edildikdə dəstəklənmir",
+          "notSupported": "Dəstəklənmir"
+        },
+        "lowGasDeadline": {
+          "label": "Gözləmə müddəti",
+          "1h": "1 saat",
+          "4h": "4 saat",
+          "24h": "24 saat"
+        }
+      },
+      "safeTx": {
+        "selfHostConfirm": {
+          "title": "Rabby-nin Safe xidmətinə keç",
+          "content": "Safe API-si əlçatan deyil. Safe-in işləməsi üçün Rabby tərəfindən yerləşdirilmiş Safe xidmətinə keçin. <strong>Bütün Safe imzaçıları tranzaksiyalara icazə vermək üçün Rabby pul kisəsindən istifadə etməlidir.</strong>",
+          "button": "Oldu"
+        }
+      },
+      "SafeNonceSelector": {
+        "explain": {
+          "contractCall": "Kontrakt çağırışı",
+          "send": "Token göndər",
+          "unknown": "Naməlum tranzaksiya"
+        },
+        "optionGroup": {
+          "recommendTitle": "Tövsiyə edilən Nonce",
+          "replaceTitle": "Növbədəki tranzaksiyanı əvəz et "
+        },
+        "option": {
+          "new": "Yeni tranzaksiya"
+        },
+        "error": {
+          "pendingList": "Gözləyən tranzaksiyaları yükləmək alınmadı, <1/><2>Yenidən cəhd et</2>"
+        }
+      },
+      "coboSafeCreate": {
+        "safeWalletTitle": "Safe{Wallet}",
+        "descriptionTitle": "Təsvir",
+        "title": "Cobo Safe yarat"
+      },
+      "coboSafeModificationRole": {
+        "title": "Safe rol dəyişikliyini təqdim et",
+        "safeWalletTitle": "Safe{Wallet}",
+        "descriptionTitle": "Təsvir"
+      },
+      "coboSafeModificationDelegatedAddress": {
+        "title": "Səlahiyyətli ünvan dəyişikliyini təqdim et",
+        "safeWalletTitle": "Safe{Wallet}",
+        "descriptionTitle": "Təsvir"
+      },
+      "coboSafeModificationTokenApproval": {
+        "title": "Token icazəsi dəyişikliyini təqdim et",
+        "safeWalletTitle": "Safe{Wallet}",
+        "descriptionTitle": "Təsvir"
+      },
+      "common": {
+        "description": "Təsvir",
+        "interactContract": "Kontraktla qarşılıqlı əlaqə",
+        "descTipSafe": "İmza aktivləri dəyişdirmir və ünvan sahibliyini yoxlamır",
+        "descTipWarningPrivacy": "İmza ünvan sahibliyini yoxlaya bilər",
+        "descTipWarningAssets": "İmza aktivləri dəyişdirə bilər",
+        "descTipWarningBoth": "İmza aktivləri dəyişdirə və ünvan sahibliyini yoxlaya bilər"
+      },
+      "protocol": "Protokol",
+      "yes": "Bəli",
+      "no": "Xeyr",
+      "hasInteraction": "Əvvəllər qarşılıqlı əlaqə olub",
+      "address": "Ünvan",
+      "advancedSettings": "Əlavə parametrlər",
+      "amount": "Məbləğ",
+      "contract": "Smart kontrakt ünvanı",
+      "trustValueTitle": "Etibar dəyəri",
+      "typedDataMessage": "Tipləşdirilmiş məlumatları imzala",
+      "label": "Etiket",
+      "addressSource": "Ünvan mənbəyi",
+      "maxPriorityFeeDisabledAlert": "Əvvəlcə Gas qiymətini təyin edin",
+      "primaryType": "Əsas növ",
+      "errorRetry": {
+        "defaultTips": "Xəta baş verdi. Sonra yenidən cəhd edin.",
+        "insufficient": "Gas balansınız şəbəkənin Gas haqqını ödəmək üçün kifayət deyil. Gas üçün vəsait əlavə edib yenidən cəhd edin.",
+        "gasPriceTooLow": "Gas qiyməti çox aşağıdır. Tranzaksiyanın təsdiqlənməsi üçün onu 30% artıracağıq. Təsdiqləyib yenidən cəhd etmək üçün “Yenidən cəhd et” düyməsinə klikləyin.",
+        "nonceTooLow": "Nonce çox aşağıdır. Dəyərini {{nonce}} edəcəyik. Təsdiqləyib yenidən cəhd etmək üçün “Yenidən cəhd et” düyməsinə klikləyin.",
+        "nonceTooHigh": "Nonce çox yüksəkdir. Nonce dəyərini düzəldib yenidən cəhd edin.",
+        "alreadySubmitted": "Tranzaksiya artıq göndərilib. Təkrar tranzaksiya aşkarlandı.",
+        "gasExceedsBlockGasLimit": "Gas sərfi blokun Gas limitini aşır. Düzəldib yenidən cəhd edin.",
+        "InvalidTx": "Etibarsız tranzaksiya.",
+        "gasLimitTooLow": "Gas limiti çox aşağıdır"
+      },
+      "signMessageTag": {
+        "contract": "Kontrakt:",
+        "eoa": "EOA:"
+      }
+    },
+    "signFooterBar": {
+      "requestFrom": "Sorğu mənbəyi",
+      "processRiskAlert": "İmzalamadan əvvəl xəbərdarlığı nəzərdən keçirin",
+      "ignoreAll": "Heç birini nəzərə alma",
+      "gridPlusConnected": "GridPlus qoşulub",
+      "gridPlusNotConnected": "GridPlus qoşulmayıb",
+      "connectButton": "Qoşul",
+      "connecting": "Qoşulur...",
+      "ledgerNotConnected": "Ledger qoşulmayıb",
+      "keystoneNotConnected": "Keystone qoşulmayıb",
+      "keystoneConnected": "Keystone qoşulub",
+      "ledgerConnected": "Ledger qoşulub",
+      "signAndSubmitButton": "İmzala",
+      "gasless": {
+        "unavailable": "Gas balansınız kifayət deyil",
+        "notEnough": "Gas balansı kifayət deyil",
+        "GetFreeGasToSign": "Pulsuz Gas al",
+        "rabbyPayGas": "Lazım olan Gas haqqını Rabby ödəyəcək, sadəcə imzalayın",
+        "customRpcUnavailableTip": "Pulsuz Gas üçün xüsusi RPC-lər dəstəklənmir",
+        "walletConnectUnavailableTip": "Pulsuz Gas üçün WalletConnect vasitəsilə qoşulmuş mobil pul kisəsi dəstəklənmir",
+        "watchUnavailableTip": "Pulsuz Gas üçün izləmə ünvanı dəstəklənmir"
+      },
+      "gasAccount": {
+        "customRPC": "Xüsusi RPC istifadə edildikdə dəstəklənmir",
+        "notEnough": "Gas kifayət deyil. Gas balansı: {{usd}}",
+        "useGasAccount": "Gas hesabından istifadə et",
+        "WalletConnectTips": "Gas hesabı WalletConnect-i dəstəkləmir",
+        "chainNotSupported": "Gas hesabı bu zənciri dəstəkləmir",
+        "loginFirst": "Əvvəlcə Gas hesabına daxil olun",
+        "signWithHardwareWalletToUse": "İstifadə etmək üçün {{brand}} ilə imzalamalısınız",
+        "login": "Daxil ol",
+        "gotIt": "Anladım",
+        "deposit": "Yatır",
+        "depositTips": "Gas hesabına vəsait yatırmağı tamamlamaq üçün bu tranzaksiya ləğv ediləcək. Vəsait yatırdıqdan sonra onu yenidən yaratmalısınız.",
+        "loginTips": "Gas hesabına girişi tamamlamaq üçün bu tranzaksiya ləğv ediləcək. Girişdən sonra onu yenidən yaratmalısınız."
+      },
+      "walletConnect": {
+        "connectedButCantSign": "Qoşulub, lakin imzalamaq mümkün deyil.",
+        "switchToCorrectAddress": "Mobil pul kisəsində düzgün ünvana keçin",
+        "switchChainAlert": "Mobil pul kisəsində {{chain}} zəncirinə keçin",
+        "notConnectToMobile": "{{brand}} ilə qoşulma yoxdur",
+        "connected": "Qoşulub və imzalamağa hazırdır",
+        "howToSwitch": "Keçid qaydası",
+        "wrongAddressAlert": "Mobil pul kisəsində başqa ünvana keçmisiniz. Mobil pul kisəsində düzgün ünvana keçin",
+        "connectBeforeSign": "{{0}} Rabby-yə qoşulmayıb, imzalamadan əvvəl qoşun",
+        "chainSwitched": "Mobil pul kisəsində başqa zəncirə keçmisiniz. Mobil pul kisəsində {{0}} zəncirinə keçin",
+        "latency": "Gecikmə",
+        "requestSuccessToast": "Sorğu uğurla göndərildi",
+        "sendingRequest": "İmzalama sorğusu göndərilir",
+        "signOnYourMobileWallet": "Mobil pul kisənizdə imzalayın.",
+        "requestFailedToSend": "İmzalama sorğusunu göndərmək alınmadı"
+      },
+      "beginSigning": "İmzalama prosesini başlat",
+      "addressTip": {
+        "onekey": "OneKey ünvanı",
+        "trezor": "Trezor ünvanı",
+        "bitbox": "BitBox02 ünvanı",
+        "keystone": "Keystone ünvanı",
+        "airgap": "AirGap ünvanı",
+        "coolwallet": "CoolWallet ünvanı",
+        "privateKey": "Şəxsi açar ünvanı",
+        "seedPhrase": "Bərpa ifadəsi ünvanı",
+        "watchAddress": "İzləmə ünvanı ilə imzalamaq mümkün deyil",
+        "safe": "Safe ünvanı",
+        "coboSafe": "Cobo Argus ünvanı",
+        "seedPhraseWithPassphrase": "Bərpa ifadəsi ünvanı (əlavə parol)"
+      },
+      "qrcode": {
+        "signWith": "{{brand}} ilə imzala",
+        "failedToGetExplain": "İzahı almaq alınmadı",
+        "txFailed": "Yaratmaq alınmadı",
+        "txFailedRetry": "Yaratmaq alınmadı: yenidən cəhd edin",
+        "txFailedBy": "{{category}} alınmadı",
+        "retryTxFailedBy": "{{category}} alınmadı: yenidən cəhd edin",
+        "sigReceived": "İmza alındı",
+        "sigCompleted": "Tranzaksiya yaradıldı",
+        "getSig": "İmzanı al",
+        "qrcodeDesc": "İmzalamaq üçün {{brand}} ilə skan edin<br></br>İmzaladıqdan sonra imzanı almaq üçün aşağıdakı düyməyə klikləyin",
+        "misMatchSignId": "Tranzaksiya məlumatları uyğun gəlmir. Tranzaksiya təfərrüatlarını yoxlayın.",
+        "unknownQRCode": "Xəta: Bu QR kodunu tanımaq mümkün olmadı",
+        "afterSignDesc": "İmzaladıqdan sonra {{brand}} üzərindəki QR kodunu kompüterinizin kamerasına göstərin"
+      },
+      "keystone": {
+        "signWith": "İmzalamaq üçün {{method}} üsuluna keç",
+        "qrcodeDesc": "İmzalamaq üçün skan edin. İmzaladıqdan sonra imzanı almaq üçün aşağıya klikləyin. USB üçün yenidən qoşulun və imzalama prosesini yenidən başlatmağa icazə verin.",
+        "misMatchSignId": "Tranzaksiya məlumatları uyğun gəlmir. Tranzaksiya təfərrüatlarını yoxlayın.",
+        "unsupportedType": "Xəta: Tranzaksiya növü dəstəklənmir və ya naməlumdur.",
+        "siging": "İmzalama sorğusu göndərilir",
+        "txRejected": "Tranzaksiya rədd edildi",
+        "shouldRetry": "Xəta baş verdi. Yenidən cəhd edin.",
+        "hardwareRejectError": "Keystone sorğusu ləğv edildi. Davam etmək üçün yenidən icazə verin.",
+        "mismatchedWalletError": "Pul kisəsi uyğun gəlmir",
+        "verifyPasswordError": "İmzalama alınmadı, kiliddən çıxardıqdan sonra yenidən cəhd edin",
+        "shouldOpenKeystoneHomePageError": "Keystone 3 Pro cihazınızın əsas səhifədə olduğuna əmin olun"
+      },
+      "ledger": {
+        "resent": "Yenidən göndərildi",
+        "signError": "Ledger imzalama xətası:",
+        "notConnected": "Pul kisəniz qoşulmayıb. Yenidən qoşulun.",
+        "siging": "İmzalama sorğusu göndərilir",
+        "txRejected": "Tranzaksiya rədd edildi",
+        "unlockAlert": "Ledger cihazınızı qoşub kiliddən çıxarın və onda Ethereum tətbiqini açın",
+        "updateFirmwareAlert": "Ledger cihazınızın daxili proqramını və Ethereum tətbiqini yeniləyin",
+        "txRejectedByLedger": "Tranzaksiya Ledger cihazınızda rədd edildi",
+        "blindSigTutorial": "Ledger-dən kor imzalama təlimatı",
+        "submitting": "İmzalandı. Tranzaksiya yaradılır",
+        "resubmited": "Yenidən təqdim edildi"
+      },
+      "common": {
+        "notSupport": "{{0}} dəstəklənmir"
+      },
+      "iGotIt": "Anladım",
+      "resend": "Yenidən cəhd et",
+      "submitTx": "Tranzaksiyanı göndər",
+      "testnet": "Testnet",
+      "mainnet": "Mainnet",
+      "cancelTransaction": "Tranzaksiyanı ləğv et",
+      "detectedMultipleRequestsFromThisDapp": "Bu Dapp-dan bir neçə sorğu aşkarlandı",
+      "cancelCurrentTransaction": "Cari tranzaksiyanı ləğv et",
+      "cancelAll": "Dapp-dan gələn bütün {{count}} sorğunu ləğv et",
+      "blockDappFromSendingRequests": "Dapp-ın sorğu göndərməsini 1 dəqiqəlik blokla",
+      "cancelConnection": "Qoşulmanı ləğv et",
+      "cancelCurrentConnection": "Cari qoşulmanı ləğv et",
+      "imKeyNotConnected": "imKey qoşulmayıb",
+      "imKeyConnected": "imKey qoşulub"
+    },
+    "signTypedData": {
+      "signTypeDataOnChain": "{{chain}} tipləşdirilmiş məlumatlarını imzala",
+      "safeCantSignText": "Bu, Safe ünvanıdır və mətn imzalamaq üçün istifadə edilə bilməz.",
+      "permit": {
+        "title": "Permit token icazəsi"
+      },
+      "permit2": {
+        "title": "Permit2 token icazəsi",
+        "sigExpireTimeTip": "Bu imzanın zəncirdə etibarlı olacağı müddət",
+        "sigExpireTime": "İmzanın bitmə vaxtı",
+        "approvalExpiretime": "İcazənin bitmə vaxtı"
+      },
+      "swapTokenOrder": {
+        "title": "Token sifarişi"
+      },
+      "sellNFT": {
+        "title": "NFT sifarişi",
+        "receiveToken": "Token al",
+        "listNFT": "NFT-ni satışa çıxar",
+        "specificBuyer": "Konkret alıcı"
+      },
+      "signMultiSig": {
+        "title": "Tranzaksiyanı təsdiqlə"
+      },
+      "createKey": {
+        "title": "Açar yarat"
+      },
+      "verifyAddress": {
+        "title": "Ünvanı yoxla"
+      },
+      "buyNFT": {
+        "payToken": "Tokenlə ödə",
+        "receiveNFT": "NFT al",
+        "expireTime": "Bitmə vaxtı",
+        "listOn": "Satış platforması"
+      },
+      "contractCall": {
+        "operationDecoded": "Əməliyyat mesajdan dekodlaşdırılıb"
+      },
+      "safeCantSignTypedData": "Bu, Safe ünvanıdır və yalnız EIP-712 tipləşdirilmiş məlumatlarının və ya mətn sətirlərinin imzalanmasını dəstəkləyir"
+    },
+    "activities": {
+      "title": "İmza qeydləri",
+      "signedTx": {
+        "label": "Tranzaksiyalar",
+        "empty": {
+          "title": "Hələ imzalanmış tranzaksiya yoxdur",
+          "desc": "Rabby vasitəsilə imzalanmış bütün tranzaksiyalar burada göstəriləcək."
+        },
+        "common": {
+          "unlimited": "məhdudiyyətsiz",
+          "unknownProtocol": "Naməlum protokol",
+          "unknown": "Naməlum",
+          "speedUp": "Sürətləndir",
+          "cancel": "Ləğv et",
+          "pendingDetail": "Gözləyən tranzaksiya təfərrüatları"
+        },
+        "tips": {
+          "pendingDetail": "Yalnız bir tranzaksiya tamamlanacaq və bu, demək olar ki, həmişə ən yüksək Gas qiyməti olan tranzaksiyadır",
+          "canNotCancel": "Sürətləndirmək və ya ləğv etmək mümkün deyil: ilk gözləyən tranzaksiya deyil",
+          "pendingBroadcast": "Gas qənaəti rejimi: daha aşağı şəbəkə haqları gözlənilir. Maksimum gözləmə: {{deadline}} saat.",
+          "pendingBroadcastBtn": "İndi yayımla",
+          "pendingBroadcastRetry": "Yayımlamaq alınmadı. Son cəhd: {{pushAt}}",
+          "pendingBroadcastRetryBtn": "Yenidən yayımla"
+        },
+        "status": {
+          "canceled": "Ləğv edilib",
+          "failed": "Alınmadı",
+          "submitFailed": "Göndərmək alınmadı",
+          "pending": "Gözləyən",
+          "withdrawed": "Sürətli ləğv",
+          "pendingBroadcasted": "Gözləyir: yayımlanıb",
+          "pendingBroadcast": "Gözləyir: yayımlanacaq",
+          "pendingBroadcastFailed": "Gözləyir: yayımlamaq alınmadı"
+        },
+        "txType": {
+          "initial": "İlkin tranzaksiya",
+          "cancel": "Ləğv tranzaksiyası",
+          "speedUp": "Sürətləndirmə tranzaksiyası"
+        },
+        "explain": {
+          "unknown": "Naməlum tranzaksiya",
+          "send": "{{amount}} {{symbol}} göndər",
+          "cancel": "{{protocol}} üçün {{token}} icazəsini ləğv et",
+          "approve": "{{protocol}} üçün {{count}} {{token}} istifadəsinə icazə ver",
+          "cancelNFTCollectionApproval": "{{protocol}} üçün NFT kolleksiyası icazəsini ləğv et",
+          "cancelSingleNFTApproval": "{{protocol}} üçün tək NFT icazəsini ləğv et",
+          "singleNFTApproval": "{{protocol}} üçün tək NFT icazəsi",
+          "nftCollectionApproval": "{{protocol}} üçün NFT kolleksiyası icazəsi"
+        },
+        "CancelTxPopup": {
+          "title": "Tranzaksiyanı ləğv et",
+          "options": {
+            "quickCancel": {
+              "title": "Sürətli ləğv",
+              "desc": "Yayımlamadan əvvəl ləğv edin, Gas haqqı yoxdur",
+              "tips": "Yalnız yayımlanmamış tranzaksiyalar üçün dəstəklənir"
+            },
+            "onChainCancel": {
+              "title": "Zəncirdə ləğv",
+              "desc": "Ləğv üçün yeni tranzaksiya, Gas tələb edir"
+            },
+            "removeLocalPendingTx": {
+              "title": "Gözləyənləri lokal olaraq təmizlə",
+              "desc": "Gözləyən tranzaksiyanı interfeysdən çıxar"
+            }
+          },
+          "removeLocalPendingTx": {
+            "title": "Tranzaksiyanı lokal olaraq sil",
+            "desc": "Bu əməliyyat gözləyən tranzaksiyanı lokal olaraq siləcək. Gözləyən tranzaksiya gələcəkdə yenə də uğurla göndərilə bilər."
+          }
+        },
+        "MempoolList": {
+          "empty": "Heç bir qovşaqda tapılmadı",
+          "reBroadcastBtn": "Yenidən yayımla",
+          "title": "{{count}} RPC qovşağında görünüb"
+        },
+        "message": {
+          "reBroadcastSuccess": "Yenidən yayımlandı",
+          "broadcastSuccess": "Yayımlandı",
+          "cancelSuccess": "Ləğv edilib",
+          "deleteSuccess": "Uğurla silindi"
+        },
+        "gas": {
+          "noCost": "Gas xərci yoxdur"
+        },
+        "SkipNonceAlert": {
+          "alert": "{{chainName}} zəncirində Nonce #{{nonce}} ötürülüb. Bu, sonrakı tranzaksiyaların gözləməsinə səbəb ola bilər. Həll etmək üçün zəncirdə <5></5> <6>tranzaksiya göndərin</6> <7></7>",
+          "clearPendingAlert": "{{chainName}} tranzaksiyası ({{nonces}}) 3 dəqiqədən çoxdur ki, gözləyir. <5></5> <6>Gözləyənləri lokal olaraq təmizləyib</6> <7></7> tranzaksiyanı yenidən göndərə bilərsiniz."
+        },
+        "PredictTime": {
+          "time": "{{time}} ərzində bloka daxil ediləcəyi gözlənilir",
+          "noTime": "Bloka daxil edilmə vaxtı hesablanır",
+          "failed": "Bloka daxil edilmə vaxtını proqnozlaşdırmaq alınmadı"
+        },
+        "CancelTxConfirmPopup": {
+          "title": "Gözləyənləri lokal olaraq təmizlə",
+          "desc": "Bu, gözləyən tranzaksiyanı interfeysinizdən çıxaracaq. Sonra yeni tranzaksiya başlada bilərsiniz.",
+          "warning": "Çıxarılmış tranzaksiya əvəz edilməzsə, zəncirdə yenə də təsdiqlənə bilər."
+        }
+      },
+      "signedText": {
+        "label": "Mətn",
+        "empty": {
+          "title": "Hələ imzalanmış mətn yoxdur",
+          "desc": "Rabby vasitəsilə imzalanmış bütün mətnlər burada göstəriləcək."
+        }
+      }
+    },
+    "receive": {
+      "title": "{{chain}} zəncirində {{token}} al",
+      "watchModeAlert1": "Bu, izləmə ünvanıdır.",
+      "watchModeAlert2": "Aktivləri almaq üçün bu ünvandan istifadə etmək istədiyinizə əminsiniz?",
+      "receiveOn": "{{token}} almaq üçün zəncir",
+      "receiveTitle": "{{token}} al",
+      "addCustomNetwork": "Xüsusi şəbəkə əlavə et",
+      "supportedChain": "Dəstəklənən zəncirlər"
+    },
+    "sendToken": {
+      "addressNotInContract": "Ünvan siyahısında yoxdur. <1></1><2>Kontaktlara əlavə et</2>",
+      "AddToContactsModal": {
+        "addedAsContacts": "Kontaktlara əlavə edildi",
+        "editAddr": {
+          "placeholder": "Ünvan qeydini daxil et",
+          "validator__empty": "Ünvan qeydini daxil edin"
+        },
+        "editAddressNote": "Ünvan qeydini redaktə et",
+        "error": "Kontaktlara əlavə etmək alınmadı"
+      },
+      "allowTransferModal": {
+        "error": "yanlış parol",
+        "placeholder": "Təsdiqləmək üçün parolu daxil edin",
+        "validator__empty": "Parolu daxil edin",
+        "addWhitelist": "Ağ siyahıya əlavə et"
+      },
+      "GasSelector": {
+        "confirm": "Təsdiqlə",
+        "level": {
+          "$unknown": "Naməlum",
+          "custom": "Fərdi",
+          "fast": "Sürətli",
+          "normal": "Normal",
+          "slow": "Yavaş"
+        },
+        "popupDesc": "Təyin etdiyiniz Gas qiymətinə əsasən köçürmə məbləğindən Gas xərci üçün vəsait ayrılacaq",
+        "popupTitle": "Gas qiymətini təyin et (Gwei)"
+      },
+      "header": {
+        "title": "Göndər"
+      },
+      "modalConfirmAddToContacts": {
+        "confirmText": "Təsdiqlə",
+        "title": "Kontaktlara əlavə et"
+      },
+      "modalConfirmAllowTransferTo": {
+        "cancelText": "Ləğv et",
+        "confirmText": "Təsdiqlə",
+        "title": "Təsdiqləmək üçün parolu daxil edin"
+      },
+      "sectionBalance": {
+        "title": "Məbləğ"
+      },
+      "sectionChain": {
+        "title": "Zəncir"
+      },
+      "sectionFrom": {
+        "title": "Mənbə"
+      },
+      "sectionTo": {
+        "addrValidator__empty": "Ünvan daxil edin",
+        "addrValidator__invalid": "Bu ünvan etibarsızdır",
+        "searchInputPlaceholder": "Axtar və ya ünvan daxil et",
+        "title": "Hədəf",
+        "placeholder": "Ünvan seç"
+      },
+      "sendButton": "Göndər",
+      "tokenInfoFieldLabel": {
+        "chain": "Zəncir",
+        "contract": "Kontrakt ünvanı"
+      },
+      "tokenInfoPrice": "Qiymət",
+      "whitelistAlert__disabled": "Ağ siyahı söndürülüb. İstənilən ünvana köçürə bilərsiniz.",
+      "whitelistAlert__notWhitelisted": "Ünvan ağ siyahıda deyil. <1 /> Köçürmə üçün müvəqqəti icazə verməyə razıyam.",
+      "whitelistAlert__temporaryGranted": "Müvəqqəti icazə verildi",
+      "whitelistAlert__whitelisted": "Ünvan ağ siyahıdadır",
+      "balanceWarn": {
+        "gasFeeReservation": "Gas haqqı üçün vəsait ayrılmalıdır"
+      },
+      "balanceError": {
+        "insufficientBalance": "Balans kifayət deyil"
+      },
+      "max": "MAKS",
+      "sectionMsgDataForEOA": {
+        "placeholder": "İstəyə bağlı",
+        "title": "Mesaj",
+        "currentIsOriginal": "Cari giriş ilkin verilənlərdir. UTF-8 forması:",
+        "currentIsUTF8": "Cari giriş UTF-8 formatındadır. İlkin verilənlər:"
+      },
+      "sectionMsgDataForContract": {
+        "placeholder": "İstəyə bağlı",
+        "title": "Kontrakt çağırışı",
+        "parseError": "Kontrakt çağırışının dekodlaşdırılması alınmadı",
+        "simulation": "Kontrakt çağırışının simulyasiyası:",
+        "notHexData": "Yalnız onaltılıq verilənlər dəstəklənir"
+      },
+      "blockedTransaction": "Bloklanmış tranzaksiya",
+      "blockedTransactionContent": "Bu tranzaksiya OFAC sanksiya siyahısındakı ünvanla qarşılıqlı əlaqədədir.",
+      "blockedTransactionCancelText": "Anladım",
+      "noSupprotTokenForDex": "Bu token bu birjada dəstəklənməyə bilər. İtkinin qarşısını almaq üçün davam etməzdən əvvəl yoxlayın",
+      "noSupprotTokenForDex_short": "Bu birjada dəstəklənmir",
+      "noSupprotTokenForSafe": "Token göndərdiyiniz Safe ünvanı bu zəncirdə yerləşdirilməyib. İtkinin qarşısını almaq üçün davam etməzdən əvvəl yoxlayın.",
+      "noSupprotTokenForSafe_short": "Safe ünvanı bu zəncirdə yerləşdirilməyib ",
+      "noSupportTokenForChain": "Alıcının ünvanı başqa zəncirdəki kontrakt ünvanıdır. İtkinin qarşısını almaq üçün davam etməzdən əvvəl yoxlayın",
+      "noSupportTokenForChain_short": "Kontrakt ünvanı bu zəncirdə yerləşdirilməyib ",
+      "selectFromAddress": "Göndərən ünvanı seç",
+      "selectToken": "Token seç",
+      "accountSelectorModal": {
+        "title": "Ünvan seç"
+      },
+      "riskAlert": {
+        "checkboxText": "Riskləri anlayıram və davam etmək istəyirəm"
+      }
+    },
+    "perps": {
+      "title": "Perps",
+      "deposit": "Yatır",
+      "withdraw": "Çıxar",
+      "transferToSpot": "Spot hesabına köçür",
+      "transferToPerps": "Perps-ə köçür",
+      "positions": "Mövqelər",
+      "openProModeInTab": "Pro rejimini vərəqdə aç",
+      "closeAll": "Hamısını bağla",
+      "closeAllPopup": {
+        "title": "Bütün mövqelərin bağlanmasını təsdiqlə",
+        "description": "Bütün açıq mövqeləriniz bazar qiymətinə bağlanacaq."
+      },
+      "cancelAllOrdersPopup": {
+        "title": "Bütün sifarişlərin ləğvini təsdiqlə",
+        "cancelAllOrdersConfirmTitle": "Bütün sifarişlərin ləğvini təsdiqlə",
+        "cancelAllOrdersConfirmMessage": "Bütün limit sifarişləriniz ləğv ediləcək",
+        "description": "Bütün açıq sifarişləriniz ləğv ediləcək."
+      },
+      "limitOrders": "Limit sifarişləri",
+      "cancelAll": "Hamısını ləğv et",
+      "limitOrderDetail": {
+        "title": "Limit {{side}} {{pair}}",
+        "time": "Vaxt",
+        "size": "Həcm",
+        "filled": "İcra edilib",
+        "currentPrice": "Cari qiymət",
+        "limitPrice": "Limit qiyməti",
+        "marginUsage": "Marja istifadəsi",
+        "cancelLimitOrder": "Limit sifarişini ləğv et",
+        "buy": "Al",
+        "sell": "Sat"
+      },
+      "toast": {
+        "cancelLimitOrderSuccess": "Limit sifarişi ləğv edildi",
+        "cancelLimitOrdersSuccess": "{{count}} limit sifarişi ləğv edildi",
+        "cancelLimitOrderError": "Limit sifarişini ləğv etmək alınmadı",
+        "limitOrderPlaced": "Limit {{direction}} {{coin}}: {{size}} həcmində ${{price}} qiymətinə yerləşdirildi",
+        "deposit": "Vəsait uğurla yatırıldı",
+        "depositTip": "{{amount}} USDC yatırıldı",
+        "success": "Uğurlu",
+        "orderError": "Sifariş xətası",
+        "withdraw": "Vəsait uğurla çıxarıldı",
+        "withdrawTip": "{{amount}} USDC uğurla çıxarıldı",
+        "twapSliceFilled": "TWAP hissəsi icra edildi",
+        "buyFilledContentNoPercentage": "{{sz}} {{coin}} @{{price}} USDC qiymətinə alındı",
+        "sellFilledContentNoPercentage": "{{sz}} {{coin}} @{{price}} USDC qiymətinə satıldı",
+        "limitOrderFilled": "Limit sifarişi icra edildi（{{percent}}%）",
+        "buyFilledContent": "{{sz}} / {{origSz}} {{coin}} @{{price}} USDC qiymətinə alındı",
+        "sellFilledContent": "{{sz}} / {{origSz}} {{coin}} @{{price}} USDC qiymətinə satıldı",
+        "orderFilled": "Sifariş icra edildi",
+        "orderPlaced": "Sifariş yerləşdirildi",
+        "terminalTwap": "TWAP sonlandırılması",
+        "terminalTwapSuccess": "TWAP sifarişi uğurla sonlandırıldı",
+        "orderCancelled": "Sifariş ləğv edildi",
+        "ordersCancelled": "Bütün sifarişlər ləğv edildi",
+        "leverageChanged": "Kredit çiyni dəyişdirildi: {{leverage}}",
+        "marginUpdated": "Marja yeniləndi",
+        "marginModeUpdated": "Marja rejimi dəyişdirildi: {{mode}}",
+        "cancelFailed": "Ləğv etmək alınmadı",
+        "cancelOrderSuccess": "Sifariş ləğv edildi",
+        "cancelAllOrderSuccess": "{{count}} sifariş uğurla ləğv edildi",
+        "cancelOrderError": "Sifarişi ləğv etmək alınmadı",
+        "openScaleOrderSuccess": "{{direction}} {{coin}}-USD: {{size}} həcmində miqyaslı sifariş yerləşdirildi",
+        "takeProfitSuccess": "Mənfəət götürmə uğurla təyin edildi",
+        "stopLossSuccess": "Zərərin dayandırılması uğurla təyin edildi",
+        "setAutoCloseSuccess": "Avtomatik bağlanma uğurla təyin edildi",
+        "openTWAPOrderSuccess": "{{direction}} {{coin}}-USD: {{size}} həcmində TWAP sifarişi açıldı",
+        "cancelTWAPOrderSuccess": "TWAP sifarişi uğurla ləğv edildi",
+        "openTPSlMarketOrderSuccess": "{{direction}} {{coin}}-USD: {{size}} həcmində {{tpsl}} bazar sifarişi ${{price}} qiymətinə yerləşdirildi",
+        "openTPSlLimitOrderSuccess": "{{direction}} {{coin}}-USD: {{size}} həcmində {{tpsl}} limit sifarişi ${{price}} qiymətinə yerləşdirildi",
+        "openLimitOrderSuccess": "{{direction}} {{coin}}-USD: {{size}} həcmində limit sifarişi ${{price}} qiymətinə yerləşdirildi",
+        "closePositionSuccess": "{{direction}} {{coin}}-USD: {{size}} həcmində mövqe ${{price}} qiymətinə bağlandı",
+        "closeAllPositionsSuccess": "Bütün mövqelər uğurla bağlandı",
+        "openPositionSuccess": "{{direction}} {{coin}}-USD: həcm {{size}}, qiymət ${{price}}"
+      },
+      "closePositionPopup": {
+        "title": "{{coin}}-USD {{direction}} mövqeyini bağla",
+        "positionSize": "Mövqe həcmi",
+        "pnl": "PnL",
+        "closeLong": "Long mövqeyini bağla",
+        "closeShort": "Short mövqeyini bağla"
+      },
+      "candleMenuKey": {
+        "oneHour": "1 saat",
+        "oneDay": "1 gün",
+        "oneWeek": "1 həftə",
+        "oneMonth": "1 ay",
+        "ytd": "İlin əvvəlindən",
+        "all": "Hamısı"
+      },
+      "permissionTips": "Bölgənizdə mövqe açmaq dəstəklənmir",
+      "newUserProcess": {
+        "gotIt": "Anladım",
+        "next": "Davam et",
+        "firstTitle": "Müddətsiz fyuçersləri öyrən",
+        "firstDescription": "Müddətsiz fyuçerslərlə yalnız aktiv alıb-satmırsınız. Gələcəkdə nə baş verəcəyinə dair gözləntilərinizlə ticarət edirsiniz.",
+        "secondTitle": "Long mövqeyi aç",
+        "secondDescription": "Qiymətin artacağını gözlədikdə Long mövqeyi açırsınız. Qiymət artarsa, qazanırsınız. Düşərsə, itirirsiniz.",
+        "thirdTitle": "Short mövqeyi aç",
+        "thirdDescription": "Qiymətin düşəcəyini gözlədikdə Short mövqeyi açırsınız. Qiymət düşərsə, qazanırsınız. Artarsa, itirirsiniz.",
+        "fourthTitle": "Kredit çiyninin tənzimlənməsi",
+        "fourthDescription": "Kredit çiyni yatırdığınızdan çox vəsaitlə ticarət etməyə imkan verir. Həm qazancınızı, həm də itkinizi artıra bilər.",
+        "fifthTitle": "Likvidasiya",
+        "fifthDescription": "Hər mövqenin likvidasiya qiyməti var. Bazar qiyməti ona çatarsa, mövqeyiniz bağlanacaq. Yüksək kredit çiyni likvidasiya riskini artırır."
+      },
+      "historyDetail": {
+        "date": "Tarix",
+        "amount": "Məbləğ",
+        "asset": "Aktiv",
+        "action": "Əməliyyat",
+        "value": "Dəyər",
+        "buy": "Al",
+        "sell": "Sat",
+        "transferDetailTitle": "Köçürmə",
+        "transferActionToSpot": "Köçürmə (Perps hesabından Spot hesabına)",
+        "transferActionToPerps": "Köçürmə (Spot hesabından Perps hesabına)",
+        "price": "Qiymət",
+        "size": "Həcm",
+        "tradeValue": "Ticarət dəyəri",
+        "fee": "Haqq",
+        "closedPnl": "Reallaşmış PnL",
+        "provider": "Təchizatçı",
+        "feeDesc": "İstifadəçilər ticarət etdikdə həm <1>ticarət haqları</1>, həm də <2>tərtibatçı haqları</2> tətbiq olunur.",
+        "title": {
+          "openLong": "Long mövqeyi aç",
+          "openShort": "Short mövqeyi aç",
+          "closeLong": "Long mövqeyini bağla",
+          "closeShort": "Short mövqeyini bağla",
+          "closeLongTp": "Long-un bağlanması, mənfəət götürmə",
+          "closeLongSl": "Long-un bağlanması, zərərin dayandırılması",
+          "closeLongLiquidation": "Long-un bağlanması, likvidasiya",
+          "closeShortLiquidation": "Short-un bağlanması, likvidasiya",
+          "closeShortTp": "Short-un bağlanması, mənfəət götürmə",
+          "closeShortSl": "Short-un bağlanması, zərərin dayandırılması"
+        }
+      },
+      "pending": "Gözləyən",
+      "logoutConfirmModal": {
+        "title": "Cari ünvandan çıxış",
+        "desc": "Cari Perps hesabınızdan çıxırsınız. Bu ünvanla daxil olaraq onu istənilən vaxt bərpa edə bilərsiniz."
+      },
+      "PerpsDepositCard": {
+        "availableToTrade": "Ticarət üçün mövcud: ",
+        "deposit": "Yatır",
+        "swap": "Mübadilə et"
+      },
+      "selectChainToWithdraw": "Çıxarış üçün zəncir seç",
+      "selectTokenToWithdraw": "Çıxarış üçün token seç",
+      "EnableUnifiedAccount": {
+        "title": "Vahid hesabı aktivləşdir",
+        "desc": "Vahid hesab ticarəti asanlaşdıran tövsiyə olunan hesab rejimidir. Bütün tokenlər üçün Spot və Perps balansları birləşdirilir, bütün mövcud aktivlərdə çarpaz marja dəstəklənir.",
+        "confirm": "Təsdiqlə",
+        "enable": "Aktivləşdir",
+        "cancel": "Ləğv et",
+        "importantTips": "Vahid hesab aktivləşdirildikdə bütün USDC təminatı çarpaz marja kimi istifadə olunacaq.",
+        "important": "Vacib"
+      },
+      "PerpsSpotSwap": {
+        "title": "Sabit kripto pulları mübadilə et",
+        "from": "Mənbə",
+        "to": "Hədəf",
+        "balance": "Balans",
+        "estReceive": "Təxmini alınacaq",
+        "swapBtn": "Mübadilə et",
+        "insufficientBalance": "Balans kifayət deyil",
+        "invalidAmount": "Düzgün məbləğ daxil edin",
+        "minimumAmount": "Minimum mübadilə məbləği {{amount}} təşkil edir",
+        "max": "Maks",
+        "toDeposit": "Yatırmağa keç →",
+        "swapBeforeTrading": "Ticarətdən əvvəl USDC-ni {{quoteAsset}} ilə mübadilə edin",
+        "enabledSuccess": "Vahid hesab aktivləşdirildi",
+        "enableFailed": "Vahid hesabı aktivləşdirmək alınmadı",
+        "swapFailed": "Mübadilə alınmadı",
+        "swapSuccess": "Mübadilə uğurla tamamlandı",
+        "estReceiveTooltip": "Təxmini alınacaq məbləğ bazar qiymətinin dəyişməsindən asılıdır.",
+        "buyAsset": "{{asset}} al",
+        "sellAsset": "{{asset}} sat",
+        "toSwapEntry": "Mübadiləyə keç →",
+        "toDepositEntry": "Yatırmağa keç →"
+      },
+      "PerpsTransferToPerps": {
+        "title": "Köçürmə",
+        "from": "Mənbə",
+        "to": "Hədəf",
+        "spot": "Spot",
+        "perps": "Perps",
+        "balance": "Balans",
+        "amount": "Məbləğ",
+        "max": "Maks",
+        "submit": "Təsdiqlə",
+        "insufficientBalance": "Balans kifayət deyil",
+        "invalidAmount": "Düzgün məbləğ daxil edin"
+      },
+      "PerpsMultiBalance": {
+        "title": "Hyperliquid balansları",
+        "deposit": "Yatır",
+        "withdraw": "Çıxar"
+      },
+      "PerpsAbout": {
+        "title": "Haqqında"
+      },
+      "depositAmountPopup": {
+        "amount": "Məbləğ",
+        "balance": "Balans",
+        "chain": "Zəncir",
+        "payWith": "Ödəniş vasitəsi",
+        "feeTip": "$1 haqq",
+        "feeTipTooltip": "Hyperliquid tərəfindən tutulan çıxarış haqqı: $1",
+        "feeTipTooltipHype": "EVM-ə çıxarış üçün ~0.00002 HYPE haqqı tutulacaq.",
+        "hypeActivationFeeTip": "İlk HyperEVM çıxarışı üçün Hyperliquid tərəfindən {{fee}} məbləğində birdəfəlik aktivləşdirmə haqqı tutulacaq.",
+        "hyperliquidFeeLabelTooltip": "Hyperliquid yeni istifadəçilərdən birdəfəlik aktivləşdirmə haqqı tutur.",
+        "receiveToken": "Alınacaq token",
+        "estReceiveLabel": "Təxmini alınacaq",
+        "estTimeLabel": "Təxmini vaxt",
+        "hyperliquidFeeLabel": "Hyperliquid haqqı",
+        "estReceive": "Təxmini alınacaq: {{balance}}",
+        "estReceiveTooltip": "Zəncirlərarası yatırma LiFi vasitəsilə icra olunur, sürüşmə yarana bilər. Təxmini çatma vaxtı {{number}} san.",
+        "estReceiveTooltipNoTime": "Zəncirlərarası yatırma LiFi vasitəsilə icra olunur, sürüşmə yarana bilər.",
+        "fetchQuoteFailed": "Yatırma üçün qiymət təklifini almaq alınmadı. Tokeni dəyişin.",
+        "goSwapTips": "Birbaşa yatırma üçün yalnız Arbitrum şəbəkəsində USDC dəstəklənir. Yatırmazdan əvvəl cari tokeninizi USDC ilə mübadilə edin.",
+        "goBridgeTips": "Birbaşa yatırma üçün yalnız Arbitrum şəbəkəsində USDC dəstəklənir. Yatırmazdan əvvəl cari tokeninizi körpü ilə Arbitrum şəbəkəsinə USDC olaraq köçürün.",
+        "minimumDepositSize": "Minimum yatırma məbləği $5 təşkil edir",
+        "minimumWithdrawSize": "Minimum çıxarış məbləği $2 təşkil edir"
+      },
+      "home": {
+        "pnl": "PnL",
+        "size": "Həcm",
+        "margin": "Marja",
+        "entryPrice": "Giriş qiyməti",
+        "markPrice": "İstinad qiyməti",
+        "liquidationPrice": "Likv. qiyməti"
+      },
+      "directDeposit": "Birbaşa yatırma",
+      "directDepositFast": "Sürətli, 0 sürüşmə",
+      "logInTips": "Perps ticarətinə başlamaq üçün ünvanınızla daxil olun və vəsait yatırın.",
+      "logInPerpsAccount": "Perps hesabıma daxil ol",
+      "learnAboutPerps": "Perps haqqında məlumat al",
+      "explorePerps": "Perps ilə tanış ol",
+      "seeMore": "Daha çox göstər",
+      "margin": "Marja",
+      "leverage": "Kredit çiyni",
+      "availableBalance": "Mövcud: {{balance}}",
+      "balanceAvailable": "Balans: {{balance}}",
+      "lastUsed": "Son istifadə olunan",
+      "selectTokenToDeposit": "Yatırmaq üçün token seç",
+      "tradePerps": "Perps ticarəti et",
+      "position": "Mövqe",
+      "yourPosition": "Mövqeyiniz",
+      "pnl": "PnL",
+      "size": "Həcm",
+      "isolated": "Təcrid olunmuş",
+      "cross": "Çarpaz",
+      "crossMarginLiqPriceTip": "Çarpaz marja rejimində ayrıca mövqenin likvidasiya qiyməti yalnız məlumat üçün təxmini hesablanır.",
+      "marginIsolated": "Marja (təcrid olunmuş)",
+      "marginCross": "Marja (çarpaz)",
+      "marginMode": "Marja rejimi",
+      "marginModeSwitchFailed": "Marja rejimini dəyişmək alınmadı, yenidən cəhd edin",
+      "cannotChangeMarginModeWithOpenPositions": "Açıq mövqelər olduqda marja rejimini dəyişmək mümkün deyil",
+      "crossMargin": "Çarpaz marja",
+      "crossMarginDesc": "Bütün mövqelər eyni marjadan istifadə edir. Bu, ayrıca mövqenin likvidasiya ehtimalını azaldır, lakin kəskin bazar dəyişikliklərində bütün çarpaz marja vəsaitləri itirilə bilər.",
+      "isolatedMargin": "Təcrid olunmuş marja",
+      "isolatedMarginDesc": "Hər mövqe öz marjasından istifadə edir. İtkilər həmin mövqe ilə məhdudlaşır, lakin o, daha asan likvidasiya oluna bilər.",
+      "unrealizedPnl": "Reallaşmamış PnL",
+      "positionValue": "Mövqe dəyəri",
+      "currentPrice": "Cari qiymət",
+      "settings": "Parametrlər",
+      "details": "Təfərrüatlar",
+      "info": "Məlumat",
+      "liquidationDistanceDown": "Qiymətin <bold>{{percent}}</bold> düşməsi likvidasiyaya səbəb olacaq",
+      "liquidationDistanceUp": "Qiymətin <bold>{{percent}}</bold> artması likvidasiyaya səbəb olacaq",
+      "autoClose": "Avtomatik bağlanma",
+      "direction": "İstiqamət",
+      "liquidationPrice": "Likvidasiya qiyməti",
+      "entryPrice": "Giriş qiyməti",
+      "price": "Qiymət",
+      "fundingPayments": "Maliyyələşdirmə ödənişləri",
+      "history": "Tarixçə",
+      "openLong": "Long mövqeyi aç",
+      "openShort": "Short mövqeyi aç",
+      "closeLong": "Long mövqeyini bağla",
+      "completed": "Tamamlanıb",
+      "closeShort": "Short mövqeyini bağla",
+      "long": "Long",
+      "short": "Short",
+      "dailyVolume": "24 saatlıq həcm",
+      "openInterest": "Açıq mövqelərin həcmi",
+      "funding": "Maliyyələşdirmə",
+      "availableToTrade": "Ticarət üçün mövcud",
+      "takeProfit": "mənfəəti götürmə",
+      "TakeProfit": "Mənfəəti götürmə",
+      "takeProfitWhen": "Mənfəəti götürmə qiymətini təyin et",
+      "stopLoss": "zərəri dayandırma",
+      "StopLoss": "Zərəri dayandırma",
+      "stopLossWhen": "Zərəri dayandırma qiymətini təyin et",
+      "openPositionTips": "Müddətsiz kontraktlarla ticarət yüksək kredit çiyni və bazar dəyişkənliyi səbəbindən sərmayənizi və təminatınızı qəfil və tam itirmək ehtimalı daxil olmaqla ciddi risk daşıyır və bütün istifadəçilərə uyğun olmaya bilər. Qiymətlərə maliyyələşdirmə dərəcələri və likvidlik təsir edə bilər və mövqeləriniz xəbərdarlıq edilmədən avtomatik likvidasiya oluna bilər. Bazar məlumatlarını Hyperliquid təqdim edir.",
+      "liquidationPriceTips": "Marjanız saxlama marjası səviyyəsindən aşağı düşdükdə əlavə zərərin qarşısını almaq üçün birjanın mövqeyinizi avtomatik bağladığı qiymət.",
+      "sizeTips": "Əməliyyatınızın marja və kredit çiyni ilə müəyyən edilən cəmi dəyəri və ya miqdarı.",
+      "rabbyFeeTipsV2": "Rabby haqqı: 0.02%",
+      "rabbyFeeTipsZero": "Rabby haqqı: 0%",
+      "providerFeeTips": "Hyperliquid haqqı: {{fee}}",
+      "timeAgo": "{{time}} əvvəl",
+      "takeProfitTipsLong": "Mənfəət götürmə qiyməti cari qiymətdən yüksək olmalıdır",
+      "takeProfitTipsShort": "Mənfəət götürmə qiyməti cari qiymətdən aşağı olmalıdır",
+      "deleteAgentSuccess": "Agent uğurla silindi",
+      "deleteAgentModal": "Maksimum agent sayına çatmısınız. Yenisini yaratmaq üçün mövcud agenti silmək istəyirsiniz?",
+      "stopLossTipsLong": "Zərəri dayandırma qiyməti cari qiymətdən aşağı olmalıdır",
+      "stopLossTipsShort": "Zərəri dayandırma qiyməti cari qiymətdən yüksək olmalıdır",
+      "stopLossTipsLongLiquidation": "Qiymət likvidasiya qiymətindən ({{price}}) aşağıdır",
+      "stopLossTipsShortLiquidation": "Qiymət likvidasiya qiymətindən ({{price}}) yüksəkdir",
+      "review": "Nəzərdən keçir",
+      "confirm": "Təsdiqlə",
+      "insufficientBalance": "Balans kifayət deyil",
+      "minimumOrderSize": "Minimum sifariş həcmi $10-dur",
+      "maximumOrderSize": "Maksimum sifariş həcmi {{amount}}",
+      "reviewOrder": "Sifarişi nəzərdən keçir",
+      "back": "Geri qayıt",
+      "estimatedLiquidationPrice": "Təxmini likvidasiya qiyməti",
+      "expectedSlippage": "Təxmini sürüşmə",
+      "lowLiquiditySwitchLimit": " Likvidlik aşağıdır, limit sifarişinə keçin.",
+      "switchToLimit": "Keç",
+      "fee": "Haqq",
+      "leverageRangeMaxError": "Maksimum kredit çiyni {{max}}x",
+      "leverageRangeMinError": "Minimum kredit çiyni {{min}}x",
+      "singleCoin": {
+        "fundingPaymentsTips": "Bu, mövqe açılandan bəri xalis maliyyələşdirmə ödənişləridir. Maliyyələşdirmə, müddətsiz kontraktın qiymətini tokenin faktiki qiymətinə yaxın saxlamaq üçün treyderlərin ödədiyi və ya aldığı saatlıq haqdır.",
+        "openInterestTips": "Bu kontrakt üzrə bütün istifadəçilərin açıq mövqelərinin cəmi.",
+        "fundingTips": "Bu, müddətsiz kontraktın qiymətini tokenin faktiki qiymətinə yaxın saxlamaq üçün treyderlərin ödədiyi və ya aldığı saatlıq haqdır. Müsbətdirsə, Long tərəfi Short tərəfinə ödəyir. Mənfidirsə, Short tərəfi Long tərəfinə ödəyir.",
+        "fundingGainsTips": "Bu, mövqe açılandan bəri xalis maliyyələşdirmə gəliridir. Maliyyələşdirmə, müddətsiz kontraktın qiymətini tokenin faktiki qiymətinə yaxın saxlamaq üçün treyderlərin ödədiyi və ya aldığı saatlıq haqdır."
+      },
+      "liquidation": "Likvidasiya",
+      "accountSelector": {
+        "activatedAddress": "Aktivləşdirilib",
+        "selectAddress": "Ünvan seç",
+        "hyperliquidBalance": "Perps balansı",
+        "notActivatedAddress": "Aktivləşdirilməyib",
+        "noPosition": "Mövqe yoxdur",
+        "position": "Mövqe",
+        "positions": "Mövqelər"
+      },
+      "riskLevel": {
+        "title": "Risk səviyyəsi",
+        "subTitle": "Real vaxtda likvidasiyaya məsafə (%)",
+        "liquidationDistance": "Likvidasiyaya məsafə",
+        "currentPrice": "Cari qiymət",
+        "liquidationPrice": "Likvidasiya qiyməti",
+        "liquidationDistanceTips": "Likvidasiyaya məsafə (%) cari qiymətin likvidasiya qiymətinizdən nə qədər uzaq olduğunu göstərir. Böyük məsafə daha təhlükəsiz mövqe, kiçik məsafə isə daha yüksək likvidasiya riski deməkdir.",
+        "danger": {
+          "title": "Təhlükə",
+          "description": "Mövqeyinizin likvidasiya riski yüksəkdir. Likvidasiya qiymətinə məsafə ≤3%-dir. Likvidasiyadan yayınmaq üçün marja əlavə etməyi və ya mövqeyinizi bağlamağı nəzərdən keçirin."
+        },
+        "warning": {
+          "title": "Xəbərdarlıq",
+          "description": "Mövqeyiniz likvidasiya həddinə yaxınlaşır. Likvidasiya qiymətinə məsafə 3% ilə 8% arasındadır. Mövqeyinizi diqqətlə izləyin və marja əlavə etməyi nəzərdən keçirin."
+        },
+        "safe": {
+          "title": "Təhlükəsiz",
+          "description": "Mövqeyiniz təhlükəsiz səviyyədədir. Likvidasiya qiymətinə məsafə >8%-dir. Bazar şəraitini izləməyə davam edin."
+        },
+        "gotIt": "Anladım",
+        "distanceLabel": "Likvidasiyaya məsafə",
+        "liqDistanceTipsShort": "Qiymətin <1>{{distance}}</1> artması likvidasiyaya səbəb olacaq.",
+        "liqDistanceTipsLong": "Qiymətin <1>{{distance}}</1> azalması likvidasiyaya səbəb olacaq."
+      },
+      "searchPerpsPopup": {
+        "openPosition": "Mövqe aç",
+        "searchPerps": "Perps axtar",
+        "onePosition": "1 mövqe",
+        "searchPosition": "Mövqe axtar",
+        "searchPlaceholder": "Perps axtar",
+        "empty": "Bazar tapılmadı",
+        "hasPosition": "Mövqe"
+      },
+      "categories": {
+        "favorite": "Seçilmişlər",
+        "topVolume": "Ən yüksək həcm"
+      },
+      "fundingRate": "Maliyyələşdirmə dərəcəsi",
+      "fundingGains": "Maliyyələşdirmə gəliri",
+      "close": "Bağla",
+      "add": "Əlavə et",
+      "addFunds": "Vəsait əlavə et",
+      "newUserGuide": {
+        "learnMore": "Ətraflı öyrən"
+      },
+      "perpsWidgetGuide": {
+        "title": "PnL həmişə göz önündə",
+        "bulletViewPositions": "Əsas mövqelərinizi istənilən veb-səhifədə izləyin.",
+        "bulletPrices": "Bazar məlumatlarını və PnL-i görmək üçün kursoru üzərinə gətirin.",
+        "bulletToggle": "İstənilən vaxt aktivləşdirin və ya söndürün.",
+        "later": "İndi deyil",
+        "open": "Viceti aktivləşdir"
+      },
+      "invitePopup": {
+        "title": "Hyperliquid haqlarına qənaət et",
+        "activatedSuccess": "Hyperliquid haqlarına 4% qənaət aktivləşdirildi",
+        "activateFailed": "Alınmadı",
+        "description": "Aktivləşdirmək üçün Rabby-nin kodundan istifadə edin",
+        "hyperliquidFee": "Hyperliquid ticarət haqları.",
+        "activateNow": "İndi aktivləşdir"
+      }
+    },
+    "perpsPro": {
+      "chatArea": {
+        "markTips": "Marjanın, reallaşmamış PnL-in hesablanması, likvidasiya və TP/SL sifarişlərinin işə düşməsi üçün istifadə olunur.",
+        "oracleTips": "Maliyyələşdirmə dərəcələrini hesablamaq üçün istifadə olunan, validatorların bildirdiyi xarici qiymətlərin medianı.",
+        "openInterestTips": "İkitərəfli açıq mövqelərin həcmi: bu kontrakt üzrə Long və Short mövqelərinin cəmi.",
+        "fundingTips": "Long tərəfinin Short tərəfinə ödəniş etdiyi saatlıq dərəcə (mənfidirsə, Short tərəfi Long tərəfinə ödəyir). Maliyyələşdirmə üçün haqq tutulmur, bu, qiymətləri spot qiymətinə yaxınlaşdırmaq üçün istifadəçilər arasında birbaşa köçürmədir. Ətraflı məlumat üçün sənədlərə baxın.",
+        "symbol": "Simvol",
+        "searchMarkets": "Bazar axtar",
+        "lastPrice": "Son qiymət",
+        "mark": "İstinad qiyməti",
+        "oracle": "Orakul",
+        "24hChange": "24 saatlıq dəyişiklik",
+        "openInterest": "Açıq mövqelərin həcmi",
+        "24hVol": "24 saatlıq həcm",
+        "volume": "Həcm",
+        "fundingCountdown": "Maliyyələşdirmə / geri sayım",
+        "8hrFunding": "8 saatlıq maliyyələşdirmə",
+        "categoryAll": "Hamısı"
+      },
+      "topBar": {
+        "favoriteEmpty": "Seçilmişlər siyahınız boşdur"
+      },
+      "userInfo": {
+        "tab": {
+          "unrealizedPnlTooltip": "Reallaşmamış PnL-i hesablamaq üçün istinad qiymətindən istifadə olunur. Reallaşmış PnL üçün yalnız ticarət qiymətlərindən istifadə olunur.",
+          "fundingTips": "Mövqe açılandan bəri xalis maliyyələşdirmə ödənişləri. Mənfidirsə, maliyyələşdirmə gəliri deməkdir.",
+          "fundingTipsV2": "Mövqe açılandan bəri xalis maliyyələşdirmə. Qırmızı (mənfi) dəyər ödənilmiş, yaşıl (müsbət) dəyər isə alınmış maliyyələşdirməni göstərir.",
+          "fundingTipsBold": "Bu, mövqe açılandan bəri hesablaşmalar üzrə cəmi maliyyələşdirməni göstərir. <bold>Yaşıl (müsbət)</bold> dəyərlər digər treyderlərdən qazancınızı, <bold>qırmızı (mənfi)</bold> dəyərlər isə onlara ödədiyiniz maliyyələşdirmə xərclərini göstərir.",
+          "closedPnlTooltip": "Reallaşmış PnL-ə haqlar və geri ödənişlər daxildir",
+          "direction": "İstiqamət",
+          "time": "Vaxt",
+          "type": "Növ",
+          "value": "Dəyər",
+          "price": "Qiymət",
+          "trigger": "İşə düşmə",
+          "filled": "İcra edilib",
+          "rate": "Dərəcə",
+          "payment": "Ödəniş",
+          "side": "Tərəf",
+          "trade": "Ticarət et",
+          "tradeValue": "Ticarət dəyəri",
+          "closedPnl": "Reallaşmış PnL",
+          "fee": "Haqq",
+          "slice": "Hissə",
+          "averagePrice": "Orta qiymət",
+          "runningTimeTotal": "İcra müddəti / cəmi",
+          "status": "Vəziyyət",
+          "reduceOnly": "Yalnız azaltma",
+          "creationTime": "Yaradılma vaxtı",
+          "terminate": "Sonlandır",
+          "order": "Sifariş",
+          "coin": "Kripto pul",
+          "size": "Həcm",
+          "markEntry": "İstinad / giriş",
+          "unrealizedPnl": "Reallaşmamış PnL",
+          "liqPrice": "Likvidasiya qiyməti",
+          "margin": "Marja",
+          "funding": "Maliyyələşdirmə",
+          "tpSl": "TP/SL",
+          "positions": "Mövqelər",
+          "openOrders": "Açıq sifarişlər",
+          "twap": "TWAP",
+          "tradeHistory": "Ticarət tarixçəsi",
+          "fundingHistory": "Maliyyələşdirmə tarixçəsi",
+          "orderHistory": "Sifariş tarixçəsi",
+          "assets": "Aktivlər",
+          "about": "Haqqında"
+        },
+        "floatingWidget": {
+          "label": "Üzən vicet",
+          "tooltip": "· Digər səhifələrə baxarkən hesabınızın PnL göstəricisini\n  üzən vicetdə göstərin.\n· Ticarət səhifəsində və Hyperliquid-də gizlədilir.",
+          "enabledToastTitle": "Üzən vicet aktivləşdirildi",
+          "enabledToastDescription": "Digər səhifələrə baxarkən görünəcək.",
+          "disabledToastTitle": "Üzən vicet söndürüldü",
+          "updateFailed": "Parametri yeniləmək alınmadı"
+        },
+        "emptyMessage": {
+          "openOrders": "Açıq sifariş yoxdur",
+          "positions": "Mövqe yoxdur",
+          "activeTwap": "Aktiv TWAP yoxdur",
+          "twapHistory": "TWAP tarixçəsi yoxdur",
+          "tradeHistory": "Ticarət tarixçəsi yoxdur",
+          "fillHistory": "İcra tarixçəsi yoxdur",
+          "fundingHistory": "Maliyyələşdirmə tarixçəsi yoxdur",
+          "orderHistory": "Sifariş tarixçəsi yoxdur",
+          "assets": "Aktiv yoxdur"
+        },
+        "assets": {
+          "columnAsset": "Aktivlər",
+          "columnTotal": "Ümumi balans",
+          "columnAvailable": "Mövcud balans",
+          "columnAction": "Əməliyyat",
+          "swapStablecoins": "Sabit kripto pulları mübadilə et",
+          "enableUnifiedAccount": "Vahid hesabı aktivləşdir",
+          "transferToPerps": "Perps-ə köçür",
+          "usdcSpot": "USDC(Spot)",
+          "usdcPerps": "USDC(Perps)"
+        },
+        "positionInfo": {
+          "viewOrders": "Sifarişlərə bax",
+          "currentPosition": "Cari mövqe",
+          "reversePosition": "Mövqeni əksinə çevir",
+          "configure": "Tənzimlə",
+          "closeAll": "Hamısını bağla",
+          "reverse": "Əksinə çevir",
+          "closeLimit": "Limitlə bağla",
+          "closeMarket": "Bazar qiymətinə bağla",
+          "close": "Bağla",
+          "limitPrice": "Limit qiyməti",
+          "closePosition": "Mövqeni bağla",
+          "closePositionTips": "Seçdiyiniz limit qiymətində bağlamağa cəhd ediləcək.",
+          "limitClose": "Limitlə bağlama",
+          "closePositionMarketTips": "Cari bazar qiymətində dərhal bağlanacaq",
+          "mid": "Orta",
+          "receive": "Al",
+          "closedPnl": "Reallaşmış PnL",
+          "newPosition": "Yeni mövqe",
+          "closePositionReverseTips": "Mövqeyiniz cari bazar qiymətində dərhal bağlanacaq və əks istiqamətdə eyni həcmdə mövqe açılacaq.",
+          "confirm": "Təsdiqlə",
+          "invalidPrice": "Yanlış qiymət",
+          "marketCloseTitle": "Mövqenin bazar qiymətinə bağlanması",
+          "marketCloseDesc": "Mövqeni dərhal bağlamağa cəhd ediləcək.",
+          "marketCloseBtn": "Bazar qiymətinə bağla",
+          "dontShowAgain": "Bunu bir daha göstərmə",
+          "confirmCloseAllTitle": "Bütün mövqelərin bağlanmasını təsdiqlə",
+          "confirmCloseAllDesc": "Bütün açıq mövqeləriniz bazar qiymətində bağlanacaq və bütün sifarişlər ləğv ediləcək.",
+          "positionSize": "Mövqe həcmi",
+          "orderPrice": "Sifariş qiyməti",
+          "marketPrice": "Bazar qiyməti",
+          "buy": "Al",
+          "sell": "Sat",
+          "buyToSell": "Alışdan satışa",
+          "sellToBuy": "Satışdan alışa",
+          "reverseAction": "Əksinə çevirmək üçün {{size}} {{coin}} {{side}}"
+        },
+        "openOrders": {
+          "order": "Sifariş",
+          "time": "Vaxt",
+          "triggerConditions": "İşə düşmə şərtləri",
+          "tpSl": "TP/SL",
+          "type": "Növ",
+          "orderValueSize": "Sifariş dəyəri / həcmi",
+          "filled": "İcra edilib",
+          "cancelAll": "Hamısını ləğv et",
+          "price": "Qiymət",
+          "cancel": "Ləğv et",
+          "reduceOnly": "Yalnız azaltma"
+        },
+        "status": {
+          "partiallyFilled": "Qismən icra olunub",
+          "filled": "İcra edilib",
+          "open": "Açıq",
+          "canceled": "Ləğv edilib",
+          "triggered": "İşə düşüb",
+          "rejected": "Rədd edilib",
+          "perpMarginRejected": "Perps marjasına görə rədd edilib",
+          "reduceOnlyCanceled": "Yalnız azaltma şərtinə görə ləğv edilib ",
+          "siblingFilledCanceled": "Əlaqəli sifariş icra olunduğu üçün ləğv edilib",
+          "minTradeNtlRejected": "Minimum ticarət dəyərinə görə rədd edilib",
+          "iocCancelRejected": "IOC ləğvi səbəbindən rədd edilib",
+          "badAloPxRejected": "Yanlış ALO PX səbəbindən rədd edilib"
+        },
+        "distanceRiskTag": {
+          "goingDown": "Qiymətin {{percent}} azalması likvidasiyaya səbəb olacaq",
+          "goingUp": "Qiymətin {{percent}} artması likvidasiyaya səbəb olacaq"
+        },
+        "twap": {
+          "activated": "Aktivləşdirilib",
+          "completed": "Tamamlanıb",
+          "terminated": "Sonlandırılıb"
+        },
+        "history": "Tarixçə",
+        "active": "Aktiv",
+        "fillHistory": "İcra tarixçəsi",
+        "terminate": "Sonlandır",
+        "yes": "Bəli",
+        "no": "Xeyr",
+        "randomized": "(təsadüfiləşdirilmiş)"
+      },
+      "statusBar": {
+        "online": "Onlayn",
+        "offline": "Oflayn",
+        "sound": "Səsi aktivləşdir",
+        "settings": "Parametrlər"
+      },
+      "orderConfirm": {
+        "buyLong": "Al/Long",
+        "sellShort": "Sat/Short",
+        "closeLong": "Long mövqeyini bağla",
+        "closeShort": "Short mövqeyini bağla",
+        "dontShowAgain": "{{orderType}} təsdiqini bir daha göstərmə. Bunu istənilən vaxt parametrlərdə dəyişə bilərsiniz.",
+        "orderTypeName": {
+          "market": "Bazar sifarişi",
+          "limit": "Limit sifarişi",
+          "conditional": "Şərti sifariş",
+          "twap": "TWAP sifarişi",
+          "closeMarket": "Bazar qiymətinə bağla",
+          "closeLimit": "Limitlə bağla",
+          "tpsl": "TP/SL"
+        },
+        "price": "Qiymət",
+        "marketPrice": "Bazar qiyməti",
+        "markPrice": "İstinad qiyməti",
+        "triggerPrice": "Aktivləşmə qiyməti",
+        "amount": "Məbləğ",
+        "estLiqPrice": "Təx. likvidasiya qiyməti",
+        "estLiqDistance": "Təx. likvidasiyaya məsafə",
+        "reduceOnly": "Yalnız azaltma",
+        "yes": "Bəli",
+        "no": "Xeyr",
+        "true": "Doğru",
+        "false": "Yanlış",
+        "estPnl": "Təx. PnL",
+        "tpSl": "TP/SL",
+        "takeProfitMarket": "Bazar qiymətinə mənfəəti götürmə",
+        "stopLossMarket": "Bazar qiymətinə zərəri dayandırma",
+        "trigger": "İşə düşmə",
+        "totalAmountApproximately": "Təxmini ümumi məbləğ",
+        "totalSize": "Ümumi həcm",
+        "totalTime": "Ümumi vaxt",
+        "lastPrice": "Son qiymət",
+        "tpslTitle": "Mövqenin TP/SL təsdiqi",
+        "symbol": "Simvol",
+        "entryPrice": "Giriş qiyməti",
+        "takeProfit": "Mənfəət götürmə",
+        "stopLoss": "Zərəri dayandırma",
+        "totalEstimatedPnl": "Ümumi təxmini PnL",
+        "orderPreview": "Sifarişin önbaxışı",
+        "scaleSymbol": "Simvol",
+        "scaleOrderType": "Sifariş növü",
+        "scaleAmount": "Məbləğ",
+        "scalePrice": "Qiymət",
+        "scaleLimit": "Limit",
+        "cost": "Xərc"
+      },
+      "settings": {
+        "title": "Parametrlər",
+        "accountType": "Hesab növü",
+        "orderConfirmations": "Sifariş təsdiqləri",
+        "soundReminder": "Səsli xatırlatma",
+        "popularTradings": "Populyar ticarətlər",
+        "accountTypeTitle": "Hesab növü",
+        "orderConfirmationsTitle": "Sifariş təsdiqləri",
+        "orderConfirmationRow": {
+          "limit": "Limit sifarişi",
+          "market": "Bazar sifarişi",
+          "conditional": "Şərti sifariş",
+          "twap": "TWAP sifarişi",
+          "closeMarket": "Bazar qiymətinə bağla",
+          "closeLimit": "Limitlə bağla",
+          "tpsl": "TP/SL sifarişi"
+        },
+        "accountTypeOption": {
+          "unifiedAccountLabel": "Vahid hesab (tövsiyə olunur)",
+          "unifiedAccountShortLabel": "Vahid hesab",
+          "unifiedAccountDesc": "Hər təminat aktivinin ayrıca balansının olduğu standart hesab parametri. Perps yalnız hesablaşma aktivini təminat kimi istifadə edə bilər və marja yalnız eyni təminat aktivinə malik çarpaz marja aktivləri arasında paylaşılır.",
+          "manualLabel": "Əl ilə",
+          "manualDesc": "Yalnız avtomatlaşdırılmış ticarətdən istifadə edənlərə tövsiyə olunur. Bütün DEX-lərin ayrı balansları var və çarpaz marja hər DEX daxilində ayrıca tətbiq olunur.",
+          "portfolioMarginLabel": "Portfel marjası",
+          "portfolioMarginDesc": "Daha çox çeviklik və kapital səmərəliliyi istəyən təcrübəli istifadəçilər üçün. Bütün spot və Perps ticarəti birləşdirilir. HYPE və BTC kimi uyğun təminat aktivləri hesablaşma aktivinə çevrilmədən birbaşa Perps mövqeləri üçün təminat kimi istifadə edilə bilər. Təminat aktivləri istifadəsiz saxlanılmasına və ya mövqe açmaq üçün borc alınmasına görə faiz qazandırır və ya faiz ödənişi tələb edir."
+        },
+        "accountTypeSwitchSuccess": "Hesab növü dəyişdirildi: {{type}}",
+        "accountTypeSwitchFailed": "Hesab növünü yeniləmək alınmadı"
+      },
+      "tradingPanel": {
+        "swapStableCoins": "Sabit kripto pulları mübadilə et",
+        "bboTips": "Ən yaxşı alış və satış təklifi (BBO) istənilən anda sifariş kitabındakı ən yaxşı satış və alış qiymətləridir. BBO sifarişləri həmişə dəqiq minimum qiymət addımı ilə yerləşdirilir və görünüş seçimlərindən asılı olmayaraq dəqiq qiymətləndirməni təmin edir.",
+        "bboDisabledTooltip": "{{bboDisabledReason}} aktiv olduqda BBO dəstəklənmir",
+        "bboPriceUnavailable": "Hazırda sifariş kitabında qiymət yoxdur. Yenidən cəhd edin.",
+        "action": "Əməliyyat",
+        "orderCount": "Sifariş sayı",
+        "buyTrigger": "Alışın aktivləşməsi",
+        "sellTrigger": "Satışın aktivləşməsi",
+        "long": "Long",
+        "short": "Short",
+        "estimatedPnlWillBe": "Təxmini PnL belə olacaq",
+        "Buy": "Al",
+        "cost": "Xərc",
+        "max": "MAKS",
+        "price": "Qiymət",
+        "Sell": "Sat",
+        "deposit": "Yatır",
+        "atLeastTwoOrders": "Ən azı iki sifariş tələb olunur",
+        "liquidationPriceTooltip": "Mövqenin riski aşağıdır, buna görə hazırda likvidasiya qiyməti yoxdur. Mövqenin artırılması və ya marjanın azaldılması riski artıracaq.",
+        "tpSlTips": "Sadə bazar TP/SL sifarişləri yerləşdirir. Limit qiymətləri və ya qismən TP/SL kimi əlavə funksiyalar üçün açıq mövqedə TP/SL təyin edin.",
+        "reduceOnlyTips": "Həcmindən asılı olmayaraq bu sifariş yeni mövqe açmayacaq. İcra zamanı mövcud mövqe ilə müqayisə ediləcək.",
+        "runtimeTooShort": "İcra müddəti 5 dəqiqədən çox olmalıdır",
+        "runtimeTooLong": "İcra müddəti 24 saatdan az olmalıdır",
+        "slippagePage": {
+          "title": "Maksimum sürüşmənin tənzimlənməsi",
+          "description": "Maksimum sürüşmə yalnız sifariş formasından yerləşdirilən bazar sifarişlərinə təsir edir. Mövqelər bağlanarkən maksimum 8%, bazar TP/SL sifarişlərində isə maksimum 10% sürüşmə tətbiq olunur.",
+          "maxSlippage": "Maksimum sürüşmə",
+          "minError": "Minimum sürüşmə 0%-dir",
+          "maxError": "Maksimum sürüşmə 100%-dir"
+        },
+        "sizeSkewTooltip": "Son və başlanğıc qiymətlərindəki həcmlərin nisbəti. Məsələn, həcm nisbəti 2.0 olduqda son qiymətdəki limit sifarişinin həcmi başlanğıc qiymətdəkindən iki dəfə çox olur. 1.0 nisbəti bərabər həcmli sifarişlər yaradır.",
+        "randomizeTooltip": "Proqnozlaşdırılmanı çətinləşdirmək üçün alt sifarişlərin vaxtını və həcmini təsadüfi seçir.",
+        "reduceOnly": "Yalnız azaltma",
+        "enableTrading": "Ticarəti aktivləşdir",
+        "addFundsToGetStarted": "Başlamaq üçün vəsait əlavə et",
+        "notAvailableInRegion": "Bölgənizdə mövcud deyil.",
+        "startPrice": "Başlanğıc qiymət",
+        "endPrice": "Son qiymət",
+        "start": "Başlanğıc",
+        "end": "Son",
+        "totalOrders": "Cəmi sifariş",
+        "sizeSkew": "Həcm nisbəti",
+        "takeProfitExpectedPnL": "Mənfəət götürüldükdə gözlənilən PnL",
+        "stopLossExpectedPnL": "Zərər dayandırıldıqda gözlənilən PnL",
+        "liquidationPrice": "Likvidasiya qiyməti",
+        "orderValue": "Sifariş dəyəri",
+        "slippage": "Sürüşmə",
+        "frequency": "Tezlik",
+        "threeThirtySeconds": "30 saniyə",
+        "numberOfOrders": "Sifariş sayı",
+        "sizePerSuborder": "Alt sifarişin həcmi",
+        "marginRequired": "Tələb olunan marja",
+        "marginUsage": "Marja istifadəsi",
+        "marginIsolated": "Təcrid olunmuş",
+        "marginCross": "Çarpaz",
+        "buyLong": "Al / Long",
+        "sellShort": "Sat / Short",
+        "availableFunds": "Mövcud vəsait",
+        "size": "Həcm",
+        "currentPosition": "Cari mövqe",
+        "tpSl": "TP / SL",
+        "placeOrder": "Sifariş yerləşdir",
+        "type": "Növ",
+        "limitPrice": "Limit qiyməti",
+        "triggerPrice": "Aktivləşmə qiyməti",
+        "enterAmount": "Məbləği daxil edin",
+        "insufficientBalance": "Balans kifayət deyil",
+        "reduceOnlyTooLarge": "Yalnız azaltma sifarişinin həcmi çox böyükdür",
+        "minimumSuborderSize": "Minimum TWAP alt sifariş həcmi $10-dur",
+        "startAndEndPriceMustBeDifferent": "Başlanğıc və son qiymətlər fərqli olmalıdır",
+        "minimumOrderSize": "Minimum sifariş həcmi $10-dur",
+        "maximumOrderSize": "Maksimum sifariş həcmi {{amount}}",
+        "invalidTpPrice": "Mənfəət götürmə qiyməti yanlışdır",
+        "limitOrderTypeOptions": {
+          "Gtc": "GTC (ləğvədək qüvvədə): Sifariş icra edilənə və ya ləğv olunana qədər gözləyəcək",
+          "Ioc": "IOC (dərhal icra et və ya ləğv et): Dərhal icra olunmayan hissə ləğv ediləcək",
+          "Alo": "ALO (yalnız likvidlik əlavə et): Sifariş kitabında yalnız limit sifarişi kimi qalacaq. Buna post-only də deyilir."
+        },
+        "aloTooLargeBuy": "Alo sifariş qiyməti ən yaxşı satış qiymətindən aşağı olmalıdır",
+        "aloTooLargeSell": "Alo sifariş qiyməti ən yaxşı alış qiymətindən yuxarı olmalıdır",
+        "tpTriggerMoreThanOrderPrice": "TP aktivləşmə qiymətiniz sifariş qiymətinizdən yuxarı olmalıdır",
+        "tpTriggerLessThanOrderPrice": "TP aktivləşmə qiymətiniz sifariş qiymətinizdən aşağı olmalıdır",
+        "slTriggerLessThanOrderPrice": "SL aktivləşmə qiymətiniz sifariş qiymətinizdən aşağı olmalıdır",
+        "slTriggerMoreThanOrderPrice": "SL aktivləşmə qiymətiniz sifariş qiymətinizdən yuxarı olmalıdır",
+        "tpTriggerPriceIsZero": "TP aktivləşmə qiymətiniz 0-dır və {{side}} mövqeyi açdıqda təyin edilməyəcək",
+        "slTriggerPriceIsZero": "SL aktivləşmə qiymətiniz 0-dır və {{side}} mövqeyi açdıqda təyin edilməyəcək",
+        "sideLongBuy": "Long (al)",
+        "sideShortSell": "Short (sat)",
+        "orderTypeTooltipLimit": "Limit sifarişi müəyyən edilmiş və ya daha sərfəli qiymətə alış və ya satış sifarişidir. Limit sifarişlərinin icrasına zəmanət verilmir.",
+        "orderTypeTooltipMarket": "Bazar sifarişi dərhal mövcud ən yaxşı bazar qiyməti ilə uyğunlaşdırılır.",
+        "orderTypeTooltipStopLimit": "Dayandırma limit sifarişləri müəyyən edilmiş dayandırma qiymətinə çatdıqda limit sifarişlərinə çevrilir. Sifarişi aktivləşdirmək üçün aktivləşmə qiymətini göstərin.",
+        "orderTypeTooltipStopMarket": "Dayandırma bazar sifarişləri müəyyən edilmiş qiymətə çatdıqda bazar sifarişlərinə çevrilir. Sifarişi aktivləşdirmək üçün aktivləşmə qiymətini göstərin.",
+        "orderTypeTooltipTakeLimit": "Mənfəət götürmə limit sifarişləri müəyyən edilmiş mənfəət götürmə qiymətinə çatdıqda limit sifarişlərinə çevrilir. Sifarişi aktivləşdirmək üçün aktivləşmə qiymətini göstərin.",
+        "orderTypeTooltipTakeMarket": "Mənfəət götürmə bazar sifarişləri müəyyən edilmiş mənfəət götürmə qiymətinə çatdıqda bazar sifarişlərinə çevrilir. Sifarişi aktivləşdirmək üçün aktivləşmə qiymətini göstərin.",
+        "orderTypeTooltipTwap": "TWAP (zamana görə çəkili orta qiymət) istifadəçinin seçdiyi dövrün zamana görə çəkili orta qiymətinə yaxın orta icra qiyməti əldə etməyə yönəlmiş alqoritmik ticarət strategiyasıdır.",
+        "orderTypeTooltipScale": "Pilləli sifarişlər bazara təsiri minimuma endirmək üçün məbləği bir neçə alt sifarişə bölməyə imkan verir.",
+        "runtime": "İcra müddəti",
+        "randomize": "Təsadüfi seç",
+        "runtimeTips": "(5 dəq-24 saat)",
+        "hours": "Saat",
+        "minutes": "Dəqiqə",
+        "hour": "saat",
+        "min": "dəq",
+        "totalTime": "Ümumi müddət (5 dəq-24 saat)",
+        "maxDurationTwap": "TWAP sifarişinin maksimum icra müddəti",
+        "invalidSlPrice": "Zərəri dayandırma qiyməti yanlışdır",
+        "slBuyMustBeHigherThanMidPrice": "Dayandırma alış sifarişinin qiyməti orta qiymətdən yuxarı olmalıdır",
+        "slSellMustBeLowerThanMidPrice": "Dayandırma satış sifarişinin qiyməti orta qiymətdən aşağı olmalıdır",
+        "tpBuyMustBeLowerThanMidPrice": "Mənfəət götürmə alış sifarişinin qiyməti orta qiymətdən aşağı olmalıdır",
+        "tpSellMustBeHigherThanMidPrice": "Mənfəət götürmə satış sifarişinin qiyməti orta qiymətdən yuxarı olmalıdır",
+        "tpMustBeHigherThanCurrentPrice": "Mənfəət götürmə qiyməti cari qiymətdən yüksək olmalıdır",
+        "slMustBeLowerThanCurrentPrice": "Zərəri dayandırma qiyməti cari qiymətdən aşağı olmalıdır",
+        "tpMustBeLowerThanCurrentPrice": "Mənfəət götürmə qiyməti cari qiymətdən aşağı olmalıdır",
+        "slMustBeHigherThanCurrentPrice": "Zərəri dayandırma qiyməti cari qiymətdən yüksək olmalıdır"
+      },
+      "marginMode": {
+        "title": "Marja rejimi",
+        "cross": "Çarpaz",
+        "crossDescription": "Bütün çarpaz mövqelər eyni çarpaz marjanı girov kimi paylaşır. Likvidasiya zamanı bu rejimdə marja balansınızı və qalan açıq çarpaz mövqelərinizi itirə bilərsiniz.",
+        "isolated": "Təcrid olunmuş",
+        "isolatedDescription": "Hər mövqeyə ayrılan marja məbləğini təyin edərək riskinizi idarə edin. Təcrid olunmuş mövqenin marja nisbəti 100%-ə çatarsa, mövqe likvidasiya ediləcək. Bu rejimdə ayrı-ayrı mövqelərə marja əlavə etmək və ya onlardan marja çıxarmaq olar.",
+        "confirm": "Təsdiqlə",
+        "cannotChange": "Marja rejimi dəyişdirilə bilmir",
+        "onlyIsolatedSupported": "Bu aktiv yalnız təcrid olunmuş marja rejimini dəstəkləyir"
+      },
+      "leverage": {
+        "title": "Kredit çiyninin tənzimlənməsi",
+        "controlPositionLeverage": "{{coin}} mövqeləri üçün kredit çiynini tənzimləyin. Maksimum kredit çiyni {{max}}x-dir.",
+        "maxPositionSize": "Kredit çiyni artdıqca maksimum mövqe həcmi azalır.",
+        "higherLeverageRisk": "Daha yüksək kredit çiyni likvidasiya riskini artırır.",
+        "minError": "Minimum kredit çiyni 1x-dir",
+        "maxError": "Maksimum kredit çiyni {{max}}x-dir",
+        "confirm": "Təsdiqlə"
+      },
+      "editMargin": {
+        "title": "Marjanın idarə edilməsi",
+        "configureMargin": "Marjanı tənzimlə",
+        "longLiquidationTips": "Qiymətin {{percent}} azalması likvidasiyaya səbəb olacaq",
+        "shortLiquidationTips": "Qiymətin {{percent}} artması likvidasiyaya səbəb olacaq",
+        "currentPosition": "Cari mövqe",
+        "currentPrice": "Cari qiymət"
+      },
+      "editTpSl": {
+        "entryPrice": "Giriş qiyməti:",
+        "markPrice": "İstinad qiyməti:",
+        "entryCurrentPrice": "Giriş qiyməti / cari qiymət",
+        "title": "Bütün mövqe üçün TP/SL",
+        "takeProfit": "Mənfəət götürmə",
+        "stopLoss": "Zərəri dayandırma",
+        "triggerPrice": "Aktivləşmə qiyməti",
+        "estimatedPnlWillBe": "Təxmini PnL belə olacaq",
+        "gain": "Qazanc",
+        "loss": "Zərər",
+        "cancelTp": "TP-ni ləğv et",
+        "cancelSl": "SL-i ləğv et",
+        "takeProfitExpectedPnl": "Mənfəət götürüldükdə gözlənilən PnL",
+        "stopLossExpectedPnl": "Zərər dayandırıldıqda gözlənilən PnL",
+        "currentPosition": "Cari mövqe",
+        "tp": "TP",
+        "sl": "SL",
+        "confirm": "Təsdiqlə",
+        "triggerHigherThanLiquidation": "Aktivləşmə qiyməti {{price}} likvidasiya qiymətindən yuxarı olmalıdır",
+        "triggerLowerThanLiquidation": "Aktivləşmə qiyməti {{price}} likvidasiya qiymətindən aşağı olmalıdır",
+        "tpTriggerInvalid": "TP aktivləşmə qiyməti yanlışdır və təyin edilməyəcək",
+        "slTriggerInvalid": "SL aktivləşmə qiyməti yanlışdır və təyin edilməyəcək"
+      },
+      "accountInfo": {
+        "available": "Mövcud: ",
+        "balance": "Balans",
+        "balanceTip": "Cəmi xalis köçürmələr + cəmi reallaşmış mənfəət + cəmi xalis maliyyələşdirmə haqları",
+        "accountEquity": "Hesab kapitalı",
+        "accountEquityTip": "Balans + reallaşmamış PnL (bütün mövqelər bağlansaydı hesabın təxmini dəyəri)",
+        "deposit": "Yatır",
+        "withdraw": "Çıxar",
+        "totalBalance": "Ümumi balans",
+        "availableBalance": "Mövcud balans",
+        "unrealizedPnl": "Reallaşmamış PnL",
+        "crossMarginRatio": "Çarpaz marja nisbəti",
+        "crossMarginRatioTips": "Saxlama marjası / marja balansı. Marja nisbəti 100%-ə çatarsa, çarpaz mövqeləriniz likvidasiya ediləcək.",
+        "crossAccountLeverage": "Çarpaz hesabın kredit çiyni",
+        "crossAccountLeverageTips": "Çarpaz hesabın kredit çiyni = çarpaz mövqelərin ümumi dəyəri / çarpaz hesabın dəyəri.",
+        "maintenanceMargin": "Saxlama marjası",
+        "maintenanceMarginTips": "Çarpaz mövqelərinizi açıq saxlamaq üçün tələb olunan minimum portfel dəyəri",
+        "accountSummary": "Hesab xülasəsi",
+        "unifiedAccountSummary": "Vahid hesabın xülasəsi",
+        "unifiedAccountRatio": "Vahid hesabın nisbəti",
+        "unifiedAccountRatioTips": "Portfelin likvidasiya riskini göstərir. Dəyər 95%-dən çox olduqda portfeliniz likvidasiya edilə bilər.",
+        "unifiedAccountLeverage": "Vahid hesabın kredit çiyni",
+        "unifiedAccountLeverageTips": "Vahid hesabın kredit çiyni = çarpaz mövqelərin ümumi dəyəri / ümumi girov balansı.",
+        "perpsMaintenanceMargin": "Perps saxlama marjası",
+        "perpsPortfolioValue": "Perps portfel dəyəri",
+        "perpsUnrealizedPnl": "Perps üzrə reallaşmamış PnL",
+        "perpsAccountSummary": "Perps hesab xülasəsi",
+        "portfolioMarginSummary": "Portfel marjasının xülasəsi",
+        "portfolioMarginRatio": "Portfel marjası nisbəti",
+        "portfolioMarginRatioTips": "Saxlama marjası / LTV-yə görə düzəldilmiş portfel dəyəri. Dəyər 95%-dən çox olduqda portfeliniz likvidasiya edilə bilər.",
+        "marginBalance": "Marja balansı",
+        "marginBalanceTips": "Marja balansı = pul kisəsinin balansı + reallaşmamış PnL. Marja balansı <= saxlama marjası olduqda mövqeləriniz likvidasiya ediləcək.",
+        "totalCollateralBalance": "Ümumi girov balansı",
+        "totalCollateralBalanceTips": "Vahid hesabınızı təmin edən girovun ümumi dəyəri.",
+        "ltvAdjustedPortfolioValue": "LTV-yə görə düzəldilmiş portfel dəyəri",
+        "ltvAdjustedPortfolioValueTips": "Hər aktivin LTV endirimindən sonra ümumi portfel dəyəri; saxlama tələbindən yuxarı qalmalıdır.",
+        "borrowCapUsed": "İstifadə olunmuş borc limiti",
+        "borrowCapUsedTips": "Bu dəyər 100% olduqda əlavə girov portfel marjasını artırmayacaq",
+        "portfolioValue": "Portfel dəyəri",
+        "portfolioValueUnifiedTips": "Portfel dəyərinə vahid hesabınızdakı spot aktivlərin dəyəri daxildir.",
+        "portfolioValuePortfolioMarginTips": "Portfel dəyərinə portfel marjası hesabınızdakı spot aktivlərin dəyəri daxildir."
+      },
+      "accountActions": {
+        "pending": "Gözləyən",
+        "available": "Mövcud",
+        "onePosition": "1 mövqe",
+        "availableBalanceTips": "Mövcud vəsait",
+        "positionCount": "{{count}} mövqe",
+        "deposit": "Yatır"
+      },
+      "orderBook": {
+        "title": "Sifariş kitabı",
+        "trades": "Alqı-satqılar",
+        "price": "Qiymət",
+        "amount": "Məbləğ",
+        "size": "Həcm",
+        "sum": "Cəm",
+        "total": "Cəmi",
+        "markPrice": "İstinad qiyməti",
+        "time": "Vaxt",
+        "noTrades": "Alqı-satqı yoxdur",
+        "viewBoth": "Hər ikisi",
+        "viewBids": "Alış təklifləri",
+        "viewAsks": "Satış təklifləri",
+        "avgPrice": "Orta qiymət",
+        "sumBase": "Cəmi {{base}}",
+        "sumUsd": "Cəmi USD"
+      }
+    },
+    "perpsDetail": {
+      "PerpsAddPositionPopup": {
+        "addToLong": "Long mövqeyinə əlavə et",
+        "totalSize": "Ümumi həcm",
+        "addSize": "Həcm əlavə et",
+        "addToShort": "Short mövqeyinə əlavə et",
+        "liquidationPriceTips": "Marjanız saxlama marjası səviyyəsindən aşağı düşdükdə əlavə zərərin qarşısını almaq üçün birjanın mövqeyinizi avtomatik bağladığı qiymət.",
+        "sizeTips": "Əməliyyatınızın marja və kredit çiyni ilə müəyyən edilən cəmi dəyəri və ya miqdarı."
+      },
+      "PerpsOpenPositionPopup": {
+        "newPosition": "Mövqe aç",
+        "openCoinPosition": "{{coin}} mövqeyi aç",
+        "checkMarketOrder": "Bazar sifarişini yoxla",
+        "checkLimitOrder": "Limit sifarişini yoxla",
+        "margin": "Marja",
+        "long": "Long",
+        "short": "Short",
+        "available": "Mövcud",
+        "leverage": "Kredit çiyni",
+        "size": "Həcm",
+        "sizeTips": "Əməliyyatınızın marja və kredit çiyni ilə müəyyən edilən cəmi dəyəri və ya miqdarı.",
+        "takeProfitWhenPriceAbove": "Qiymət bu həddən yuxarı olduqda mənfəəti götür",
+        "takeProfitWhenPriceBelow": "Qiymət bu həddən aşağı olduqda mənfəəti götür",
+        "stopLossWhenPriceAbove": "Qiymət bu həddən yuxarı olduqda zərəri dayandır",
+        "stopLossWhenPriceBelow": "Qiymət bu həddən aşağı olduqda zərəri dayandır",
+        "invalidNumber": "Yanlış ədəd",
+        "insufficientBalance": "Balans kifayət deyil",
+        "free": "Pulsuz",
+        "rabbyFee": "Rabby haqqı",
+        "providerFee": "Hyperliquid haqqı",
+        "minimumOrderSize": "Minimum sifariş həcmi $10-dur",
+        "maximumOrderSize": "Maksimum sifariş həcmi {{amount}}",
+        "minMargin": "Minimum marja {{amount}}",
+        "maxMargin": "Maksimum marja {{amount}}",
+        "orderType": "Sifariş növü",
+        "currentPrice": "Cari qiymət",
+        "check": "Yoxla",
+        "orderTypeMarket": "Bazar",
+        "orderTypeLimit": "Limit",
+        "limitPrice": "Limit qiyməti",
+        "mayExecuteImmediately": "Bu limit sifarişi dərhal icra oluna bilər",
+        "setLimitOrderBtn": "Limit sifarişi təyin et"
+      },
+      "PerpEditLimitPriceTag": {
+        "setLimitBuyPrice": "Limit alış qiymətini təyin et",
+        "setLimitSellPrice": "Limit satış qiymətini təyin et",
+        "mid": "Orta",
+        "set": "Təyin et",
+        "blockError": "Sifariş qiyməti 10% qiymət qoruma limitini aşır.",
+        "warning": "Limit qiyməti bazar qiymətindən 5%+ fərqlənir",
+        "confirmTitle": "Limit qiymətinə baxış",
+        "confirmMessage": "Limit qiyməti bazar qiymətindən 5%+ fərqlənir"
+      },
+      "PerpsEditMarginPopup": {
+        "margin": "Marja",
+        "title": "Marjanın tənzimlənməsi",
+        "addMargin": "Marja əlavə et",
+        "reduceMargin": "Marjanı azalt",
+        "currentPrice": "Cari qiymət",
+        "amountToAdd": "Əlavə ediləcək məbləğ",
+        "amountToReduce": "Azaldılacaq məbləğ",
+        "perpsBalance": "Perps balansı",
+        "available": "Mövcud",
+        "liqPrice": "Likv. qiyməti",
+        "reduceMarginTooltip": "Mövqeni azaltmaq üçün marja kifayət deyil.",
+        "confirm": "Təsdiqlə",
+        "insufficientBalance": "Balans kifayət deyil",
+        "exceedMaxReduction": "Maksimum azaltma həddini aşır",
+        "addMarginSuccess": "Marja uğurla əlavə edildi",
+        "reduceMarginSuccess": "Marja uğurla azaldıldı",
+        "upto": "Ən çox",
+        "upTo": "Ən çox",
+        "liqDistance": "Likv. məsafəsi"
+      },
+      "PerpsClosePositionPopup": {
+        "title": "Mövqeni bağla",
+        "amount": "Məbləğ",
+        "total": "Cəmi",
+        "minimumWarning": "Minimum bağlama məbləği {{percent}}%-dir",
+        "receive": "Al",
+        "closedPnl": "Reallaşmış PnL",
+        "fee": "Haqq",
+        "confirm": "Təsdiqlə"
+      },
+      "PerpsAutoCloseModal": {
+        "title": "Mövqenin avtomatik bağlanması",
+        "takeProfitWhen": "Mənfəət götürmə şərti",
+        "takeProfitWhenPriceAbove": "Qiymət bu həddən yuxarı olduqda mənfəəti götür",
+        "takeProfitWhenPriceBelow": "Qiymət bu həddən aşağı olduqda mənfəəti götür",
+        "stopLossWhen": "Zərəri dayandırma şərti",
+        "stopLossWhenPriceAbove": "Qiymət bu həddən yuxarı olduqda zərəri dayandır",
+        "stopLossWhenPriceBelow": "Qiymət bu həddən aşağı olduqda zərəri dayandır",
+        "currentPrice": "Cari qiymət: ",
+        "EntryAndCurrentPrice": "Giriş: ${{entryPrice}} Cari: ${{currentPrice}}",
+        "priceAbove": "Qiymət bu həddən yuxarıdır",
+        "priceBelow": "Qiymət bu həddən aşağıdır",
+        "whenPriceAbove": "Qiymət bu həddən yuxarı olduqda",
+        "whenPriceBelow": "Qiymət bu həddən aşağı olduqda",
+        "youGain": "Qazancınız",
+        "youLoss": "Zərəriniz",
+        "takeProfitExpectedPNL": "Mənfəət götürüldükdə gözlənilən PnL",
+        "stopLossExpectedPNL": "Zərər dayandırıldıqda gözlənilən PnL",
+        "confirm": "Təsdiqlə",
+        "takeProfit": "Mənfəət götürmə",
+        "stopLoss": "Zərəri dayandırma",
+        "noPosition": "Əvvəlcə marjanı daxil etməlisiniz",
+        "takeProfitTipsLong": "Mənfəət götürmə qiyməti cari qiymətdən yüksək olmalıdır",
+        "takeProfitTipsShort": "Mənfəət götürmə qiyməti cari qiymətdən aşağı olmalıdır",
+        "stopLossTipsLong": "Zərəri dayandırma qiyməti cari qiymətdən aşağı olmalıdır",
+        "stopLossTipsShort": "Zərəri dayandırma qiyməti cari qiymətdən yüksək olmalıdır",
+        "stopLossTipsLongLiquidation": "Qiymət likvidasiya qiymətindən ({{price}}) aşağıdır",
+        "stopLossTipsShortLiquidation": "Qiymət likvidasiya qiymətindən ({{price}}) yuxarıdır",
+        "cancel": "Ləğv et"
+      },
+      "needDepositFirst": "Əvvəlcə vəsait yatırmalısınız."
+    },
+    "sendPoly": {
+      "title": "Göndəriləcək ünvan",
+      "enterAddress": "Ünvan daxil et",
+      "enterAddressOrENS": "Ünvan daxil et və ya axtar",
+      "selectExchangeSource": "Birja mənbəyini seç",
+      "emptyWhitelist": {
+        "title": "Ağ siyahıya ünvan əlavə et",
+        "desc": "Sürətli köçürmələr üçün etibarlı ünvanları ağ siyahıya əlavə edin, növbəti dəfə təsdiq tələb olunmayacaq",
+        "addNow": "İndi əlavə et"
+      },
+      "whitelist": {
+        "title": "Ağ siyahı",
+        "addWhitelistDesc": "Sürətli köçürmələr üçün etibarlı ünvanları ağ siyahıya əlavə edin, növbəti dəfə təsdiq tələb olunmayacaq",
+        "addWhitelist": "Ağ siyahıya əlavə et",
+        "removeFromWhitelist": "Ağ siyahıdan çıxar",
+        "notWhitelist": "Ünvan ağ siyahıda deyil"
+      },
+      "sendToImportedAddress": "İdxal edilmiş ünvana göndər",
+      "selectImportedAddress": "İdxal edilmiş ünvanı seç",
+      "addWhitelist": {
+        "title": "Ağ siyahıya ünvan əlavə et",
+        "desc": "Sürətli köçürmələr üçün etibarlı ünvanları ağ siyahıya əlavə edin, növbəti dəfə təsdiq tələb olunmayacaq"
+      },
+      "riskAlert": {
+        "title": "Bu ünvana göndər",
+        "understandRisks": "Riskləri anlayıram və davam etmək istəyirəm",
+        "cexDepositAddress": "{{cexName}} yatırma ünvanı",
+        "cexAddress": "{{cexName}} ünvanı",
+        "passwordPlaceholder": "Davam etmək üçün parolu daxil edin",
+        "TransferBefore": "Əvvəllər köçürmə edilib",
+        "TransferBeforeValue": "Bəli",
+        "AddToWhitelist": "Ağ siyahıya əlavə et",
+        "riskType": {
+          "risks": {
+            "dexNoDeposite": "CEX yatırma ünvanı deyil, vəsait itirilə bilər",
+            "contractAddress": "Kontrakt ünvanı aşkarlandı, vəsait itirilə bilər",
+            "scamAddress": "Rabby tərəfindən dələduz ünvanı kimi işarələnib",
+            "noSend": "180 gündür bu ünvana göndərməmisiniz"
+          }
+        }
+      }
+    },
+    "whitelist": {
+      "title": "Ünvanı ağ siyahıya əlavə et",
+      "address": "Ünvan",
+      "name": "Ad",
+      "exchangeAddress": "Birja ünvanı",
+      "nameYourAddress": "Ünvanınıza ad verin",
+      "addSuccess": "Uğurla əlavə edildi",
+      "invalidAddress": "Bu ünvan etibarsızdır",
+      "enterAddress": "Ünvan daxil et",
+      "riskTitle": "Ünvanı ağ siyahıya əlavə et",
+      "confirmPassword": "Parolu təsdiqlə",
+      "tips": {
+        "removed": "Ağ siyahı ünvanı silindi",
+        "added": "Ünvan ağ siyahıya əlavə edildi",
+        "repeated": "Cari ünvan artıq ağ siyahıdadır.",
+        "tooltip": "Ağ siyahı ünvanı"
+      },
+      "verifyPwd": {
+        "title": "Ağ siyahıda olmayan ünvan",
+        "inputPlaceholder": "Bu köçürməni təsdiqləmək üçün parolunuzu daxil edin"
+      }
+    },
+    "sendTokenComponents": {
+      "GasReserved": "Gas xərci üçün <1>0</1> {{ tokenName }} ayrılıb",
+      "SwitchReserveGas": "Gas üçün ehtiyat ayır <1 />"
+    },
+    "sendNFT": {
+      "header": {
+        "title": "Göndər"
+      },
+      "sectionChain": {
+        "title": "Zəncir"
+      },
+      "sectionFrom": {
+        "title": "Mənbə"
+      },
+      "sectionAmount": {
+        "title": "Məbləğ"
+      },
+      "sectionTo": {
+        "title": "Hədəf",
+        "addrValidator__empty": "Ünvan daxil edin",
+        "addrValidator__invalid": "Bu ünvan etibarsızdır",
+        "searchInputPlaceholder": "Axtar və ya ünvan daxil et"
+      },
+      "nftInfoFieldLabel": {
+        "Collection": "Kolleksiya",
+        "Contract": "Kontrakt",
+        "sendAmount": "Göndəriləcək məbləğ"
+      },
+      "sendButton": "Göndər",
+      "whitelistAlert__disabled": "Ağ siyahı söndürülüb. İstənilən ünvana köçürə bilərsiniz.",
+      "whitelistAlert__whitelisted": "Ünvan ağ siyahıdadır",
+      "whitelistAlert__temporaryGranted": "Müvəqqəti icazə verildi",
+      "whitelistAlert__notWhitelisted": "Ünvan ağ siyahıda deyil. <1 /> Köçürmə üçün müvəqqəti icazə verməyə razıyam.",
+      "tipNotOnAddressList": "Ünvan siyahısında deyil.",
+      "tipAddToContacts": "Kontaktlara əlavə et",
+      "confirmModal": {
+        "title": "Təsdiqləmək üçün parolu daxil edin"
+      }
+    },
+    "approvals": {
+      "header": {
+        "title": "{{ address }} ünvanındakı icazələr"
+      },
+      "tab-switch": {
+        "contract": "Kontraktlar üzrə",
+        "assets": "Aktivlər üzrə",
+        "eip-7702": "EIP-7702"
+      },
+      "component": {
+        "table": {
+          "bodyEmpty": {
+            "7702": "EIP-7702 səlahiyyət həvaləsi yoxdur",
+            "loadingText": "Yüklənir...",
+            "noDataText": "İcazə yoxdur",
+            "noMatchText": "Uyğunluq yoxdur"
+          }
+        },
+        "EIP7702SupportChains": "EIP-7702-ni dəstəkləyən zəncirlər:",
+        "ApprovalContractItem": {
+          "ApprovalCount_one": "İcazə",
+          "ApprovalCount_other": "İcazələr"
+        },
+        "RevokeButton": {
+          "btnText_zero": "Geri al",
+          "btnText_one": "Geri al ({{count}})",
+          "btnText_other": "Geri al ({{count}})",
+          "permit2Batch": {
+            "modalContent": "Eyni Permit2 kontraktının icazələri eyni imza altında birləşdiriləcək.",
+            "modalTitle_one": "Cəmi <2>{{count}}</2> imza tələb olunur",
+            "modalTitle_other": "Cəmi <2>{{count}}</2> imza tələb olunur"
+          },
+          "notSupport7702Title": "Dəstəklənməyən ünvan növü",
+          "notSupport7702Content": "EIP-7702 səlahiyyət həvalələrinin geri alınması yalnız şəxsi açar və ya bərpa ifadəsi ünvanları üçün dəstəklənir"
+        },
+        "ViewMore": {
+          "text": "Daha çox göstər"
+        }
+      },
+      "search": {
+        "placeholder": "{{ type }} üçün ad/ünvan üzrə axtarış"
+      },
+      "tableConfig": {
+        "byContracts": {
+          "columnTitle": {
+            "contract": "Kontrakt",
+            "contractTrustValue": "Kontraktın etibar dəyəri",
+            "revokeTrends": "24 saatlıq geri alma meyilləri",
+            "myApprovedAssets": "İcazə verdiyim aktivlər",
+            "myApprovalTime": "İcazə verdiyim vaxt"
+          },
+          "columnTip": {
+            "contractTrustValue": "Etibar dəyəri bu kontraktın xərclədiyi aktivlərin ümumi dəyəridir. Aşağı etibar dəyəri riskə və ya 180 günlük fəaliyyətsizliyə işarə edir.",
+            "contractTrustValueWarning": "Kontraktın etibar dəyəri < $100,000",
+            "contractTrustValueDanger": "Kontraktın etibar dəyəri < $10,000"
+          }
+        },
+        "byAssets": {
+          "columnTitle": {
+            "asset": "Aktiv",
+            "type": "Növ",
+            "approvedAmount": "İcazə verilən məbləğ",
+            "approvedSpender": "İcazəli xərcləyən",
+            "myApprovalTime": "İcazə verdiyim vaxt"
+          },
+          "columnCell": {
+            "approvedAmount": {
+              "tipApprovedAmount": "İcazə verilən məbləğ",
+              "tipMyBalance": "Balansım"
+            }
+          }
+        },
+        "byEIP7702": {
+          "columnTitle": {
+            "currentAddress": "Cari ünvan",
+            "delegatedAddress": "Səlahiyyət verilmiş ünvan"
+          }
+        }
+      },
+      "RevokeApprovalModal": {
+        "subTitleTokenAndNFT": "İcazə verilən token və NFT",
+        "subTitleContract": "Aşağıdakı kontraktlara icazə verilib",
+        "selectAll": "Hamısını seç",
+        "unSelectAll": "Bütün seçimləri ləğv et",
+        "confirm": "Təsdiqlə {{ selectedCount }}",
+        "title": "İcazələr",
+        "tooltipPermit2": "Bu icazə Permit2 kontraktı vasitəsilə verilib:\n{{ permit2Id }}"
+      },
+      "revokeModal": {
+        "confirmRevokePrivateKey": "Bərpa ifadəsi və ya şəxsi açar ünvanı ilə {{count}} icazəni 1 kliklə toplu şəkildə geri ala bilərsiniz.",
+        "confirmRevokeLedger": "{{count}} icazəni bir tapşırıq siyahısında toplu şəkildə geri alın",
+        "batchRevoke": "Toplu geri al",
+        "revokeOneByOne": "Tək-tək geri al",
+        "revoked": "Geri alınıb:",
+        "totalRevoked": "Cəmi:",
+        "approvalCount_zero": "{{count}} icazə",
+        "approvalCount_one": "{{count}} icazə",
+        "approvalCount_other": "{{count}} icazə",
+        "signAndStartRevoke": "İmzala və geri almağa başla",
+        "pause": "Fasilə ver",
+        "resume": "Davam et",
+        "done": "Tamamla",
+        "ledgerConfirmTitle": "Ledger ilə toplu geri alma",
+        "confirmTitle": "Bir kliklə toplu geri alma",
+        "cancelTitle": "Qalan geri almaları ləğv et",
+        "confirm": "Təsdiqlə",
+        "cancelBody": "Bu səhifəni bağlasanız, qalan geri almalar icra edilməyəcək.",
+        "gasNotEnough": "Göndərmək üçün Gas kifayət deyil",
+        "gasTooHigh": "Gas haqqı yüksəkdir",
+        "submitTxFailed": "Göndərmək alınmadı",
+        "defaultFailed": "Tranzaksiya alınmadı",
+        "stillRevoke": "Yenə də geri al",
+        "paused": "Fasilə verilib",
+        "waitInQueue": "Növbədə gözlə",
+        "useGasAccount": "Gas balansınız azdır. Gas hesabınız Gas haqlarını ödəyəcək.",
+        "revokeWithLedger": "Ledger ilə geri almağa başla",
+        "connectLedger": "Ledger-ə qoşul",
+        "ledgerSended": "Sorğunu Ledger cihazında imzalayın ({{current}}/{{total}})",
+        "ledgerSending": "İmza sorğusu göndərilir ({{current}}/{{total}})",
+        "ledgerAlert": "Ledger cihazınızda Ethereum tətbiqini açın",
+        "ledgerSigned": "İmzalandı. Tranzaksiya yaradılır ({{current}}/{{total}})",
+        "simulationFailed": "Simulyasiya alınmadı",
+        "revokeWithOneKey": "OneKey ilə geri almağa başla",
+        "oneKeySended": "Sorğunu OneKey cihazında imzalayın ({{current}}/{{total}})",
+        "oneKeySending": "İmza sorğusu göndərilir ({{current}}/{{total}})",
+        "oneKeySigned": "İmzalandı. Tranzaksiya yaradılır ({{current}}/{{total}})"
+      }
+    },
+    "gasTopUp": {
+      "title": "Gas balansının ani artırılması",
+      "description": "Başqa zəncirdəki mövcud tokenləri bizə göndərərək Gas balansını artırın. Ödənişiniz təsdiqlənən kimi, geri dönməz olmasını gözləmədən köçürmə dərhal edilir.",
+      "topUpChain": "Balansı artırılacaq zəncir",
+      "Amount": "Məbləğ",
+      "Continue": "Davam et",
+      "InsufficientBalance": "Cari zəncirdə Rabby-nin kontrakt ünvanında balans kifayət deyil. Daha sonra yenidən cəhd edin.",
+      "hightGasFees": "Hədəf şəbəkədə Gas haqları yüksək olduğu üçün bu artırma məbləği çox azdır.",
+      "No_Tokens": "Token yoxdur",
+      "InsufficientBalanceTips": "Balans kifayət deyil",
+      "payment": "Gas balansını artırma ödənişi",
+      "Loading_Tokens": "Tokenlər yüklənir...",
+      "Including-service-fee": "{{fee}} xidmət haqqı daxil olmaqla",
+      "service-fee-tip": "Gas balansını artırma xidmətini göstərərkən Rabby tokenin qiymət dəyişməsindən yaranan zərəri və artırmanın Gas haqqını ödəyir. Buna görə 20% xidmət haqqı tutulur.",
+      "Confirm": "Təsdiqlə",
+      "Deposit-tip": "USDC/USDT ilə yatır",
+      "Value": "Dəyər",
+      "Payment-Token": "Ödəniş tokeni",
+      "Select-payment-token": "Ödəniş tokenini seç",
+      "Token": "Token",
+      "Balance": "Balans"
+    },
+    "swap": {
+      "title": "Mübadilə et",
+      "approve": "İcazə ver",
+      "pendingTip": "Tranzaksiya göndərildi. Uzun müddət gözləmədə qalarsa, parametrlərdə gözləyənləri təmizləməyə cəhd edə bilərsiniz.",
+      "Pending": "Gözləyən",
+      "completedTip": "Tranzaksiya zəncirdədir, qeyd yaratmaq üçün məlumatlar deşifrə edilir",
+      "Completed": "Tamamlanıb",
+      "slippage_tolerance": "Sürüşmə həddi:",
+      "actual-slippage": "Faktiki sürüşmə:",
+      "gas-x-price": "Gas qiyməti: {{price}} qvey.",
+      "no-transaction-records": "Tranzaksiya qeydləri yoxdur",
+      "swap-history": "Mübadilə tarixçəsi",
+      "InSufficientTip": "Tranzaksiya simulyasiyası və Gas hesablaması üçün balans kifayət deyil. Aqreqatorun ilkin təklifləri göstərilir",
+      "testnet-is-not-supported": "Fərdi şəbəkə dəstəklənmir",
+      "not-supported": "Dəstəklənmir",
+      "slippage-adjusted-refresh-quote": "Sürüşmə dəyişdirildi. Təklifi yeniləyin.",
+      "price-expired-refresh-quote": "Qiymətin etibarlılıq müddəti bitdi. Təklifi yeniləyin.",
+      "approve-x-symbol": "{{symbol}} üçün icazə ver",
+      "approve-and-swap": "{{name}} vasitəsilə icazə ver və mübadilə et",
+      "approve-swap": "İcazə ver və mübadilə et",
+      "swap-via-x": "{{name}} vasitəsilə mübadilə et",
+      "get-quotes": "Təklifləri al",
+      "chain": "Zəncir",
+      "swap-from": "Mübadilə edilən",
+      "from": "Mənbə",
+      "to": "Hədəf",
+      "search-by-name-address": "Ad / ünvan üzrə axtar",
+      "amount-in": "{{symbol}} ilə məbləğ",
+      "unlimited-allowance": "Limitsiz icazə",
+      "insufficient-balance": "Balans kifayət deyil",
+      "no-fee-for-wrap": "Bükmə üçün Rabby haqqı yoxdur",
+      "hidden-no-quote-rates_one": "{{count}} məzənnə mövcud deyil",
+      "hidden-no-quote-rates_other": "{{count}} məzənnə mövcud deyil",
+      "Gas-fee-too-high": "Gas haqqı çox yüksəkdir",
+      "rabby-fee": "Rabby haqqı",
+      "preferMEV": "Qabaqlamadan qorunma",
+      "preferMEVTip": "Sendviç hücumu riskini azaltmaq üçün Ethereum və BNB Chain mübadilələrində \"Qabaqlamadan qorunma\" funksiyasını aktivləşdirin. Qeyd: fərdi RPC və ya WalletConnect ünvanından istifadə edirsinizsə, bu funksiya dəstəklənmir",
+      "minimum-received": "Minimum alınan",
+      "there-is-no-fee-and-slippage-for-this-trade": "Bu əməliyyatda sürüşmə yoxdur",
+      "no-slippage-for-wrap": "Bükmə üçün sürüşmə yoxdur",
+      "approve-tips": "1.İcazə ver → 2.Mübadilə et",
+      "best": "Ən yaxşı",
+      "unable-to-fetch-the-price": "Qiyməti əldə etmək mümkün olmadı",
+      "fail-to-simulate-transaction": "Tranzaksiya simulyasiyası alınmadı",
+      "security-verification-failed": "Təhlükəsizlik yoxlaması alınmadı",
+      "need-to-approve-token-before-swap": "Mübadilədən əvvəl tokenə icazə vermək lazımdır",
+      "this-exchange-is-not-enabled-to-trade-by-you": "Bu birjada ticarəti aktivləşdirməmisiniz.",
+      "enable-it": "Aktivləşdir",
+      "this-token-pair-is-not-supported": "Token cütü dəstəklənmir",
+      "QuoteLessWarning": "Alınacaq məbləğ Rabby-nin tranzaksiya simulyasiyası ilə hesablanıb. DEX-in təklifi {{receive}} təşkil edir. Gözlənilən təklifdən {{diff}} az alacaqsınız.",
+      "by-transaction-simulation-the-quote-is-valid": "Tranzaksiya simulyasiyasına əsasən təklif etibarlıdır",
+      "wrap-contract": "Bükmə kontraktı",
+      "directlySwap": "{{symbol}} tokenləri birbaşa smart kontraktla bükülür",
+      "rates-from-cex": "CEX məzənnələri",
+      "edit": "Redaktə et",
+      "tradingSettingTips": "{{viewCount}} birja təklif verir, {{tradeCount}} birjada ticarət aktivdir",
+      "the-following-swap-rates-are-found": "Aşağıdakı məzənnələr tapıldı",
+      "quotes": "Təkliflər",
+      "best-subtitle": "Ən yaxşı təklif məzənnə və Gas haqları daxil olmaqla ən aşağı təxmini ümumi xərcə görə müəyyən edilir.",
+      "sort-with-gas": "Gas daxil olmaqla sırala",
+      "est-payment": "Təxmini ödəniş:",
+      "est-receiving": "Təxmini alınan:",
+      "est-difference": "Təxmini fərq:",
+      "selected-offer-differs-greatly-from-current-rate-may-cause-big-losses": "Seçilmiş təklif cari məzənnədən çox fərqlənir, böyük itkilərə səbəb ola bilər",
+      "rate": "Dərəcə",
+      "low-slippage-may-cause-failed-transactions-due-to-high-volatility": "Yüksək dəyişkənlik zamanı aşağı sürüşmə tranzaksiyaların uğursuzluğuna səbəb ola bilər",
+      "transaction-might-be-frontrun-because-of-high-slippage-tolerance": "Yüksək sürüşmə həddi səbəbindən tranzaksiya qabaqlama hücumuna məruz qala bilər",
+      "recommend-slippage": "Qabaqlama hücumunun qarşısını almaq üçün <2>{{ slippage }}</2>% sürüşmə tövsiyə edirik",
+      "slippage-tolerance": "Sürüşmə həddi",
+      "select-token": "Token seç",
+      "enable-exchanges": "Birjaları aktivləşdir",
+      "exchanges": "Birjalar",
+      "view-quotes": "Təkliflərə bax",
+      "trade": "Ticarət et",
+      "dex": "DEX",
+      "cex": "CEX",
+      "enable-trading": "Ticarəti aktivləşdir",
+      "i-understand-and-accept-it": "Anlayıram və qəbul edirəm",
+      "confirm": "Təsdiqlə",
+      "tradingSettingTip1": "1. Aktivləşdirildikdən sonra birjanın kontraktı ilə birbaşa qarşılıqlı əlaqədə olacaqsınız",
+      "tradingSettingTip2": "2. Rabby birjaların kontraktlarından yaranan risklərə görə məsuliyyət daşımır",
+      "gas-fee": "Gas haqqı: {{gasUsed}}",
+      "estimate": "Təxmini:",
+      "actual": "Faktiki:",
+      "max": "MAKS",
+      "two-step-approve": "İcazə limitini dəyişmək üçün 2 tranzaksiya imzalayın",
+      "two-step-approve-details": "USDT tokeninin icazə limitini dəyişmək üçün 2 tranzaksiya lazımdır. Əvvəlcə limiti sıfırlamalı, yalnız sonra yeni limit təyin etməlisiniz.",
+      "process-with-two-step-approve": "İki mərhələli icazə ilə davam et",
+      "fetch-best-quote": "Ən yaxşı təklif alınır",
+      "usd-after-fees": "≈ {{usd}} ",
+      "no-fees-for-wrap": "Bükmə üçün Rabby haqqı yoxdur",
+      "No-available-quote": "Mövcud təklif yoxdur",
+      "price-impact": "Qiymətə təsir",
+      "loss-tips": "{{usd}} itirirsiniz. Kiçik bazarda daha az məbləğ sınayın.",
+      "Auto": "Avtomatik",
+      "no-quote-found": "Təklif tapılmadı",
+      "source": "Mənbə",
+      "rabbyFee": {
+        "title": "Rabby haqqı",
+        "swapDesc": "Rabby pul kisəsi həmişə aparıcı aqreqatorlardan ən yaxşı məzənnəni tapır və təkliflərinin etibarlılığını yoxlayır. Rabby avtomatik olaraq təklifə daxil edilən 0.25% haqq (bükmə üçün 0%) tutur.",
+        "bridgeDesc": "Rabby pul kisəsi həmişə aparıcı aqreqatorlardan ən yaxşı məzənnəni tapır və təkliflərinin etibarlılığını yoxlayır. Rabby avtomatik olaraq təklifə daxil edilən 0.25% haqq tutur.",
+        "wallet": "Pul kisəsi",
+        "rate": "Haqq dərəcəsi",
+        "button": "Anladım"
+      },
+      "lowCreditModal": {
+        "title": "Bu tokenin etibar dəyəri aşağıdır",
+        "desc": "Aşağı etibar dəyəri çox vaxt tələ tokeni və ya çox aşağı likvidlik kimi yüksək riskə işarə edir."
+      },
+      "understandRisks": "Riskləri anlayıram və davam etmək istəyirəm",
+      "search-by-token-name-address": "Token adı / ünvanı üzrə axtar"
+    },
+    "bridge": {
+      "From": "Mənbə",
+      "To": "Hədəf",
+      "Balance": "Balans: ",
+      "Select": "Seç",
+      "select-chain": "Zəncir seç",
+      "no-quote-found": "Təklif tapılmadı. Başqa token cütlərini sınayın.",
+      "no-quote": "Təklif yoxdur",
+      "title": "Körpü ilə köçür",
+      "history": "Körpü tarixçəsi",
+      "the-following-bridge-route-are-found": "Aşağıdakı marşrut tapıldı",
+      "no-transaction-records": "Tranzaksiya qeydləri yoxdur",
+      "pendingTip": "Tranzaksiya göndərildi. Uzun müddət gözləmədə qalarsa, parametrlərdə gözləyənləri təmizləməyə cəhd edə bilərsiniz.",
+      "Pending": "Gözləyən",
+      "completedTip": "Tranzaksiya zəncirdədir, qeyd yaratmaq üçün məlumatlar deşifrə edilir",
+      "Completed": "Tamamlanıb",
+      "estimate": "Təxmini:",
+      "actual": "Faktiki:",
+      "gas-fee": "Gas haqqı: {{gasUsed}}",
+      "gas-x-price": "Gas qiyməti: {{price}} qvey.",
+      "detail-tx": "Təfərrüat",
+      "unlimited-allowance": "Limitsiz icazə",
+      "insufficient-balance": "Balans kifayət deyil",
+      "bridgeTo": "Körpünün hədəfi",
+      "BridgeTokenPair": "Körpü token cütü",
+      "tokenPairPlaceholder": "Token cütünü seç",
+      "Amount": "Məbləğ",
+      "getRoutes": "Marşrutları al",
+      "slippage-adjusted-refresh-quote": "Sürüşmə dəyişdirildi. Marşrutu yeniləyin.",
+      "price-expired-refresh-route": "Qiymətin etibarlılıq müddəti bitdi. Marşrutu yeniləyin.",
+      "approve-x-symbol": "{{symbol}} üçün icazə ver",
+      "approve-and-bridge": "İcazə ver və körpü ilə köçür",
+      "need-to-approve-token-before-bridge": "Körpü ilə köçürmədən əvvəl tokenə icazə vermək lazımdır",
+      "via-bridge": "{{bridge}} vasitəsilə",
+      "duration": "{{duration}} dəq",
+      "estimated-value": "≈ {{value}} ",
+      "best": "Ən yaxşı",
+      "best-subtitle": "Ən yaxşı təklif təxmini ümumi xərc (Gas haqları daxil) və çatdırılma sürətinin birgə qiymətləndirilməsi ilə müəyyən edilir.",
+      "bridge-cost": "Körpü xərci",
+      "rabby-fee": "Rabby haqqı",
+      "bridge-via-x": "{{name}} üzərindən körpü ilə köçür",
+      "no-route-found": "Marşrut tapılmadı",
+      "aggregator-not-enabled": "Bu aqreqatorla ticarəti aktivləşdirməmisiniz.",
+      "enable-it": "Aktivləşdir",
+      "recommendFromToken": "Mövcud təklif üçün <1></1> tokenindən körpü ilə köçürün",
+      "est-payment": "Təxmini ödəniş:",
+      "est-receiving": "Təxmini alınan:",
+      "est-difference": "Təxmini fərq:",
+      "loss-tips": "{{usd}} itirirsiniz. Başqa məbləğ sınayın.",
+      "price-impact": "Qiymətə təsir",
+      "max-tips": "Bu dəyər körpü üçün Gas xərcini çıxmaqla hesablanır.",
+      "showMore": {
+        "title": "Daha çox göstər",
+        "source": "Körpü mənbəyi"
+      },
+      "settingModal": {
+        "title": "Ticarət üçün körpü aqreqatorlarını aktivləşdir",
+        "confirm": "Təsdiqlə",
+        "SupportedBridge": "Dəstəklənən körpü:",
+        "confirmModal": {
+          "title": "Bu aqreqatorla ticarəti aktivləşdir",
+          "tip1": "1. Aktivləşdirdikdən sonra bu aqreqatorun kontraktı ilə birbaşa qarşılıqlı əlaqədə olacaqsınız.",
+          "tip2": "2. Rabby bu aqreqatorun kontraktından yaranan risklərə görə məsuliyyət daşımır",
+          "i-understand-and-accept-it": "Anlayıram və qəbul edirəm"
+        }
+      },
+      "pendingItem": {
+        "pending": "Gözləyən",
+        "swapStatus": "Mübadilənin vəziyyəti",
+        "sendStatus": "Göndərişin vəziyyəti",
+        "completed": "Tamamlanıb",
+        "failed": "Alınmadı",
+        "queued": "Növbədədir",
+        "bridgeStatus": "Körpünün vəziyyəti",
+        "sendingFrom": "{{chain}} zəncirindən göndərilir",
+        "swap": "Mübadilə et",
+        "beReturnFailed": "Körpü köçürməsi alınmadı. Aktivləriniz qaytarıldı.",
+        "receivedDifferentTokenNeedSwap": "Başqa token aldınız. Onu seçdiyiniz tokenlə mübadilə edə bilərsiniz.",
+        "receivedDifferentTokenFromSource": "Körpü köçürməsi alınmadı. Mənbə zəncirində başqa token qaytarıldı.",
+        "BridgeStatusUnavailable": "Körpünün vəziyyəti məlum deyil. Vəsaitin çatdığını təsdiqləmək üçün tranzaksiya tarixçənizi yoxlayın.",
+        "fromFailed": "Tranzaksiya baş tutmadı. Yenidən cəhd edin.",
+        "longTimeNoReceive": "Şəbəkə yüklənib. Bu, həmişəkindən uzun çəkə bilər. Səbirlə gözləyin.",
+        "receivingTo": "{{chain}} zəncirində alınır",
+        "estimatedTime": "Təxmini vaxt"
+      },
+      "tokenPairDrawer": {
+        "title": "Dəstəklənən token cütlərindən seç",
+        "tokenPair": "Token cütü",
+        "balance": "Balansın dəyəri",
+        "noData": "Dəstəklənən token cütü yoxdur"
+      },
+      "bridgeDbkBtn": "DBK rəsmi xidməti ilə körpü köçürməsi et"
+    },
+    "manageAddress": {
+      "no-address": "Ünvan yoxdur",
+      "no-match": "Uyğunluq yoxdur",
+      "current-address": "Cari ünvan",
+      "address-management": "Ünvanların idarə edilməsi",
+      "update-balance-data": "Balans məlumatlarını yenilə",
+      "search": "Axtar",
+      "manage-address": "Ünvanı idarə et",
+      "deleted": "Silindi",
+      "deleteSuccess": "Uğurla silindi",
+      "whitelisted-address": "Ağ siyahıdakı ünvan",
+      "addressTypeTip": "{{type}} ilə idxal edilib",
+      "delete-desc": "Silməzdən əvvəl aktivlərinizi necə qorumağı anlamaq üçün aşağıdakı məqamları nəzərə alın.",
+      "delete-checklist-1": "Anlayıram ki, bu ünvanı silsəm, ona aid şəxsi açar və bərpa ifadəsi silinəcək və Rabby onları bərpa edə BİLMƏYƏCƏK.",
+      "delete-checklist-2": "Şəxsi açarın və ya bərpa ifadəsinin ehtiyat nüsxəsini çıxardığımı və indi silməyə hazır olduğumu təsdiqləyirəm.",
+      "confirm": "Təsdiqlə",
+      "seedPhraseNotBackedUp": "Pul kisəsinin ehtiyat nüsxəsi yoxdur",
+      "backupSeedPhraseNow": "Ehtiyat nüsxə çıxarmağa başla",
+      "cancel": "Ləğv et",
+      "delete-private-key-modal-title_one": "{{count}} şəxsi açar ünvanını sil",
+      "delete-private-key-modal-title_other": "{{count}} şəxsi açar ünvanını sil",
+      "delete-seed-phrase-title_one": "Bərpa ifadəsini və ona aid {{count}} ünvanı sil",
+      "delete-seed-phrase-title_other": "Bərpa ifadəsini və ona aid {{count}} ünvanı sil",
+      "delete-title_one": "{{count}} {{brand}} ünvanını sil",
+      "delete-title_other": "{{count}} {{brand}} ünvanını sil",
+      "delete-empty-seed-phrase": "Bərpa ifadəsini və ona aid 0 ünvanı sil",
+      "hd-path": "HD yolu:",
+      "no-address-under-seed-phrase": "Bu bərpa ifadəsinə aid heç bir ünvan idxal etməmisiniz.",
+      "noSeedPhraseAddress": "Bu bərpa ifadəsi üçün ünvan əlavə edilməyib. Ünvan əlavə edə və ya bərpa ifadəsini silə bilərsiniz.",
+      "add-address": "Ünvan əlavə et",
+      "delete-seed-phrase": "Bərpa ifadəsini sil",
+      "confirm-delete": "Silməni təsdiqlə",
+      "private-key": "Şəxsi açar",
+      "seed-phrase": "Bərpa ifadəsi",
+      "watch-address": "Yalnız izləmə",
+      "backup-seed-phrase": "Bərpa ifadəsinin ehtiyat nüsxəsini yarat",
+      "delete-all-addresses-but-keep-the-seed-phrase": "Bütün ünvanları sil, bərpa ifadəsini saxla",
+      "delete-all-addresses-and-the-seed-phrase": "Bütün ünvanları və bərpa ifadəsini sil",
+      "seed-phrase-delete-title": "Bərpa ifadəsi silinsin?",
+      "sort-by-balance": "Balansa görə sırala",
+      "sort-by-address-type": "Ünvan növünə görə sırala",
+      "sort-by-address-note": "Ünvan qeydinə görə sırala",
+      "sort-address": "Ünvanları sırala",
+      "enterThePassphrase": "Əlavə parolu daxil edin",
+      "enterPassphraseTitle": "İmzalamaq üçün əlavə parolu daxil edin",
+      "passphraseError": "Əlavə parol yanlışdır",
+      "addNewAddress": "Yeni ünvan əlavə et",
+      "CurrentDappAddress": {
+        "desc": "Dapp ünvanını dəyiş"
+      }
+    },
+    "dashboard": {
+      "home": {
+        "offline": "Şəbəkə əlaqəsi kəsilib və məlumat alınmır",
+        "panel": {
+          "swap": "Mübadilə et",
+          "send": "Göndər",
+          "receive": "Al",
+          "gasTopUp": "Gas balansını artır",
+          "queue": "Növbə",
+          "transactions": "Tranzaksiyalar",
+          "approvals": "İcazələr",
+          "feedback": "Rəy",
+          "rabbyPoints": "Rabby xalları",
+          "more": "Daha çox",
+          "manageAddress": "Ünvanı idarə et",
+          "nft": "NFT",
+          "ecology": "Ekosistem",
+          "bridge": "Körpü ilə köçür",
+          "perps": "Perps",
+          "mobile": "Mobil sinxronizasiya",
+          "gasAccount": "Gas hesabı",
+          "setting": "Parametrlər",
+          "searchDapp": "Dapp axtar",
+          "dapps": "Dapp-lar",
+          "settings": "Parametrlər",
+          "perpsPositions_one": "{{count}} mövqe",
+          "perpsPositions_other": "{{count}} mövqe",
+          "dragTip": "Sıralamaq üçün funksiyanı basıb saxlayın",
+          "convertDust": "Kiçik qalıqları çevir",
+          "staking": "Steykinq"
+        },
+        "comingSoon": "Tezliklə",
+        "soon": "Tezliklə",
+        "refreshTheWebPageToTakeEffect": "Tətbiq olunması üçün veb səhifəni yeniləyin",
+        "rabbyIsInUseAndMetamaskIsBanned": "Rabby istifadə olunur və MetaMask bloklanıb",
+        "flip": "Dəyiş",
+        "metamaskIsInUseAndRabbyIsBanned": "MetaMask istifadə olunur və Rabby bloklanıb",
+        "transactionNeedsToSign": "tranzaksiya imzalanmalıdır",
+        "transactionsNeedToSign": "tranzaksiya imzalanmalıdır",
+        "view": "Bax",
+        "viewFirstOne": "Birincisinə bax",
+        "rejectAll": "Hamısını rədd et",
+        "pendingCount": "1 gözləyən",
+        "pendingCountPlural": "{{countStr}} gözləyən",
+        "queue": {
+          "title": "Növbə",
+          "count": "{{count}} növbədə"
+        },
+        "whatsNew": "Yeniliklər",
+        "importType": "{{type}} ilə idxal edilib",
+        "missingDataTooltip": "{{text}} ilə bağlı cari şəbəkə problemlərinə görə balans yenilənməyə bilər.",
+        "chain": " zənciri, ",
+        "chainEnd": " zənciri",
+        "appChainTips": "Hyperliquid və Polymarket hesabları daxil deyil",
+        "slotAppChainTips": "{{appChainNames}} hesabı daxil deyil",
+        "stablecoinSwapPopup": {
+          "title": "0% mübadilə haqqı",
+          "supportPrefix": "Dəstəklənir",
+          "supportCount": "30+",
+          "supportSuffix": "40+ zəncirdə stabil token",
+          "goToSwap": "Mübadiləyə keç",
+          "close": "Bağla"
+        }
+      },
+      "recentConnection": {
+        "disconnected": "Ayrılıb",
+        "rpcUnavailable": "Fərdi RPC əlçatan deyil",
+        "metamaskTooltip": "Bu Dapp üçün MetaMask-dan istifadə etməyə üstünlük verirsiniz. Bunu istənilən vaxt Parametrlər > MetaMask-a üstünlük verilən Dapp-lar bölməsində dəyişin",
+        "connected": "Qoşulub",
+        "notConnected": "Qoşulmayıb",
+        "connectedDapp": "Rabby cari Dapp-a qoşulmayıb. Qoşulmaq üçün Dapp-ın veb səhifəsində qoşulma düyməsini tapıb klikləyin.",
+        "noDappFound": "Dapp tapılmadı",
+        "disconnectAll": "Hamısını ayır",
+        "disconnectRecentlyUsed": {
+          "title_one": "Qoşulmuş <strong>{{count}}</strong> Dapp-ı ayır",
+          "title_other": "Qoşulmuş <strong>{{count}}</strong> Dapp-ı ayır",
+          "description": "Bərkidilmiş Dapp-lar qoşulu qalacaq",
+          "title": "Son istifadə edilmiş <strong>{{count}}</strong> Dapp-ı ayır"
+        },
+        "title": "Qoşulmuş Dapp-lar",
+        "pinned": "Bərkidilmiş",
+        "noPinnedDapps": "Bərkidilmiş Dapp yoxdur",
+        "dragToSort": "Sıralamaq üçün sürükləyin",
+        "recentlyConnected": "Son qoşulanlar",
+        "noRecentlyConnectedDapps": "Son qoşulmuş Dapp yoxdur",
+        "noConnectedDapps": "Qoşulmuş Dapp yoxdur",
+        "dapps": "Dapp-lar",
+        "metamaskModeTooltip": "Rabby bu Dapp-a qoşula bilmir? <1>MetaMask rejimini</1> aktivləşdirməyi sınayın",
+        "metamaskModeTooltipNew": "Dapp-da \"MetaMask\" seçdikdə Rabby pul kisəsi qoşulacaq. Bunu Daha çox > Rabby-ni MetaMask kimi göstərərək qoş bölməsində idarə edə bilərsiniz"
+      },
+      "feedback": {
+        "directMessage": {
+          "content": "Birbaşa mesaj",
+          "description": "DeBank-da Rabby pul kisəsinin rəsmi hesabı ilə söhbət edin"
+        },
+        "proposal": {
+          "content": "Təklif",
+          "description": "DeBank-da Rabby pul kisəsi üçün təklif göndərin"
+        },
+        "title": "Rəy"
+      },
+      "nft": {
+        "empty": "Dəstəklənən kolleksiyalarda NFT tapılmadı",
+        "collectionList": {
+          "collections": {
+            "label": "Kolleksiyalar"
+          },
+          "all_nfts": {
+            "label": "Bütün NFT-lər"
+          }
+        },
+        "listEmpty": "Hələ heç bir NFT almamısınız",
+        "modal": {
+          "collection": "Kolleksiya",
+          "chain": "Zəncir",
+          "lastPrice": "Son qiymət",
+          "purchaseDate": "Alış tarixi",
+          "sendTooltip": "Hazırda yalnız ERC 721 və ERC 1155 NFT-ləri dəstəklənir",
+          "send": "Göndər"
+        }
+      },
+      "rabbyBadge": {
+        "imageLabel": "Rabby nişanı",
+        "title": "Rabby nişanını tələb et",
+        "freeGasTitle": "Pulsuz Gas nişanını tələb et",
+        "enterClaimCode": "Tələb kodunu daxil edin",
+        "swapTip": "Əvvəlcə Rabby pul kisəsində tanınmış DEX ilə mübadilə etməlisiniz.",
+        "freeGasTip": "Pulsuz Gas istifadə edərək tranzaksiya imzalayın. Gas kifayət etmədikdə 'Pulsuz Gas' düyməsi avtomatik görünəcək.",
+        "learnMore": "Ətraflı öyrən",
+        "goToSwap": "Mübadiləyə keç",
+        "claim": "Tələb et",
+        "viewYourClaimCode": "Tələb kodunuza DeBank-da baxın",
+        "noCode": "Bu ünvan üçün tələb kodunu aktivləşdirməmisiniz",
+        "freeGasNoCode": "Əvvəlcə aşağıdakı düyməyə klikləyərək DeBank-a keçin və cari ünvanınızla tələb kodunu alın.",
+        "learnMoreOnDebank": "DeBank-da ətraflı öyrən",
+        "rabbyValuedUserNo": "Rabby-nin dəyərli istifadəçisi №{{num}}",
+        "rabbyFreeGasUserNo": "Rabby-nin pulsuz Gas istifadəçisi №{{num}}",
+        "claimSuccess": "Uğurla tələb edildi",
+        "viewOnDebank": "DeBank-da bax"
+      },
+      "contacts": {
+        "noDataLabel": "məlumat yoxdur",
+        "noData": "Məlumat yoxdur",
+        "oldContactList": "Köhnə kontakt siyahısı",
+        "oldContactListDescription": "Kontaktlar və izləmə ünvanları birləşdirildiyi üçün köhnə kontaktların ehtiyat nüsxəsi burada saxlanacaq. Bir müddət sonra siyahını siləcəyik. İstifadəyə davam edirsinizsə, vaxtında əlavə edin."
+      },
+      "security": {
+        "tokenApproval": "Token icazəsi",
+        "nftApproval": "NFT icazəsi",
+        "comingSoon": "Tezliklə daha çox funksiya",
+        "title": "Təhlükəsizlik"
+      },
+      "settings": {
+        "lock": {
+          "never": "Heç vaxt"
+        },
+        "7Days": "7 gün",
+        "1Day": "1 gün",
+        "4Hours": "4 saat",
+        "1Hour": "1 saat",
+        "10Minutes": "10 dəqiqə",
+        "backendServiceUrl": "Server xidməti URL-i",
+        "inputOpenapiHost": "OpenAPI serverini daxil edin",
+        "pleaseCheckYourHost": "Server ünvanını yoxlayın",
+        "host": "Server",
+        "reset": "İlkin parametri bərpa et",
+        "save": "Yadda saxla",
+        "pendingTransactionCleared": "Gözləyən tranzaksiya təmizləndi",
+        "clearPending": "Gözləyənləri lokal olaraq təmizlə",
+        "clearPendingTip1": "Bu əməliyyat gözləyən tranzaksiyanı interfeysinizdən silərək şəbəkədə uzun gözləmə müddətinin yaratdığı problemləri həll etməyə kömək edir.",
+        "clearPendingTip2": "Bu, hesab balansınıza təsir etmir və bərpa ifadəsini yenidən daxil etməyi tələb etmir. Bütün aktivlər və hesab məlumatları təhlükəsiz qalır.",
+        "autoLockTime": "Avtomatik kilidləmə vaxtı",
+        "claimRabbyBadge": "Rabby nişanını tələb et!",
+        "cancel": "Ləğv et",
+        "enableWhitelist": "Ağ siyahını aktivləşdir",
+        "disableWhitelist": "Ağ siyahını söndür",
+        "enableWhitelistTip": "Aktivləşdirildikdən sonra Rabby ilə yalnız ağ siyahıdakı ünvanlara aktiv göndərə bilərsiniz.",
+        "disableWhitelistTip": "Söndürüldükdən sonra istənilən ünvana aktiv göndərə bilərsiniz",
+        "warning": "Xəbərdarlıq",
+        "clearWatchAddressContent": "Bütün izləmə ünvanlarını silmək istədiyinizə əminsiniz?",
+        "updateVersion": {
+          "content": "Rabby pul kisəsi üçün yeniləmə mövcuddur. Əl ilə yeniləmə qaydasını öyrənmək üçün klikləyin.",
+          "okText": "Təlimata bax",
+          "successTip": "Ən son versiyadan istifadə edirsiniz",
+          "title": "Yeniləmə mövcuddur"
+        },
+        "features": {
+          "label": "Funksiyalar",
+          "lockWallet": "Pul kisəsini kilidlə",
+          "signatureRecord": "İmza qeydləri",
+          "manageAddress": "Ünvanı idarə et",
+          "connectedDapp": "Qoşulmuş Dapp-lar",
+          "searchDapps": "Dapp axtar",
+          "gasTopUp": "Gas balansını artır",
+          "rabbyPoints": "Rabby xalları",
+          "ecosystem": "Ekosistem"
+        },
+        "settings": {
+          "label": "Parametrlər",
+          "enableWhitelistForSendingAssets": "Aktiv göndərmək üçün ağ siyahını aktivləşdir",
+          "customRpc": "RPC URL-ini dəyiş",
+          "metamaskPreferredDapps": "MetaMask-a üstünlük verilən Dapp-lar",
+          "currentLanguage": "Cari dil",
+          "currency": "Valyuta",
+          "searchCurrency": "Valyuta axtar",
+          "enableTestnets": "Testnet-ləri aktivləşdir",
+          "toggleThemeMode": "Mövzu rejimi",
+          "themeMode": "Mövzu rejimi",
+          "customTestnet": "Xüsusi şəbəkə əlavə et",
+          "metamaskMode": "Rabby-ni MetaMask kimi göstərərək qoş",
+          "enableDappAccount": "Dapp ünvanını müstəqil dəyiş",
+          "switchPasswordForNonWhitelistedTx": "Ağ siyahıdan kənar köçürmələr üçün parol",
+          "biometricUnlock": "Biometriya ilə kiliddən çıxar",
+          "biometricUnlockHint": "Bu cihazda kiliddən çıxarmaq üçün biometriyadan istifadə edin.",
+          "biometricUnlockUnsupported": "Bu cihaz biometriya ilə kiliddən çıxarmanı dəstəkləmir.",
+          "perpsFloatWidget": "Perps üzən vidceti",
+          "dataAnalysis": "Məlumat təhlili"
+        },
+        "aboutUs": "Haqqımızda",
+        "currentVersion": "Cari versiya",
+        "updateAvailable": "Yeniləmə mövcuddur",
+        "supportedChains": "İnteqrasiya edilmiş zəncirlər",
+        "followUs": "Bizi izlə",
+        "testnetBackendServiceUrl": "Testnet server xidməti URL-i",
+        "clearWatchMode": "İzləmə rejimini təmizlə",
+        "requestDeBankTestnetGasToken": "DeBank Testnet Gas tokenini istə",
+        "clearPendingWarningTip": "Çıxarılmış tranzaksiya əvəz edilməzsə, zəncirdə yenə də təsdiqlənə bilər.",
+        "DappAccount": {
+          "title": "Dapp ünvanını müstəqil dəyiş",
+          "desc": "Aktivləşdirdikdən sonra hər Dapp-a qoşulacaq ünvanı müstəqil seçə bilərsiniz. Əsas ünvanın dəyişdirilməsi Dapp-lara qoşulmuş ünvanlara təsir etməyəcək.",
+          "button": "Aktivləşdir"
+        },
+        "rateModalTriggerOnHome": {
+          "description": "Rabby pul kisəsini necə qiymətləndirirsiniz?"
+        },
+        "rateModal": {
+          "thxDesc": "Rabby-ni bəyənirsinizsə, Chrome mağazasında qısa qiymətləndirməniz bizim üçün dəyərlidir.",
+          "thxTitle": "Təşəkkür edirik!",
+          "rateOnChromeStoreButton": "Chrome veb mağazasında qiymətləndir",
+          "feedbackDesc": "Rəyiniz var? Sizi dinləyirik.",
+          "submitFeedbackButton": "Göndər",
+          "feedbackPlaceholder": "Rabby rəyinizi dəyərləndirir!",
+          "feedbackSuccess": "Rəyiniz üçün təşəkkür edirik!"
+        },
+        "PwdForNonWhitelistedTx": {
+          "titleEnable": "Parol yoxlaması aktivləşdirilsin?",
+          "titleDisable": "Söndürmək üçün parolu daxil edin",
+          "descEnable": "Aktivləşdirdikdən sonra bu genişlənmədə ağ siyahıda olmayan ünvana köçürmə üçün parolunuz tələb olunacaq.",
+          "descDisable": "Söndürdükdən sonra ağ siyahıda olmayan ünvanlar üçün parol yoxlaması tələb olunmayacaq.",
+          "inputPlaceholder": "Təsdiqləmək üçün parolu daxil edin",
+          "wrongPassword": "Yanlış parol"
+        },
+        "biometricUnlockEnabled": "Biometriya ilə kiliddən çıxarma aktivləşdirildi.",
+        "biometricUnlockEnableFailed": "Biometriya ilə kiliddən çıxarmanı aktivləşdirmək alınmadı",
+        "biometricUnlockDisabled": "Biometriya ilə kiliddən çıxarma söndürüldü",
+        "biometricUnlockDisableFailed": "Biometriya ilə kiliddən çıxarmanı söndürmək alınmadı",
+        "biometricUnlockUnsupported": "Bu cihaz biometriya ilə kiliddən çıxarmanı dəstəkləmir",
+        "biometricUnlockSetupTitle": "Biometriya ilə kiliddən çıxarmanı aktivləşdir",
+        "biometricUnlockPasswordPlaceholder": "Parolu daxil edin",
+        "biometricUnlockSetupDesc": "Biometriya ilə kiliddən çıxarmanı aktivləşdirmək üçün parolunuzu təsdiqləyin.",
+        "clearPendingCheckbox": "Yerli Nonce məlumatlarımı və imza qeydlərimi də sıfırla"
+      },
+      "tokenDetail": {
+        "noIssuer": "Emitent haqqında məlumat yoxdur",
+        "NoListedBy": "Siyahıya alınma məlumatı yoxdur",
+        "NoSupportedExchanges": "Dəstəklənən birja yoxdur",
+        "customizedHasAddedTips": "Token Rabby siyahısında deyil. Onu token siyahısına əl ilə əlavə etmisiniz.",
+        "AddToMyTokenList": "Token siyahıma əlavə et",
+        "maybeScamTips": "Bu token aşağı keyfiyyətlidir və dələduzluq məqsədli ola bilər",
+        "verifyScamTips": "Bu, dələduzluq tokenidir",
+        "blockedTip": "Bloklanmış token siyahıda göstərilməyəcək",
+        "blocked": "Bloklanıb",
+        "selectedCustom": "Token Rabby siyahısında deyil. Onu token siyahısına əl ilə əlavə etmisiniz.",
+        "notSelectedCustom": "Token Rabby siyahısında deyil. Aktivləşdirsəniz, token siyahısına əlavə olunacaq.",
+        "customized": "Fərdiləşdirilmiş",
+        "scamTx": "Dələduzluq tranzaksiyası",
+        "txFailed": "Alınmadı",
+        "notSupported": "Bu zəncirdəki token dəstəklənmir",
+        "swap": "Mübadilə et",
+        "send": "Göndər",
+        "receive": "Al",
+        "noTransactions": "Tranzaksiya yoxdur",
+        "TokenName": "Token adı",
+        "Chain": "Zəncir",
+        "ContractAddress": "Kontrakt ünvanı",
+        "myBalance": "Balansım",
+        "BridgeIssue": "Üçüncü tərəfin körpü ilə köçürdüyü token",
+        "OriginIssue": "Birbaşa bu blokçeyndə buraxılıb",
+        "BridgeProvider": "Körpü təminatçısı",
+        "IssuerWebsite": "Emitentin veb saytı",
+        "OriginalToken": "İlkin token",
+        "ListedBy": "Siyahıya əlavə edən",
+        "SupportedExchanges": "Dəstəklənən birjalar",
+        "fdvTips": "Maksimum təklifin hamısı dövriyyədə olsaydı, bazar kapitallaşması bu qədər olardı. Tam seyreltilmiş dəyər = qiymət x maksimum təklif. Maksimum təklif yoxdursa, ümumi təklif götürülür. Hər iki təklif təyin edilməyibsə və ya sonsuzdursa, bu dəyər göstərilmir.",
+        "blockedTips": "Bloklanmış token siyahıda göstərilməyəcək",
+        "customizedButton": "fərdiləşdirilmiş",
+        "customizedButtons": "fərdiləşdirilmiş",
+        "customizedListTitle": "fərdi token",
+        "customizedListTitles": "fərdi tokenlər",
+        "blockedListTitle": "bloklanmış token",
+        "blockedListTitles": "bloklanmış tokenlər",
+        "blockedButton": "bloklanıb",
+        "blockedButtons": "bloklanıb",
+        "bridgeToEth": "Ethereum zəncirinə körpü ilə köçür",
+        "bridge": "Körpü ilə köçür"
+      },
+      "assets": {
+        "usdValue": "USD dəyəri",
+        "amount": "Məbləğ",
+        "price": "Qiymət",
+        "side": "Tərəf",
+        "portfolio": {
+          "nftTips": "Bu protokolun tanıdığı minimum qiymət əsasında hesablanır.",
+          "fractionTips": "Əlaqəli ERC20 tokeninin qiyməti əsasında hesablanır."
+        },
+        "tokenButton": {
+          "subTitle": "Bu siyahıdakı tokenlər ümumi balansa əlavə edilməyəcək."
+        },
+        "table": {
+          "assetAmount": "Aktiv / məbləğ",
+          "price": "Qiymət",
+          "useValue": "USD dəyəri",
+          "healthRate": "Sağlamlıq göstəricisi",
+          "debtRatio": "Borc nisbəti",
+          "unlockAt": "Kilidin açılma vaxtı",
+          "lentAgainst": "Kredit təminatı",
+          "type": "Növ",
+          "strikePrice": "İcra qiyməti",
+          "exerciseEnd": "İcra müddətinin sonu",
+          "tradePair": "Ticarət cütü",
+          "side": "Tərəf",
+          "leverage": "Kredit çiyni",
+          "review": "Nəzərdən keçir",
+          "PL": "PnL",
+          "unsupportedPoolType": "Dəstəklənməyən hovuz növü",
+          "claimable": "Tələb edilə bilən",
+          "endAt": "Bitmə vaxtı",
+          "dailyUnlock": "Gündəlik kilid açılması",
+          "pool": "Hovuz",
+          "token": "Token",
+          "balanceValue": "Balans / dəyər",
+          "percent": "Faiz",
+          "summaryTips": "Aktivin dəyərinin ümumi xalis sərvətə nisbəti",
+          "summaryDescription": "Statistik hesablamalar üçün protokollardakı bütün aktivlər (məsələn, LP tokenləri) onları təşkil edən əsas aktivlərə ayrılır",
+          "noMatch": "Uyğunluq yoxdur",
+          "noTokens": "Token yoxdur",
+          "noLpTokens": "Likvidlik təminatçısı (LP) tokeni yoxdur",
+          "lowValueDescription": "Aşağı dəyərli aktivlər burada göstəriləcək",
+          "lowValueAssets_0": "{{count}} aşağı dəyərli token",
+          "lowValueAssets_one": "{{count}} aşağı dəyərli token",
+          "lowValueAssets_other": "{{count}} aşağı dəyərli token",
+          "searchToken": "Token axtar",
+          "lowValueDefis": "{{count}} aşağı dəyərli DeFi aktivi"
+        },
+        "noAssets": "Aktiv yoxdur",
+        "blockLinkText": "Tokeni bloklamaq üçün ünvanı axtar",
+        "blockDescription": "Blokladığınız token burada göstəriləcək",
+        "unfoldChain": "Daha 1 zəncir",
+        "unfoldChainPlural": "Daha {{moreLen}} zəncir",
+        "customButtonText": "Fərdi token əlavə et",
+        "customDescription": "Əlavə etdiyiniz fərdi token burada göstəriləcək",
+        "comingSoon": "Tezliklə...",
+        "searchPlaceholder": "Tokenlər",
+        "AddMainnetToken": {
+          "title": "Fərdi token əlavə et",
+          "selectChain": "Zəncir seç",
+          "searching": "Token axtarılır",
+          "tokenAddress": "Token ünvanı",
+          "tokenAddressPlaceholder": "Token ünvanı",
+          "notFound": "Token tapılmadı",
+          "isBuiltInToken": "Token artıq dəstəklənir"
+        },
+        "AddTestnetToken": {
+          "title": "Fərdi şəbəkə tokeni əlavə et",
+          "selectChain": "Zəncir seç",
+          "searching": "Token axtarılır",
+          "tokenAddress": "Token ünvanı",
+          "tokenAddressPlaceholder": "Token ünvanı",
+          "notFound": "Token tapılmadı"
+        },
+        "TestnetAssetListContainer": {
+          "add": "Token",
+          "addNetwork": "Şəbəkə əlavə et",
+          "addToken": "Token əlavə et",
+          "addTestnet": "Şəbəkə"
+        },
+        "noTestnetAssets": "Fərdi şəbəkə aktivi yoxdur",
+        "addTokenEntryText": "Token",
+        "openInTab": "Rabby vərəqində aç",
+        "openInTabV2": "Vərəqdə aç",
+        "openProMode": "Pro rejimini aç",
+        "searchTokenPlaceholder": "Token axtar",
+        "addAssets": "Aktiv əlavə et"
+      },
+      "hd": {
+        "howToConnectLedger": "Ledger-ə qoşulma qaydası",
+        "howToConnectKeystone": "Keystone-a qoşulma qaydası",
+        "userRejectedTheRequest": "İstifadəçi sorğunu rədd etdi.",
+        "ledger": {
+          "doc1": "Yalnız bir Ledger qoşun",
+          "doc2": "Kiliddən çıxarmaq üçün PIN kodunu daxil edin",
+          "doc3": "Ethereum tətbiqini açın",
+          "reconnect": "İşləmirsə, <1>əvvəldən yenidən qoşulmağa cəhd edin.</1>",
+          "connected": "Ledger qoşuldu"
+        },
+        "keystone": {
+          "title": "Keystone 3 Pro cihazınızın əsas səhifədə olduğuna əmin olun",
+          "doc1": "Yalnız bir Keystone qoşun",
+          "doc2": "Kiliddən çıxarmaq üçün parolu daxil edin",
+          "doc3": "Kompüterə qoşulmağa icazə verin",
+          "reconnect": "İşləmirsə, <1>əvvəldən yenidən qoşulmağa cəhd edin.</1>"
+        },
+        "howToSwitch": "Keçid qaydası",
+        "imkey": {
+          "doc1": "Yalnız bir imKey qoşun",
+          "doc2": "Kiliddən çıxarmaq üçün PIN kodunu daxil edin"
+        },
+        "howToConnectImKey": "imKey-yə qoşulma qaydası",
+        "ledgerIsDisconnected": "Ledger cihazınız qoşulmayıb",
+        "onekeyIsDisconnected": "OneKey cihazınız qoşulmayıb",
+        "trezor": {
+          "doc1": "Trezor cihazınızı qoşun",
+          "doc2": "Cihazınızı kiliddən çıxarın"
+        },
+        "onekey": {
+          "doc1": "<1>OneKey Bridge<1/> quraşdırın",
+          "doc2": "OneKey cihazınızı qoşun",
+          "doc3": "Cihazınızı kiliddən çıxarın"
+        }
+      },
+      "GnosisWrongChainAlertBar": {
+        "notDeployed": "Safe ünvanınız bu zəncirdə yerləşdirilməyib"
+      },
+      "echologyPopup": {
+        "title": "Ekosistem"
+      },
+      "MetamaskModePopup": {
+        "title": "MetaMask rejimi",
+        "desc": "Rabby-ni Dapp-a qoşa bilmirsinizsə, MetaMask rejimini aktivləşdirin və MetaMask seçimi ilə qoşulun.",
+        "footerText": "Daha çox > MetaMask rejimi bölməsində MetaMask rejiminə daha çox Dapp əlavə edin",
+        "enableDesc": "Dapp yalnız MetaMask ilə işləyirsə, aktivləşdirin",
+        "toastSuccess": "Aktivləşdirildi. Yenidən qoşulmaq üçün səhifəni yeniləyin."
+      },
+      "offlineChain": {
+        "chain": "{{chain}} inteqrasiyası tezliklə dayandırılacaq.",
+        "tips": "{{chain}} zəncirinin inteqrasiyası {{date}} tarixində dayandırılacaq. Aktivlərinizə təsir etməyəcək, lakin onlar ümumi balansınıza daxil edilməyəcək. Onlara çıxış üçün zənciri “Daha çox” bölməsində fərdi şəbəkə kimi əlavə edə bilərsiniz."
+      },
+      "recentConnectionGuide": {
+        "title": "Dapp-a qoşulmaq üçün ünvanı burada dəyişin",
+        "button": "Anladım"
+      },
+      "rabbyPointsPopup": {
+        "title": "Rabby xalları",
+        "desc": "Xallarınızı Rabby Mobile tətbiqində yoxlayın.",
+        "downloadIntro": "Hələ tətbiqiniz yoxdur? İndi endirin."
+      },
+      "noData": "Uyğun valyuta yoxdur",
+      "ZeroAssets": {
+        "desc": "Web3-dən istifadə etmək üçün pul kisənizə vəsait əlavə edin",
+        "addAssets": "Aktiv əlavə et"
+      }
+    },
+    "nft": {
+      "floorPrice": "/ Minimum qiymət:",
+      "title": "NFT",
+      "all": "Hamısı",
+      "starred": "Seçilmişlər ({{count}})",
+      "empty": {
+        "title": "Seçilmiş NFT yoxdur",
+        "description": "NFT-ni \"Hamısı\" bölməsindən seçib \"Seçilmişlər\" bölməsinə əlavə edə bilərsiniz"
+      },
+      "noNft": "NFT yoxdur"
+    },
+    "newAddress": {
+      "title": "Ünvan əlavə et",
+      "addNewAddress": "Yeni ünvan yarat",
+      "addMoreAddresses": "Daha çox ünvan əlavə et",
+      "importMoreWallets": "Daha çox ünvan əlavə et",
+      "createANewSeedPhrase": "Yeni bərpa ifadəsi yarat",
+      "moreWallets": "Daha çox pul kisəsi",
+      "newSeedPhraseCreated": "Yeni bərpa ifadəsi yaradıldı",
+      "newAddressAdded": "Yeni ünvan əlavə edildi",
+      "addMoreAddressesFromThisSeedPhrase": "Bu bərpa ifadəsindən daha çox ünvan əlavə et",
+      "importSeedPhrase": "Bərpa ifadəsini idxal et",
+      "importPrivateKey": "Şəxsi açarı idxal et",
+      "privateKeyTab": "Şəxsi açar",
+      "seedPhraseTab": "Bərpa ifadəsi",
+      "bulkImportPrivateKey": "Şəxsi açarları toplu idxal et",
+      "bulkImportPrivateKeySupport": "1000-ə qədər EVM-ə uyğun şəxsi açar dəstəklənir",
+      "bulkImportPrivateKeyInputTab": "Şəxsi açarı daxil et",
+      "bulkImportPrivateKeyPlaceholder": "Hər şəxsi açar yeni sətir və ya xüsusi simvolla ayrılmalıdır.",
+      "bulkImportPrivateKeyExceeded": "Eyni vaxtda ən çox {{count}} şəxsi açar dəstəklənir",
+      "bulkImportPrivateKeyInvalid": "Bəzi şəxsi açarlar etibarsızdır. Onları silin və ya yenidən daxil edin.",
+      "duplicateAddressesSkippedTitle": "Bəzi ünvanlar artıq idxal edilib",
+      "duplicateAddressesSkippedDesc_one": "{{count}} ünvan artıq mövcud olduğu üçün ötürüldü.",
+      "duplicateAddressesSkippedDesc_other": "{{count}} ünvan artıq mövcud olduğu üçün ötürüldü.",
+      "openExtensionToGetStarted": "Başlamaq üçün Rabby genişləndirməsini açın",
+      "newAddressCreated": "Yeni ünvan yaradıldı",
+      "addressImported": "Ünvan idxal edildi",
+      "addressAdded": "Ünvan əlavə edildi",
+      "addressAddedCount_one": "{{count}} ünvan əlavə edildi",
+      "addressAddedCount_other": "{{count}} ünvan əlavə edildi",
+      "importMyMetamaskAccount": "MetaMask hesabımı idxal et",
+      "watchAddress": "İzləmə ünvanı",
+      "imported": "Əvvəllər idxal edilib",
+      "addContacts": {
+        "content": "İzləmə ünvanı əlavə et",
+        "description": "İstənilən açıq pul kisəsi ünvanını izlə",
+        "required": "Ünvan daxil edin",
+        "notAValidAddress": "Etibarlı ünvan deyil",
+        "scanViaMobileWallet": "Mobil pul kisəsi ilə skan et",
+        "scanViaPcCamera": "Kompüter kamerası ilə skan et",
+        "scanQRCode": "QR kodları WalletConnect-ə uyğun pul kisələri ilə skan edin",
+        "walletConnect": "Pul kisəsinə qoşul",
+        "walletConnectVPN": "VPN-dən istifadə etsəniz, WalletConnect qeyri-sabit işləyəcək.",
+        "cameraTitle": "QR kodu kameranızla skan edin",
+        "addressEns": "Ünvan / ENS"
+      },
+      "unableToImport": {
+        "title": "İdxal etmək mümkün deyil",
+        "description": "Bir neçə QR əsaslı avadanlıq pul kisəsinin idxalı dəstəklənmir. Başqa cihazı idxal etməzdən əvvəl {{0}} cihazındakı bütün ünvanları silin."
+      },
+      "connectHardwareWallets": "Avadanlıq pul kisələrinə qoşul",
+      "firefoxLedgerDisableTips": "Ledger Firefox ilə uyğun deyil",
+      "connectMobileWalletApps": "Mobil pul kisəsi tətbiqlərinə qoşul",
+      "connectInstitutionalWallets": "İnstitusional pul kisələrinə qoşul",
+      "createNewSeedPhrase": "Yeni bərpa ifadəsi yarat",
+      "importKeystore": "Keystore idxal et",
+      "selectImportMethod": "İdxal üsulunu seç",
+      "theSeedPhraseIsInvalidPleaseCheck": "Bərpa ifadəsi etibarsızdır, yoxlayın!",
+      "seedPhrase": {
+        "importTips": "Gizli bərpa ifadənizi bütövlükdə 1-ci xanaya yapışdıra bilərsiniz",
+        "whatIsASeedPhrase": {
+          "question": "Bərpa ifadəsi nədir?",
+          "answer": "Aktivlərinizi idarə etmək üçün istifadə olunan 12, 18 və ya 24 sözdən ibarət ifadə."
+        },
+        "isItSafeToImportItInRabby": {
+          "question": "Onu Rabby-yə idxal etmək təhlükəsizdir?",
+          "answer": "Bəli, o, brauzerinizdə yerli olaraq saxlanılacaq və yalnız siz ona çıxış əldə edə biləcəksiniz."
+        },
+        "importError": "[CreateMnemonics] gözlənilməz addım {{0}}",
+        "importQuestion1": "Bərpa ifadəmi itirsəm və ya paylaşsam, aktivlərimə çıxışı həmişəlik itirəcəyəm",
+        "importQuestion2": "Bərpa ifadəm yalnız cihazımda saxlanılır. Rabby ona çıxış əldə edə bilmir",
+        "importQuestion3": "Bərpa ifadəmin ehtiyat nüsxəsini yaratmadan Rabby-ni silsəm, Rabby onu bərpa edə bilməz",
+        "importQuestion4": "Bərpa ifadəsinin ehtiyat nüsxəsini yaratmadan Rabby-ni silsəm, Rabby onu mənim üçün bərpa edə bilməz.",
+        "riskTips": "Başlamazdan əvvəl aşağıdakı təhlükəsizlik tövsiyələrini oxuyun və yadda saxlayın.",
+        "showSeedPhrase": "Bərpa ifadəsini göstər",
+        "backup": "Bərpa ifadəsinin ehtiyat nüsxəsini yarat",
+        "backupTips": "Bərpa ifadəsinin ehtiyat nüsxəsini yaradarkən ekranınıza başqa heç kimin baxmadığına əmin olun",
+        "copy": "Bərpa ifadəsini kopyala",
+        "saved": "İfadəni yadda saxladım",
+        "pleaseSelectWords": "Sözləri seçin",
+        "verificationFailed": "Yoxlama alınmadı",
+        "createdSuccessfully": "Uğurla yaradıldı",
+        "verifySeedPhrase": "Bərpa ifadəsini yoxla",
+        "fillInTheBackupSeedPhraseInOrder": "Ehtiyat nüsxədəki bərpa ifadəsini ardıcıllıqla daxil edin",
+        "wordPhrase": "Bərpa ifadəm <1>{{count}}</1> sözdən ibarətdir",
+        "wordPhraseSelected": "Bərpa ifadəm <1>{{count}} sözdən</1> ibarətdir",
+        "wordPhraseAndPassphrase": "Bərpa ifadəm <1>{{count}}</1> sözdən ibarətdir və parolu var",
+        "wordPhraseAndPassphraseSelected": "Bərpa ifadəm <1>{{count}} sözdən</1> ibarətdir və parolu var",
+        "slip39SeedPhrase": "Bərpa ifadəm <1>{{SLIP39}}</1> formatındadır",
+        "slip39SeedPhraseWithPassphrase": "Bərpa ifadəm <1>{{SLIP39}}</1> formatındadır və parolu var",
+        "slip39SeedPhrasePlaceholder_one": "Bərpa ifadənizin {{count}} nömrəli payını buraya daxil edin",
+        "slip39SeedPhrasePlaceholder_two": "Bərpa ifadənizin {{count}} nömrəli payını buraya daxil edin",
+        "slip39SeedPhrasePlaceholder_few": "Bərpa ifadənizin {{count}} nömrəli payını buraya daxil edin",
+        "slip39SeedPhrasePlaceholder_other": "Bərpa ifadənizin {{count}} nömrəli payını buraya daxil edin",
+        "clearAll": "Hamısını təmizlə",
+        "pastedAndClear": "Yapışdırıldı və mübadilə buferi təmizləndi",
+        "invalidContent": "Etibarsız məzmun",
+        "inputInvalidCount_one": "Daxil edilən 1 ifadə bərpa ifadəsi qaydalarına uyğun deyil, yoxlayın.",
+        "inputInvalidCount_other": "Daxil edilən {{count}} ifadə bərpa ifadəsi qaydalarına uyğun deyil, yoxlayın.",
+        "passphrase": "Əlavə parol",
+        "showMoreOptions": "Daha çox seçim göstər",
+        "inputInvalid": "Etibarsız sözlər aşkarlandı. Vurğulanan sözləri yoxlayın."
+      },
+      "metamask": {
+        "step1": "  MetaMask-dan bərpa ifadəsini və ya şəxsi açarı ixrac edin <br /> <1>Təlimata baxmaq üçün klikləyin <1/></1>",
+        "step2": "Bərpa ifadəsini və ya şəxsi açarı Rabby-yə idxal edin",
+        "step3": "İdxal tamamlandı və bütün aktivləriniz <br /> avtomatik görünəcək",
+        "how": "MetaMask hesabımı necə idxal edim?",
+        "step": "Addım",
+        "importSeedPhrase": "Bərpa ifadəsini və ya şəxsi açarı idxal et",
+        "importSeedPhraseTips": "O, yalnız brauzerdə yerli olaraq saxlanılacaq. Rabby şəxsi məlumatlarınıza heç vaxt çıxış əldə etməyəcək.",
+        "tips": "Tövsiyələr:",
+        "tipsDesc": "Bərpa ifadəniz/şəxsi açarınız MetaMask-a və ya hər hansı konkret pul kisəsinə aid deyil; o, yalnız sizə məxsusdur."
+      },
+      "privateKey": {
+        "required": "Şəxsi açarı daxil edin",
+        "placeholder": "Şəxsi açarınızı daxil edin",
+        "whatIsAPrivateKey": {
+          "question": "Şəxsi açar nədir?",
+          "answer": "Aktivlərinizi idarə etmək üçün istifadə olunan hərf və rəqəmlər ardıcıllığı."
+        },
+        "repeatImportTips": {
+          "desc": "Bu ünvan idxal edilib.",
+          "question": "Bu ünvana keçmək istəyirsiniz?"
+        },
+        "isItSafeToImportItInRabby": {
+          "question": "Onu Rabby-yə idxal etmək təhlükəsizdir?",
+          "answer": "Bəli, o, brauzerinizdə yerli olaraq saxlanılacaq və yalnız siz ona çıxış əldə edə biləcəksiniz."
+        },
+        "isItPossibleToImportKeystore": {
+          "question": "Keystore idxal etmək mümkündür?",
+          "answer": "Bəli, burada <1> Keystore idxal edə bilərsiniz </1>."
+        },
+        "notAValidPrivateKey": "Etibarlı şəxsi açar deyil"
+      },
+      "importedSuccessfully": "Uğurla idxal edildi",
+      "ledger": {
+        "title": "Ledger-ə qoşul",
+        "cameraPermissionTitle": "Rabby-yə kameraya çıxış icazəsi ver",
+        "cameraPermission1": "Brauzerin açılan pəncərəsində Rabby-yə kameraya çıxış icazəsi verin",
+        "allowRabbyPermissionsTitle": "Rabby-yə aşağıdakılar üçün icazə verin:",
+        "ledgerPermission1": "HID cihazına qoşulmaq",
+        "ledgerPermissionTip": "Aşağıda \"İcazə ver\" düyməsinə klikləyin və növbəti açılan pəncərədə Ledger cihazınıza çıxışa icazə verin.",
+        "permissionsAuthorized": "İcazələr verildi",
+        "nowYouCanReInitiateYourTransaction": "İndi tranzaksiyanızı yenidən başlada bilərsiniz.",
+        "allow": "İcazə ver",
+        "error": {
+          "ethereum_app_not_installed_error": "Ledger cihazınızda Ethereum tətbiqini quraşdırın.",
+          "ethereum_app_unconfirmed_error": "Ethereum tətbiqini açmaq sorğusunu rədd etdiniz.",
+          "ethereum_app_open_error": "Ledger cihazınızda Ethereum tətbiqini quraşdırın/qəbul edin.",
+          "running_app_close_error": "Ledger cihazınızda işləyən tətbiqi bağlamaq alınmadı."
+        }
+      },
+      "imkey": {
+        "title": "imKey-yə qoşul",
+        "imkeyPermissionTip": "Aşağıda \"İcazə ver\" düyməsinə klikləyin və növbəti açılan pəncərədə imKey cihazınıza çıxışa icazə verin."
+      },
+      "keystone": {
+        "title": "Keystone-a qoşul",
+        "allowRabbyPermissionsTitle": "Rabby-yə aşağıdakılar üçün icazə verin:",
+        "keystonePermission1": "USB cihazına qoşulmaq",
+        "keystonePermissionTip": "Növbəti açılan pəncərədə Keystone cihazınıza çıxışa icazə vermək üçün aşağıda \"İcazə ver\" düyməsinə klikləyin və Keystone 3 Pro cihazınızın əsas səhifədə olduğuna əmin olun.",
+        "noDeviceFoundError": "Yalnız bir Keystone qoşun",
+        "deviceIsLockedError": "Kiliddən çıxarmaq üçün parolu daxil edin",
+        "deviceRejectedExportAddress": "Rabby-yə qoşulmağa icazə verin",
+        "deviceIsBusy": "Cihaz məşğuldur",
+        "exportAddressJustAllowedOnHomePage": "Ünvanın ixracına yalnız əsas səhifədə icazə verilir",
+        "unknowError": "Naməlum xəta, yenidən cəhd edin"
+      },
+      "onekey": {
+        "onekeyPermission1": "USB cihazına qoşulmaq",
+        "allowRabbyPermissionsTitle": "Rabby-yə aşağıdakılar üçün icazə verin:",
+        "onekeyPermissionTip": "Növbəti açılan pəncərədə OneKey cihazınıza çıxışa icazə vermək üçün aşağıda \"İcazə ver\" düyməsinə klikləyin. OneKey pəncərədə görünmürsə, cihazınızın kompüterə düzgün qoşulduğunu yoxlayın.",
+        "whyOneKey": "Niyə OneKey?",
+        "buyOneKey": "OneKey al",
+        "haveOneKey": "Hələ OneKey cihazınız yoxdur?"
+      },
+      "walletConnect": {
+        "connectYour": "Qoşun",
+        "viaWalletConnect": "WalletConnect vasitəsilə",
+        "connectedSuccessfully": "Uğurla qoşuldu",
+        "qrCodeError": "Şəbəkənizi yoxlayın və ya QR kodu yeniləyin",
+        "qrCode": "QR kod",
+        "url": "URL",
+        "changeBridgeServer": "Körpü serverini dəyiş",
+        "status": {
+          "received": "Skan uğurludur. Təsdiq gözlənilir",
+          "rejected": "Qoşulma ləğv edildi. Yenidən cəhd etmək üçün QR kodu skan edin.",
+          "brandError": "Yanlış pul kisəsi tətbiqi.",
+          "brandErrorDesc": "Qoşulmaq üçün {{brandName}} tətbiqindən istifadə edin",
+          "accountError": "Ünvan uyğun gəlmir.",
+          "accountErrorDesc": "Mobil pul kisənizdə ünvanı dəyişin",
+          "connected": "Qoşulub",
+          "duplicate": "İdxal etməyə çalışdığınız ünvan təkrarlanır",
+          "default": "{{brand}} ilə skan edin"
+        },
+        "title": "{{brandName}} ilə qoşul",
+        "disconnected": "Ayrılıb",
+        "tip": {
+          "accountError": {
+            "tip1": "Qoşulub, lakin imzalamaq mümkün deyil.",
+            "tip2": "Mobil pul kisəsində düzgün ünvana keçin"
+          },
+          "disconnected": {
+            "tip": "{{brandName}} ilə qoşulma yoxdur"
+          },
+          "connected": {
+            "tip": "{{brandName}} ilə qoşulub"
+          }
+        },
+        "button": {
+          "disconnect": "Ayır",
+          "connect": "Qoşul",
+          "howToSwitch": "Keçid qaydası"
+        }
+      },
+      "hd": {
+        "tooltip": {
+          "removed": "Ünvan Rabby-dən çıxarılıb",
+          "added": "Ünvan Rabby-yə əlavə edilib",
+          "connectError": "Qoşulma dayandı. Yenidən qoşulmaq üçün səhifəni yeniləyin.",
+          "disconnected": "Avadanlıq pul kisəsinə qoşulmaq mümkün deyil. Yenidən qoşulmağa cəhd edin."
+        },
+        "nonAddr": "Bu bərpa ifadəsi üçün ünvan əlavə edilməyib. İfadəni Rabby genişləndirməsi > Ünvanı idarə et bölməsində silə bilərsiniz.",
+        "waiting": "Gözlənilir",
+        "clickToGetInfo": "Zəncirdəki məlumatı almaq üçün kliklə",
+        "addToRabby": "Rabby-yə əlavə et",
+        "basicInformation": "Əsas məlumat",
+        "addresses": "Ünvanlar",
+        "loadingAddress": "{{0}}/{{1}} ünvan yüklənir",
+        "notes": "Qeydlər",
+        "getOnChainInformation": "Zəncirdəki məlumatı al",
+        "hideOnChainInformation": "Zəncirdəki məlumatı gizlət",
+        "usedChains": "İstifadə olunan zəncirlər",
+        "firstTransactionTime": "İlk tranzaksiyanın vaxtı",
+        "balance": "Balans",
+        "ledger": {
+          "hdPathType": {
+            "ledgerLive": "Ledger Live: Ledger-in rəsmi HD yolu. İlk 3 ünvan arasında zəncirdə istifadə olunmuş ünvanlar var.",
+            "bip44": "BIP44 standartı: BIP44 protokolunun müəyyən etdiyi HD yolu. İlk 3 ünvan arasında zəncirdə istifadə olunmuş ünvanlar var.",
+            "legacy": "Köhnə: MEW / Mycrypto tərəfindən istifadə olunan HD yolu. İlk 3 ünvan arasında zəncirdə istifadə olunmuş ünvanlar var."
+          },
+          "hdPathTypeNoChain": {
+            "ledgerLive": "Ledger Live: Ledger-in rəsmi HD yolu. İlk 3 ünvan arasında zəncirdə istifadə olunmuş ünvanlar yoxdur.",
+            "bip44": "BIP44 standartı: BIP44 protokolunun müəyyən etdiyi HD yolu. İlk 3 ünvan arasında zəncirdə istifadə olunmuş ünvanlar yoxdur.",
+            "legacy": "Köhnə: MEW / Mycrypto tərəfindən istifadə olunan HD yolu. İlk 3 ünvan arasında zəncirdə istifadə olunmuş ünvanlar yoxdur."
+          }
+        },
+        "trezor": {
+          "hdPathType": {
+            "bip44": "BIP44: BIP44 protokolunun müəyyən etdiyi HD yolu.",
+            "ledgerLive": "Ledger Live: Ledger-in rəsmi HD yolu.",
+            "legacy": "Köhnə: MEW / Mycrypto tərəfindən istifadə olunan HD yolu."
+          },
+          "hdPathTypeNoChain": {
+            "bip44": "BIP44: BIP44 protokolunun müəyyən etdiyi HD yolu.",
+            "ledgerLive": "Ledger Live: Ledger-in rəsmi HD yolu.",
+            "legacy": "Köhnə: MEW / Mycrypto tərəfindən istifadə olunan HD yolu."
+          },
+          "message": {
+            "disconnected": "{{0}} qoşulması dayandı. Yenidən qoşulmaq üçün səhifəni yeniləyin."
+          }
+        },
+        "onekey": {
+          "hdPathType": {
+            "bip44": "BIP44: BIP44 protokolunun müəyyən etdiyi HD yolu."
+          },
+          "hdPathTypeNoChain": {
+            "bip44": "BIP44: BIP44 protokolunun müəyyən etdiyi HD yolu."
+          }
+        },
+        "mnemonic": {
+          "hdPathType": {
+            "default": "Standart: Bərpa ifadəsinin idxalı üçün standart HD yolu istifadə olunur.",
+            "bip44": "BIP44 standartı: BIP44 protokolunun müəyyən etdiyi HD yolu.",
+            "ledgerLive": "Ledger Live: Ledger-in rəsmi HD yolu.",
+            "legacy": "Köhnə: MEW / Mycrypto tərəfindən istifadə olunan HD yolu."
+          },
+          "hdPathTypeNoChain": {
+            "default": "Standart: Bərpa ifadəsinin idxalı üçün standart HD yolu istifadə olunur."
+          }
+        },
+        "gridplus": {
+          "hdPathType": {
+            "ledgerLive": "Ledger Live: Ledger-in rəsmi HD yolu. İlk 3 ünvan arasında zəncirdə istifadə olunmuş ünvanlar var.",
+            "bip44": "BIP44 standartı: BIP44 protokolunun müəyyən etdiyi HD yolu. İlk 3 ünvan arasında zəncirdə istifadə olunmuş ünvanlar var.",
+            "legacy": "Köhnə: MEW / Mycrypto tərəfindən istifadə olunan HD yolu. İlk 3 ünvan arasında zəncirdə istifadə olunmuş ünvanlar var."
+          },
+          "hdPathTypeNochain": {
+            "ledgerLive": "Ledger Live: Ledger-in rəsmi HD yolu. İlk 3 ünvan arasında zəncirdə istifadə olunmuş ünvanlar yoxdur.",
+            "bip44": "BIP44 standartı: BIP44 protokolunun müəyyən etdiyi HD yolu. İlk 3 ünvan arasında zəncirdə istifadə olunmuş ünvanlar yoxdur.",
+            "legacy": "Köhnə: MEW / Mycrypto tərəfindən istifadə olunan HD yolu. İlk 3 ünvan arasında zəncirdə istifadə olunmuş ünvanlar yoxdur."
+          },
+          "switch": {
+            "title": "Yeni GridPlus cihazına keç",
+            "content": "Bir neçə GridPlus cihazının idxalı dəstəklənmir. Yeni GridPlus cihazına keçsəniz, idxal prosesi başlamazdan əvvəl cari cihazın ünvan siyahısı silinəcək."
+          },
+          "switchToAnotherGridplus": "Başqa GridPlus cihazına keç"
+        },
+        "keystone": {
+          "hdPathType": {
+            "bip44": "BIP44: BIP44 protokolunun müəyyən etdiyi HD yolu.",
+            "ledgerLive": "Ledger Live: Ledger-in rəsmi HD yolu. Ledger Live yolu ilə yalnız 10 ünvanı idarə edə bilərsiniz.",
+            "legacy": "Köhnə: MEW / Mycrypto tərəfindən istifadə olunan HD yolu."
+          },
+          "hdPathTypeNochain": {
+            "bip44": "BIP44: BIP44 protokolunun müəyyən etdiyi HD yolu.",
+            "ledgerLive": "Ledger Live: Ledger-in rəsmi HD yolu. Ledger Live yolu ilə yalnız 10 ünvanı idarə edə bilərsiniz.",
+            "legacy": "Köhnə: MEW / Mycrypto tərəfindən istifadə olunan HD yolu."
+          }
+        },
+        "bitbox02": {
+          "hdPathType": {
+            "bip44": "BIP44: BIP44 protokolunun müəyyən etdiyi HD yolu."
+          },
+          "hdPathTypeNoChain": {
+            "bip44": "BIP44: BIP44 protokolunun müəyyən etdiyi HD yolu."
+          },
+          "disconnected": "BitBox02 cihazına qoşulmaq mümkün deyil. Yenidən qoşulmaq üçün səhifəni yeniləyin. Səbəb: {{0}}"
+        },
+        "selectHdPath": "HD yolunu seç:",
+        "selectIndexTip": "Ünvanların başlanğıc sıra nömrəsini seçin:",
+        "manageAddressFrom": "{{0}} ilə {{1}} arasındakı ünvanları idarə et",
+        "advancedSettings": "Əlavə parametrlər",
+        "customAddressHdPath": "Fərdi ünvanın HD yolu",
+        "connectedToLedger": "Ledger-ə qoşulub",
+        "connectedToTrezor": "Trezor-a qoşulub",
+        "connectedToOnekey": "OneKey-yə qoşulub",
+        "manageSeedPhrase": "Bərpa ifadəsini idarə et",
+        "manageGridplus": "GridPlus-u idarə et",
+        "manageKeystone": "Keystone-u idarə et",
+        "manageAirgap": "AirGap-i idarə et",
+        "manageImtokenOffline": "imToken-i idarə et",
+        "manageCoolwallet": "CoolWallet-i idarə et",
+        "manageBitbox02": "BitBox02-ni idarə et",
+        "manageNgraveZero": "NGRAVE ZERO-nu idarə et",
+        "done": "Tamamla",
+        "addressesIn": "{{0}} daxilindəki ünvanlar",
+        "addressesInRabby": "Rabby{{0}} daxilindəki ünvanlar",
+        "qrCode": {
+          "switch": {
+            "title": "Yeni {{0}} cihazına keç",
+            "content": "Bir neçə {{0}} cihazının idxalı dəstəklənmir. Yeni {{0}} cihazına keçsəniz, idxal prosesi başlamazdan əvvəl cari cihazın ünvan siyahısı silinəcək."
+          },
+          "switchAnother": "Başqa {{0}} cihazına keç"
+        },
+        "manageImKey": "imKey-ni idarə et",
+        "importBtn": "İdxal et ({{count}})"
+      },
+      "importYourKeystore": "Keystore idxal et",
+      "incorrectPassword": "yanlış parol",
+      "keystore": {
+        "description": "İdxal etmək istədiyiniz Keystore faylını seçin və müvafiq parolu daxil edin",
+        "password": {
+          "required": "Parolu daxil edin",
+          "placeholder": "Parol"
+        }
+      },
+      "coboSafe": {
+        "inputSafeModuleAddress": "Safe modulunun ünvanını daxil edin",
+        "invalidAddress": "Etibarsız ünvan",
+        "whichChainIsYourCoboAddressOn": "Cobo ünvanınız hansı zəncirdədir",
+        "addCoboArgusAddress": "Cobo Argus ünvanı əlavə et",
+        "findTheAssociatedSafeAddress": "Əlaqəli Safe ünvanını tap",
+        "import": "İdxal et"
+      },
+      "addFromCurrentSeedPhrase": "Cari bərpa ifadəsindən əlavə et",
+      "trezor": {
+        "title": "Trezor-a qoşul"
+      }
+    },
+    "unlock": {
+      "btn": {
+        "unlock": "Kiliddən çıxar",
+        "unlockWithPassword": "Parolla kiliddən çıxar",
+        "biometric": "Biometriya ilə kiliddən çıxar"
+      },
+      "password": {
+        "required": "Kiliddən çıxarmaq üçün parolu daxil edin",
+        "placeholder": "Kiliddən çıxarmaq üçün parolu daxil edin",
+        "error": "yanlış parol"
+      },
+      "title": "Rabby pul kisəsi",
+      "description": "Ethereum və EVM üçün seçdiyiniz pul kisəsi",
+      "btnForgotPassword": "Parolu unutmusunuz?",
+      "biometricFailed": "Biometriya ilə kiliddən çıxarmaq alınmadı"
+    },
+    "addToken": {
+      "noTokenFound": "Token tapılmadı",
+      "tokenSupported": "Token Rabby-də dəstəklənir",
+      "tokenCustomized": "Cari token artıq xüsusi tokenlərə əlavə edilib",
+      "tokenNotFound": "Bu kontrakt ünvanında token tapılmadı",
+      "title": "Rabby-yə xüsusi token əlavə et",
+      "balance": "Balans",
+      "tokenOnMultiChains": "Token ünvanı bir neçə zəncirdədir. Birini seçin",
+      "noTokenFoundOnThisChain": "Bu zəncirdə token tapılmadı",
+      "hasAdded": "Bu tokeni artıq əlavə etmisiniz."
+    },
+    "switchChain": {
+      "title": "Rabby-yə xüsusi şəbəkə əlavə et",
+      "chainNotSupport": "Tələb olunan zəncir hələ Rabby-də dəstəklənmir",
+      "testnetTip": "Testnet-lərə qoşulmazdan əvvəl \"Daha çox\" bölməsində \"Testnet-ləri aktivləşdir\" seçimini aktivləşdirin",
+      "chainNotSupportYet": "Tələb olunan zəncir hələ Rabby-də dəstəklənmir",
+      "chainId": "Zəncir ID-si:",
+      "unknownChain": "Naməlum zəncir",
+      "requestsReceived": "1 sorğu alındı",
+      "requestsReceivedPlural": "{{count}} sorğu alındı",
+      "requestRabbyToSupport": "Rabby-dən dəstək istə",
+      "chainNotSupportAddChain": "Tələb olunan zəncir hələ Rabby-yə inteqrasiya edilməyib. Onu xüsusi Testnet kimi əlavə edə bilərsiniz",
+      "addChain": "Testnet əlavə et",
+      "desc": "Tələb olunan şəbəkə hələ Rabby-yə inteqrasiya edilməyib. Onu əl ilə xüsusi şəbəkə kimi əlavə edə bilərsiniz"
+    },
+    "signText": {
+      "title": "Mətni imzala",
+      "message": "Mətn mesajı",
+      "createKey": {
+        "interactDapp": "Əlaqə qurulan Dapp",
+        "description": "Təsvir"
+      },
+      "sameSafeMessageAlert": "Eyni mesaj təsdiqlənib; əlavə imza tələb olunmur."
+    },
+    "securityEngine": {
+      "yes": "Bəli",
+      "no": "Xeyr",
+      "whenTheValueIs": "dəyər {{value}} olduqda",
+      "currentValueIs": "Cari dəyər {{value}}",
+      "viewRules": "Təhlükəsizlik qaydalarına bax",
+      "undo": "Geri qaytar",
+      "riskProcessed": "Risk xəbərdarlığı nəzərə alınmadı",
+      "ignoreAlert": "Xəbərdarlığı nəzərə alma",
+      "ruleDisabled": "Təhlükəsizlik qaydaları söndürülüb. Təhlükəsizliyiniz üçün onları istənilən vaxt aktivləşdirə bilərsiniz.",
+      "unknownResult": "Təhlükəsizlik sistemi hazırda əlçatan olmadığı üçün nəticə naməlumdur",
+      "alertTriggerReason": "Xəbərdarlığın səbəbi:",
+      "understandRisk": "Anlayıram və hər hansı itkiyə görə məsuliyyəti qəbul edirəm",
+      "forbiddenCantIgnore": "Qadağanedici risk aşkarlandı. Onu nəzərə almamaq olmaz.",
+      "ruleDetailTitle": "Risk təfərrüatları",
+      "enableRule": "Qaydanı aktivləşdir",
+      "viewRiskLevel": "Risk səviyyəsinə bax"
+    },
+    "connect": {
+      "listedBy": "Siyahıya əlavə edən",
+      "sitePopularity": "Saytın populyarlığı",
+      "myMark": "İşarəm",
+      "flagByRabby": "Rabby tərəfindən işarələnib",
+      "flagByMM": "MetaMask tərəfindən işarələnib",
+      "flagByScamSniffer": "ScamSniffer tərəfindən işarələnib",
+      "verifiedByRabby": "Rabby tərəfindən yoxlanılıb",
+      "foundForbiddenRisk": "Qadağanedici risklər aşkarlandı. Qoşulma bloklanıb.",
+      "markAsTrustToast": "\"Etibarlı\" kimi işarələ",
+      "markAsBlockToast": "\"Bloklanmış\" kimi işarələ",
+      "markRemovedToast": "İşarə silindi",
+      "title": "Dapp-a qoşul",
+      "selectChainToConnect": "Qoşulmaq üçün zəncir seçin",
+      "markRuleText": "İşarəm",
+      "connectBtn": "Qoşul",
+      "noWebsite": "Yoxdur",
+      "popularLevelHigh": "Yüksək",
+      "popularLevelMedium": "Orta",
+      "popularLevelLow": "Aşağı",
+      "popularLevelVeryLow": "Çox aşağı",
+      "noMark": "İşarə yoxdur",
+      "blocked": "Bloklanıb",
+      "trusted": "Etibarlı",
+      "addedToWhitelist": "Ağ siyahınıza əlavə edildi",
+      "addedToBlacklist": "Qara siyahınıza əlavə edildi",
+      "removedFromAll": "Bütün siyahılardan çıxarıldı",
+      "notOnAnyList": "Heç bir siyahıda deyil",
+      "onYourBlacklist": "Qara siyahınızdadır",
+      "onYourWhitelist": "Ağ siyahınızdadır",
+      "manageWhiteBlackList": "Ağ/qara siyahını idarə et",
+      "SignTestnetPermission": {
+        "title": "İmzalama icazəsi"
+      },
+      "ignoreAll": "Heç birini nəzərə alma",
+      "otherWalletBtn": "Başqa pul kisəsi ilə qoşul",
+      "SelectWallet": {
+        "title": "Qoşulmaq üçün pul kisəsi seçin",
+        "desc": "Quraşdırdığınız pul kisələrindən seçin"
+      },
+      "connectAddress": "Ünvanı qoş",
+      "connected": "Qoşulub"
+    },
+    "addressDetail": {
+      "add-to-whitelist": "Ağ siyahıya əlavə et",
+      "remove-from-whitelist": "Ağ siyahıdan çıxar",
+      "address-detail": "Ünvan təfərrüatları",
+      "backup-private-key": "Şəxsi açarın ehtiyat nüsxəsini yarat",
+      "backup-seed-phrase": "Bərpa ifadəsinin ehtiyat nüsxəsini yarat",
+      "delete-address": "Ünvanı sil",
+      "delete-desc": "Silməzdən əvvəl aktivlərinizi necə qorumağı anlamaq üçün aşağıdakı məqamları nəzərə alın.",
+      "direct-delete-desc": "Bu, {{renderBrand}} ünvanıdır, Rabby onun şəxsi açarını və ya bərpa ifadəsini saxlamır, onu birbaşa silə bilərsiniz",
+      "admins": "İnzibatçılar",
+      "tx-requires": "Hər tranzaksiya üçün <2>{{num}}</2> təsdiq tələb olunur",
+      "edit-memo-title": "Ünvan qeydini redaktə et",
+      "please-input-address-note": "Ünvan qeydini daxil edin",
+      "address": "Ünvan",
+      "address-note": "Ünvan qeydi",
+      "assets": "Aktivlər",
+      "qr-code": "QR kodu",
+      "source": "Mənbə",
+      "hd-path": "HD yolu",
+      "manage-seed-phrase": "Bərpa ifadəsini idarə et",
+      "manage-addresses-under-this-seed-phrase": "Bu bərpa ifadəsinə aid ünvanları idarə et",
+      "safeModuleAddress": "Safe modulunun ünvanı",
+      "coboSafeErrorModule": "Ünvanın müddəti bitib, onu silib yenidən idxal edin.",
+      "importedDelegatedAddress": "İdxal edilmiş səlahiyyətli ünvan",
+      "manage-addresses-under": "Bu {{brand}} daxilindəki ünvanları idarə et",
+      "deleteSeedPhrase": {
+        "title": "Ünvan və bərpa ifadəsi silinsin?",
+        "title2": "Ünvan silinsin?",
+        "sub-title": "Bu əməliyyat geri qaytarılmır. Aktivlərinizi qorumaq üçün aşağıdakıları nəzərdən keçirin:",
+        "check1": "Anlayıram ki, bu ünvan silindikdə onun şəxsi açarı və bərpa ifadəsi də silinir. Rabby onları mənim üçün bərpa edə bilməz.",
+        "check2": "Şəxsi açarımın və ya bərpa ifadəmin ehtiyat nüsxəsini yaratdığımı və silməyə hazır olduğumu təsdiqləyirəm.",
+        "keepSeedPhrase": "Bu, həmin bərpa ifadəsinə aid yeganə ünvandır. Bərpa ifadəsini saxlamaq istəyirsiniz?",
+        "onlyDeleteAddr": "Yalnız bu ünvan silinəcək. Digər ünvanlarınız hələ də bərpa ifadəsindən istifadə etdiyi üçün o saxlanılacaq.",
+        "remainSeedPhrase": "Bərpa ifadəniz cihazınızda qalır.",
+        "option1": "Ünvanı sil, bərpa ifadəsini saxla",
+        "option2": "Ünvanı və bərpa ifadəsini sil"
+      },
+      "deletePrivateKey": {
+        "title": "Ünvan və şəxsi açar silinsin?",
+        "sub-title": "Bu əməliyyat geri qaytarılmır. Aktivlərinizi qorumaq üçün aşağıdakıları nəzərdən keçirin:",
+        "check1": "Anlayıram ki, bu ünvan silindikdə onun şəxsi açarı da silinir. Rabby onu mənim üçün bərpa edə bilməz.",
+        "check2": "Şəxsi açarımın və ya bərpa ifadəmin ehtiyat nüsxəsini yaratdığımı və silməyə hazır olduğumu təsdiqləyirəm."
+      },
+      "notBackup": "Ehtiyat nüsxə yoxdur"
+    },
+    "preferMetamaskDapps": {
+      "title": "MetaMask-a üstünlük verilən Dapp-lar",
+      "desc": "Hansı pul kisəsinə keçməyinizdən asılı olmayaraq, aşağıdakı Dapp-lar MetaMask vasitəsilə qoşulu qalacaq",
+      "howToAdd": "Əlavə etmə qaydası",
+      "howToAddDesc": "Saytda sağ düyməni klikləyin və bu seçimi tapın",
+      "empty": "Dapp yoxdur"
+    },
+    "customRpc": {
+      "opened": "Açıq",
+      "closed": "Bağlı",
+      "empty": "Xüsusi RPC URL-i yoxdur",
+      "title": "RPC URL-ini dəyiş",
+      "desc": "Dəyişdirildikdən sonra xüsusi RPC Rabby qovşağını əvəz edəcək. Rabby qovşağından istifadə etməyə davam etmək üçün xüsusi RPC-ni silin.",
+      "add": "RPC URL-ini dəyiş",
+      "EditRPCModal": {
+        "invalidRPCUrl": "Etibarsız RPC URL-i",
+        "invalidChainId": "Etibarsız zəncir ID-si",
+        "rpcAuthFailed": "RPC autentifikasiyası alınmadı",
+        "title": "RPC URL-ini dəyiş",
+        "rpcUrl": "RPC URL",
+        "rpcUrlPlaceholder": "RPC URL-ini daxil edin"
+      },
+      "EditCustomTestnetModal": {
+        "title": "Xüsusi şəbəkə əlavə et",
+        "quickAdd": "Chainlist-dən tez əlavə et"
+      }
+    },
+    "requestDebankTestnetGasToken": {
+      "title": "DeBank Testnet Gas tokenini istə",
+      "mintedTip": "Rabby nişanı sahibləri gündə bir dəfə istəyə bilər",
+      "notMintedTip": "Yalnız Rabby nişanı sahibləri istəyə bilər",
+      "claimBadgeBtn": "Rabby nişanını tələb et",
+      "time": "Gündə",
+      "requested": "Bu gün artıq sorğu göndərmisiniz",
+      "requestBtn": "Sorğu göndər"
+    },
+    "safeQueue": {
+      "title": "Növbə ({{total}})",
+      "sameNonceWarning": "Bu tranzaksiyalar eyni Nonce dəyərindən istifadə etdikləri üçün ziddiyyət təşkil edir. Birinin icrası digərlərini avtomatik əvəz edəcək.",
+      "loading": "Gözləyən tranzaksiyalar yüklənir",
+      "noData": "Gözləyən tranzaksiya yoxdur",
+      "loadingFaild": "Safe serveri qeyri-sabit olduğu üçün məlumat əlçatan deyil, 5 dəqiqədən sonra yenidən yoxlayın",
+      "accountSelectTitle": "Bu tranzaksiyanı istənilən ünvanla təqdim edə bilərsiniz",
+      "LowerNonceError": "Əvvəlcə Nonce dəyəri {{nonce}} olan tranzaksiya icra edilməlidir",
+      "submitBtn": "Tranzaksiyanı təqdim et",
+      "unknownTx": "Naməlum tranzaksiya",
+      "cancelExplain": "{{protocol}} üçün {{token}} icazəsini ləğv et",
+      "unknownProtocol": "Naməlum protokol",
+      "approvalExplain": "{{protocol}} üçün {{count}} {{token}} istifadəsinə icazə ver",
+      "unlimited": "məhdudiyyətsiz",
+      "action": {
+        "send": "Göndər",
+        "cancel": "Gözləyən tranzaksiyanı ləğv et"
+      },
+      "viewBtn": "Bax",
+      "replaceBtn": "Əvəz et",
+      "ReplacePopup": {
+        "options": {
+          "send": "Token göndər",
+          "reject": "Tranzaksiyanı rədd et"
+        },
+        "title": "Bu tranzaksiyanın necə əvəz ediləcəyini seçin",
+        "desc": " İmzalanmış tranzaksiya silinə bilməz, lakin eyni Nonce dəyərinə malik yeni tranzaksiya ilə əvəz edilə bilər."
+      }
+    },
+    "importSuccess": {
+      "title": "Uğurla idxal edildi",
+      "addressCount": "{{count}} ünvan",
+      "gnosisChainDesc": "Bu ünvanın {{count}} zəncirdə yerləşdirildiyi aşkarlandı"
+    },
+    "backupSeedPhrase": {
+      "title": "Bərpa ifadəsinin ehtiyat nüsxəsini yarat",
+      "alert": "Bu bərpa ifadəsi aktivlərinizə giriş vasitəsidir. Onu İTİRMƏYİN və başqalarına AÇIQLAMAYIN, əks halda aktivlərinizi həmişəlik itirə bilərsiniz. Ona təhlükəsiz mühitdə baxın və diqqətlə qoruyun.",
+      "clickToShow": "Bərpa ifadəsini göstərmək üçün klikləyin",
+      "copySeedPhrase": "Bərpa ifadəsini kopyala",
+      "showQrCode": "QR kodunu göstər",
+      "qrCodePopupTitle": "QR kodu",
+      "qrCodePopupTips": "Bərpa ifadəsinin QR kodunu heç vaxt başqaları ilə paylaşmayın. Ona təhlükəsiz mühitdə baxın və diqqətlə qoruyun.",
+      "doneButton": "Bərpa ifadəsini yadda saxladım"
+    },
+    "backupPrivateKey": {
+      "title": "Şəxsi açarın ehtiyat nüsxəsini yarat",
+      "alert": "Bu şəxsi açar aktivlərinizə giriş vasitəsidir. Onu İTİRMƏYİN və başqalarına AÇIQLAMAYIN, əks halda aktivlərinizi həmişəlik itirə bilərsiniz. Ona təhlükəsiz mühitdə baxın və diqqətlə qoruyun.",
+      "clickToShow": "Şəxsi açarı göstərmək üçün klikləyin",
+      "clickToShowQr": "Şəxsi açarın QR kodunu göstərmək üçün klikləyin"
+    },
+    "ethSign": {
+      "alert": "'eth_sign' ilə imzalama aktiv itkisinə səbəb ola bilər. Təhlükəsizliyiniz üçün Rabby bu üsulu dəstəkləmir."
+    },
+    "createPassword": {
+      "title": "Parol təyin et",
+      "passwordRequired": "Parolu daxil edin",
+      "passwordMin": "Parol ən azı 8 simvoldan ibarət olmalıdır",
+      "passwordPlaceholder": "Parol ən azı 8 simvoldan ibarət olmalıdır",
+      "confirmRequired": "Parolu təsdiqləyin",
+      "confirmError": "Parollar uyğun gəlmir",
+      "confirmPlaceholder": "Parolu təsdiqləyin",
+      "agree": "<1/> <2>İstifadə şərtlərini</2> və <4>Məxfilik siyasətini</4> oxudum və qəbul edirəm"
+    },
+    "welcome": {
+      "step1": {
+        "title": "Bütün Dapp-lara giriş",
+        "desc": "Rabby MetaMask-ın dəstəklədiyi bütün Dapp-lara qoşulur"
+      },
+      "step2": {
+        "title": "Tam şəxsi nəzarət",
+        "desc": "Şəxsi açarlar cihazda saxlanılır və yalnız siz onlara daxil ola bilərsiniz",
+        "btnText": "Başla"
+      }
+    },
+    "importSafe": {
+      "title": "Safe ünvanı əlavə et",
+      "placeholder": "Ünvan daxil edin",
+      "error": {
+        "invalid": "Etibarlı ünvan deyil",
+        "required": "Ünvan daxil edin"
+      },
+      "loading": "Bu ünvanın yerləşdirildiyi zəncir axtarılır",
+      "gnosisChainDesc": "Bu ünvanın {{count}} zəncirdə yerləşdirildiyi aşkarlandı"
+    },
+    "importQrBase": {
+      "desc": "{{brandName}} aparat pul kisəsindəki QR kodunu skan edin",
+      "btnText": "Yenidən cəhd et"
+    },
+    "pendingDetail": {
+      "Header": {
+        "predictTime": "Bloka daxil edilmə vaxtı (təxmini)"
+      },
+      "TxStatus": {
+        "completed": "Tamamlanıb",
+        "pendingBroadcasted": "Gözləyir: yayımlanıb",
+        "pendingBroadcast": "Gözləyir: yayımlanacaq",
+        "reBroadcastBtn": "Yenidən yayımla"
+      },
+      "TxHash": {
+        "hash": "Tranzaksiya heşi"
+      },
+      "TxTimeline": {
+        "pending": "Vəziyyət yoxlanılır...",
+        "created": "Tranzaksiya yaradıldı",
+        "broadcasted": "Yenicə yayımlandı",
+        "broadcastedCount_ordinal_one": "Yayımlama №{{count}}",
+        "broadcastedCount_ordinal_two": "Yayımlama №{{count}}",
+        "broadcastedCount_ordinal_few": "Yayımlama №{{count}}",
+        "broadcastedCount_ordinal_other": "Yayımlama №{{count}}"
+      },
+      "MempoolList": {
+        "col": {
+          "nodeName": "Qovşağın adı",
+          "nodeOperator": "Qovşağın operatoru",
+          "txStatus": "Tranzaksiyanın vəziyyəti"
+        },
+        "txStatus": {
+          "appeared": "Görünüb",
+          "appearedOnce": "Bir dəfə görünüb",
+          "notFound": "Tapılmadı"
+        },
+        "title": "{{count}} RPC qovşağında görünüb"
+      },
+      "PendingTxList": {
+        "title": "Gözləyən tranzaksiyalarda Gas qiymətinin sırası: #{{rank}}",
+        "titleNotFound": "Bütün gözləyən tranzaksiyalar arasında sıralama yoxdur",
+        "filterBaseFee": {
+          "label": "Yalnız baza haqqı tələbinə uyğun olanlar",
+          "tooltip": "Yalnız Gas qiyməti blokun baza haqqı tələblərinə uyğun olan tranzaksiyaları göstərin"
+        },
+        "col": {
+          "gasPrice": "Gas qiyməti",
+          "action": "Tranzaksiya əməliyyatı",
+          "balanceChange": "Balans dəyişikliyi",
+          "actionType": "Əməliyyat növü",
+          "interact": "Qarşılıqlı əlaqə tərəfi"
+        },
+        "titleSame": "Cari ilə eyni olanlarda Gas qiymətinin sırası: #{{rank}}",
+        "titleSameNotFound": "Cari ilə eyni olanlar arasında sıralama yoxdur"
+      },
+      "Empty": {
+        "noData": "Məlumat tapılmadı"
+      },
+      "PrePackInfo": {
+        "col": {
+          "prePackContent": "Bloka daxil edilmə öncəsi məzmun",
+          "expectations": "Gözləntilər",
+          "prePackResults": "Bloka daxil edilmə öncəsi nəticələr",
+          "difference": "Yoxlama nəticələri"
+        },
+        "type": {
+          "pay": "Ödə",
+          "receive": "Al"
+        },
+        "noLoss": "İtki aşkarlanmadı",
+        "noError": "Xəta aşkarlanmadı",
+        "title": "Bloka daxil edilmə öncəsi yoxlama",
+        "error": "{{count}} xəta aşkarlandı",
+        "loss": "{{lossCount}} itki aşkarlandı",
+        "desc": "Simulyasiya son blokda icra edildi, yenilənmə vaxtı: {{time}}"
+      },
+      "Predict": {
+        "completed": "Tranzaksiya tamamlandı",
+        "predictFailed": "Bloka daxil edilmə vaxtını proqnozlaşdırmaq alınmadı",
+        "skipNonce": "Ethereum zəncirində ünvanınızın Nonce ardıcıllığında boşluq var, buna görə cari tranzaksiya tamamlana bilmir"
+      }
+    },
+    "dappSearch": {
+      "selectChain": "Zəncir seç",
+      "searchResult": {
+        "foundDapps": "<2>{{count}}</2> Dapp tapıldı",
+        "totalDapps": "Cəmi <2>{{count}}</2> Dapp"
+      },
+      "expand": "Genişləndir",
+      "emptyFavorite": "Seçilmiş Dapp yoxdur",
+      "favorite": "Seçilmişlər",
+      "emptySearch": "Dapp tapılmadı",
+      "listBy": "Dapp-ı siyahıya əlavə edən",
+      "searchPlaceholder": "Dapp adına görə axtarış",
+      "searchButton": "Axtar"
+    },
+    "rabbyPoints": {
+      "title": "Rabby xalları",
+      "out-of-x-current-total-points": "Paylanmış cəmi {{total}} xaldan",
+      "share-on": "Paylaş",
+      "referral-code-copied": "Dəvət kodu kopyalandı",
+      "earn-points": "Xal qazan",
+      "top-100": "İlk 100",
+      "claimItem": {
+        "claim": "Tələb et",
+        "disabledTip": "Hazırda tələb ediləcək xal yoxdur",
+        "go": "Keç",
+        "earnTip": "Gündə bir dəfə. Xalları 00:00 UTC+0-dan sonra qazanın",
+        "claimed": "Tələb edilib"
+      },
+      "claimModal": {
+        "title": "İlkin xalları tələb et",
+        "snapshotTime": "Anlıq qeydin vaxtı: {{time}}",
+        "placeholder": "Əlavə xal üçün dəvət kodunu daxil edin (istəyə bağlı)",
+        "claim": "Tələb et",
+        "addressBalance": "Pul kisəsinin balansı",
+        "MetaMaskSwap": "MetaMask mübadiləsi",
+        "rabbyUser": "Rabby-nin aktiv istifadəçisi",
+        "rabbyValuedUserBadge": "Rabby-nin dəyərli istifadəçi nişanı",
+        "rabbyDesktopGenesisNft": "Rabby masaüstü versiyasının ilkin NFT-si",
+        "walletBalance": "Pul kisəsinin balansı",
+        "activeStats": "Aktivlik vəziyyəti",
+        "referral-code": "Dəvət kodu",
+        "invalid-code": "etibarsız kod",
+        "cantUseOwnCode": "Öz dəvət kodunuzdan istifadə edə bilməzsiniz.",
+        "season2": "Mövsüm 2"
+      },
+      "referralCode": {
+        "referral-code-cannot-be-empty": "Dəvət kodu boş ola bilməz",
+        "referral-code-cannot-exceed-15-characters": "Dəvət kodu 15 simvoldan çox ola bilməz",
+        "referral-code-already-exists": "Dəvət kodu artıq mövcuddur",
+        "referral-code-available": "Dəvət kodu istifadə üçün mövcuddur",
+        "my-referral-code": "Dəvət kodum",
+        "refer-a-new-user-to-get-50-points": "50 xal qazanmaq üçün yeni istifadəçi dəvət edin",
+        "set-my-code": "Kodumu təyin et",
+        "set-my-referral-code": "Dəvət kodumu təyin et",
+        "once-set-this-referral-code-is-permanent-and-cannot-change": "Təyin edildikdən sonra bu dəvət kodu daimi olur və dəyişdirilə bilməz.",
+        "max-15-characters-use-numbers-and-letters-only": "Maksimum 15 simvol, yalnız rəqəm və hərflərdən istifadə edin.",
+        "confirm": "Təsdiqlə",
+        "verifyAddressModal": {
+          "verify-address": "Ünvanı yoxla",
+          "please-sign-this-text-message-to-verify-that-you-are-the-owner-of-this-address": "Bu ünvanın sahibi olduğunuzu doğrulamaq üçün bu mətn mesajını imzalayın",
+          "cancel": "Ləğv et",
+          "sign": "İmzala"
+        }
+      },
+      "code-set-successfully": "Dəvət kodu uğurla təyin edildi",
+      "initialPointsClaimEnded": "İlkin xalları tələb etmə müddəti bitdi",
+      "firstRoundEnded": "🎉 Rabby xallarının birinci mərhələsi başa çatdı",
+      "secondRoundEnded": "🎉 Rabby xallarının ikinci mərhələsi başa çatdı"
+    },
+    "customTestnet": {
+      "title": "Fərdi şəbəkə",
+      "desc": "Rabby fərdi şəbəkələrin təhlükəsizliyini yoxlaya bilmir. Yalnız etibarlı şəbəkələr əlavə edin.",
+      "add": "Xüsusi şəbəkə əlavə et",
+      "empty": "Fərdi şəbəkə yoxdur",
+      "currency": "Valyuta",
+      "id": "ID",
+      "CustomTestnetForm": {
+        "id": "Zəncir ID-si",
+        "name": "Şəbəkə adı",
+        "rpcUrl": "RPC URL",
+        "idRequired": "Zəncir ID-sini daxil edin",
+        "nameRequired": "Şəbəkə adını daxil edin",
+        "rpcUrlRequired": "RPC URL-i daxil edin",
+        "nativeTokenSymbol": "Valyuta simvolu",
+        "nativeTokenSymbolRequired": "Valyuta simvolunu daxil edin",
+        "blockExplorerUrl": "Explorer URL-i (istəyə bağlı)"
+      },
+      "AddFromChainList": {
+        "title": "Chainlist-dən tez əlavə et",
+        "search": "Fərdi şəbəkənin adını və ya ID-sini axtar",
+        "empty": "Zəncir tapılmadı",
+        "tips": {
+          "added": "Bu zənciri artıq əlavə etmisiniz",
+          "supported": "Zəncir artıq Rabby pul kisəsinə inteqrasiya edilib"
+        }
+      },
+      "signTx": {
+        "title": "Tranzaksiya məlumatları"
+      },
+      "ConfirmModifyRpcModal": {
+        "desc": "Zəncir artıq Rabby-yə inteqrasiya edilib. Onun RPC URL-ini dəyişmək istəyirsiniz?"
+      }
+    },
+    "addChain": {
+      "title": "Rabby-yə xüsusi şəbəkə əlavə et",
+      "desc": "Rabby fərdi şəbəkələrin təhlükəsizliyini yoxlaya bilmir. Yalnız etibarlı şəbəkələr əlavə edin."
+    },
+    "sign": {
+      "transactionSpeed": "Tranzaksiya sürəti"
+    },
+    "ecology": {
+      "sonic": {
+        "home": {
+          "airdrop": "Pulsuz paylanma",
+          "airdropDesc": "Opera və Sonic istifadəçilərinə ~200 milyon S.",
+          "airdropBtn": "Xal qazan",
+          "arcadeDesc": "S tokenlərinin pulsuz paylanması üçün pulsuz oyunlar oynayıb xal qazanın.",
+          "arcadeBtn": "İndi oyna",
+          "migrateTitle": "Köçürmə",
+          "migrateDesc": "→",
+          "migrateBtn": "Tezliklə",
+          "earnTitle": "Qazanc",
+          "earnDesc": "$S tokenlərinizi stake edin",
+          "earnBtn": "Tezliklə",
+          "socialsTitle": "İştirak et"
+        },
+        "points": {
+          "sonicPoints": "Sonic xalları",
+          "referralCode": "Dəvət kodu",
+          "referralCodeCopied": "Dəvət kodu kopyalandı",
+          "today": "Bu gün",
+          "shareOn": "Paylaş",
+          "sonicArcade": "Sonic Arcade",
+          "sonicArcadeBtn": "Oynamağa başla",
+          "pointsDashboard": "Xalların idarə paneli",
+          "pointsDashboardBtn": "Xal qazanmağa başla",
+          "errorTitle": "Xalları yükləmək mümkün olmadı",
+          "errorDesc": "Xallarınız yüklənərkən xəta baş verdi. Yenidən cəhd edin.",
+          "retry": "Yenidən cəhd et",
+          "getReferralCode": "Dəvət kodu al"
+        }
+      },
+      "dbk": {
+        "home": {
+          "bridge": "DBK zəncirinə körpü ilə köçür",
+          "bridgePoweredBy": "OP Superchain dəstəyi ilə",
+          "bridgeBtn": "Körpü ilə köçür",
+          "mintNFT": "DBK Genesis NFT-si yarat",
+          "mintNFTDesc": "DBK zəncirinin şahidi olun",
+          "mintNFTBtn": "Yarat",
+          "withdraw": "DBK zəncirindən çıxar"
+        },
+        "bridge": {
+          "tabs": {
+            "deposit": "Yatır",
+            "withdraw": "Çıxar"
+          },
+          "labelFrom": "Mənbə",
+          "labelTo": "Hədəf",
+          "info": {
+            "toAddress": "Alıcı ünvanı",
+            "receiveOn": "{{chainName}} şəbəkəsində al",
+            "completeTime": "Tamamlanma vaxtı",
+            "gasFee": "Gas haqqı"
+          },
+          "error": {
+            "notEnoughBalance": "Balans kifayət deyil"
+          },
+          "ActivityPopup": {
+            "empty": "Hələ fəaliyyət yoxdur",
+            "deposit": "Yatır",
+            "withdraw": "Çıxar",
+            "status": {
+              "deposit": "Yatır",
+              "withdraw": "Çıxar",
+              "waitingToProve": "Vəziyyət kökü dərc edildi",
+              "rootPublished": "Vəziyyət kökü dərc edildi",
+              "readyToProve": "Sübut etməyə hazırdır",
+              "proved": "Sübut edildi",
+              "challengePeriod": "Etiraz müddəti",
+              "readyToClaim": "Tələb etməyə hazırdır",
+              "claimed": "Tələb edilib"
+            },
+            "proveBtn": "Sübut et",
+            "claimBtn": "Tələb et",
+            "title": "Fəaliyyətlər"
+          },
+          "WithdrawConfirmPopup": {
+            "question1": "Anlayıram ki, çıxarışı sübut etdikdən sonra vəsaitimi Ethereum-da tələb edə bilmək üçün ~7 gün gözləməliyəm",
+            "question2": "Anlayıram ki, çıxarış başladıqdan sonra onu sürətləndirmək və ya ləğv etmək mümkün deyil",
+            "question3": "Anlayıram ki, şəbəkə haqları təxminidir və dəyişəcək",
+            "title": "DBK zəncirindən çıxarış ~7 gün çəkir",
+            "tips": "Çıxarış 3 addımdan ibarətdir, 1 DBK zənciri tranzaksiyası və 2 Ethereum tranzaksiyası tələb edir",
+            "step1": "Çıxarışı başlat",
+            "step2": "Ethereum-da sübut et",
+            "step3": "Ethereum-da tələb et",
+            "btn": "Çıxar"
+          }
+        },
+        "minNFT": {
+          "title": "DBK Genesis",
+          "minted": "Yaradıldı",
+          "myBalance": " Balansım",
+          "mintBtn": "Yarat"
+        }
+      }
+    },
+    "miniSignFooterBar": {
+      "signWithLedger": "Ledger ilə imzala",
+      "signWithOneKey": "OneKey ilə imzala",
+      "status": {
+        "txCreated": "Tranzaksiya yaradıldı",
+        "txSigned": "İmzalandı. Tranzaksiya yaradılır",
+        "txSending": "İmzalama sorğusu göndərilir",
+        "txSendings": "İmzalama sorğusu göndərilir({{current}}/{{total}})"
+      },
+      "speedUpTitle": "Sürətləndirmə",
+      "cancelTitle": "Zəncirdə ləğv",
+      "cancleDesc": "Daha sürətli ləğv üçün Gas qiyməti {{percent}} artırıldı",
+      "speedUpDesc": "Daha tez sürətləndirmək üçün Gas qiyməti {{percent}} artırıldı"
+    },
+    "gasAccount": {
+      "gasFee": "Gas haqqı",
+      "title": "Gas hesabı",
+      "gasDeposit": "Gas yatırılması",
+      "gasToken": "Gas tokeni",
+      "deposit": "Yatır",
+      "depositNow": "İndi yatır",
+      "signWithPendingHardwareToUse": "İstifadə etmək üçün {{addressAlias}} ilə imzalayın",
+      "depositSubmitted": "Yatırma sorğusu göndərildi",
+      "withdraw": "Çıxar",
+      "noBalance": "Balans yoxdur",
+      "gasExceed": "Gas hesabının balansı $1000-dan çox ola bilməz",
+      "safeAddressDepositTips": "Çoximzalı ünvanlardan yatırma dəstəklənmir.",
+      "risk": "Cari ünvanınız riskli hesab edildiyindən bu funksiya mövcud deyil.",
+      "logout": "Cari Gas hesabından çıx",
+      "switchAccount": "Pul kisəsini dəyiş",
+      "claimFreeGas": "{{usdValue}} dəyərində pulsuz Gas tələb et",
+      "depositFailed": "Yatırmaq alınmadı",
+      "lowBalance": "Gas kifayət deyil (＜$1.00). Gələcək tranzaksiyaların rahat icrası üçün Gas yatırın.",
+      "gasBalance": "Gas balansı",
+      "withdrawDisabledIAP": "Balansınızda çıxarıla bilməyən fiat vəsaitlər olduğundan çıxarışlar söndürülüb. Token balansınızı çıxarmaq üçün dəstəyə müraciət edin",
+      "benefitCard": {
+        "title": "Bütün zəncirlərdə Gas haqlarını ödə",
+        "subtitle": "Gas bitdikdə",
+        "item1": "Rabby haqqı yoxdur",
+        "desc1": "Gas ödənişi üçün əlavə haqq yoxdur",
+        "item2": "Bütün şəbəkələri dəstəkləyir",
+        "desc2": "80+ şəbəkədə avtomatik Gas ödənişləri",
+        "item3": "Bütün tranzaksiyaları dəstəkləyir",
+        "desc3": "Mübadilə, körpü, göndərmə, Dapp-lar və sair"
+      },
+      "history": {
+        "noHistory": "Tarixçə yoxdur",
+        "noHistoryForPast30Days": "Son 30 gün üçün tarixçə yoxdur."
+      },
+      "loginInTip": {
+        "title": "USDC / USDT yatır",
+        "desc": "Bütün zəncirlərdə Gas haqlarını ödə",
+        "login": "Gas hesabına daxil ol",
+        "loginAndClaim": "Daxil ol və {{usdValue}} tələb et",
+        "gotIt": "Anladım",
+        "loginTips1": "Gas haqlarını ödə",
+        "loginTips2": "istənilən zəncirdə istənilən ünvan üçün",
+        "loginTips3": "Gas bitdikdə",
+        "learnAbout": "Gas hesabı haqqında ətraflı öyrən"
+      },
+      "about": {
+        "title1": "Gas hesabı nədir",
+        "desc1": "Gas hesabı Gas haqlarını ödəməyin yeni üsuludur. Hər zəncirin öz tokenindən istifadə etmək əvəzinə, bir hesabla bütün zəncirlərdəki bütün ünvanlarınızın Gas haqqını ödəyə bilərsiniz. Sadədir, istifadəsi könüllüdür və Gas həmişə var.",
+        "title2": "Gas hesabından istifadə qaydası",
+        "desc2": "Gas hesabına vəsait əlavə edin və istənilən tranzaksiyada istifadə edin. İmzalayarkən Gas ödənişi üçün zəncirin öz tokenini və ya Gas hesabını seçin, istənilən vaxt dəyişin.",
+        "title3": "Gas hesabında əlavə haqlar varmı",
+        "desc3": "Rabby pul kisəsi əlavə haqq tutmur. Yalnız tranzaksiyanızın Gas haqqını və həmin Gas-ı Gas hesabından ünvanınıza göndərmək üçün az miqdarda Gas haqqı ödəyirsiniz.",
+        "title4": "Gas hesabı təhlükəsizdirmi",
+        "desc4": "Gas hesabı heç bir kontrakt icazəsi və ya digər icazə tələb etmir. Rabby-nin Gas hesabı ünvanına vəsait yatırırsınız və Rabby lazım olduqda ünvanınıza Gas göndərir. Quruluşu tam təhlükəsizdir."
+      },
+      "loginConfirmModal": {
+        "title": "Daxil olmaq üçün ünvan seç",
+        "desc": "Təsdiqdən sonra yalnız bu ünvandan vəsait yatıra bilərsiniz"
+      },
+      "gasAccountList": {
+        "address": "Ünvan",
+        "gasAccountBalance": "Balans"
+      },
+      "logoutConfirmModal": {
+        "title": "Cari Gas hesabından çıx",
+        "desc": "Çıxış Gas hesabını söndürür. Bu ünvanla daxil olaraq Gas hesabını bərpa edə bilərsiniz.",
+        "logout": "Çıx"
+      },
+      "depositPopup": {
+        "title": "Yatır",
+        "gasDepositTitle": "Gas yatırılması",
+        "desc": "Rabby-nin DeBank L2 hesabına əlavə haqq olmadan vəsait yatırın, istənilən vaxt çıxarın.",
+        "zeroInvalidAmount": "Məbləğ sıfır ola bilməz",
+        "invalidAmount": "500-dən az olmalıdır",
+        "minAmountRequired": "Minimum yatırma məbləği: ${{value}}",
+        "amount": "Məbləğ",
+        "token": "Token",
+        "selectToken": "Yatırmaq üçün token seç",
+        "paymentAddr": "Ödəniş pul kisəsi",
+        "paymentAddress": "Ödəniş pul kisəsi",
+        "balanceLabel": "Balans",
+        "insufficientBalanceLabel": "Balans kifayət deyil",
+        "unavailablePaymentWallet": "Seçilmiş ödəniş pul kisəsi əlçatan deyil",
+        "suggestedToken": "Tövsiyə olunan tokenlər",
+        "bridgeLabel": "Körpü ilə köçür",
+        "estReceiveLabel": "Təxmini alınacaq: {{usd}}",
+        "estReceiveTip": "Xidmət {{name}} vasitəsilə icra olunur, sürüşmə ola bilər",
+        "depositSuccess": "Vəsait uğurla yatırıldı",
+        "depositFailed": "Yatırmaq alınmadı, yenidən cəhd edin",
+        "bridgeDepositFailed": "Körpü ilə yatırmaq alınmadı, yenidən cəhd edin",
+        "noAvailableToken": "Mövcud token yoxdur",
+        "InsufficientToken": "Token balansı kifayət deyil"
+      },
+      "depositPayPopup": {
+        "topUpPayTips": "Tələb olunan Gas: {{topUpUsd}}, təxmini qalan Gas: {{balance}}"
+      },
+      "withdrawPopup": {
+        "noEnoughValuetBalance": "Saxlanc balansı kifayət deyil. Zənciri dəyişin və ya sonra yenidən cəhd edin.",
+        "noEnoughGas": "Məbləğ Gas haqlarını ödəmək üçün çox azdır",
+        "noEnoughValueBalance": "Saxlanc balansı kifayət deyil. Zənciri dəyişin və ya sonra yenidən cəhd edin.",
+        "riskMessageFromChain": "Risk nəzarətinə görə çıxarış limiti bu zəncirdən yatırılan ümumi məbləğdən asılıdır.",
+        "riskMessageFromAddress": "Risk nəzarətinə görə çıxarış limiti bu ünvanın yatırdığı ümumi məbləğdən asılıdır",
+        "selectDestinationChain": "Təyinat zəncirini seç",
+        "selectRecipientAddress": "Alıcı ünvanını seç",
+        "withdrawalLimit": "Çıxarış limiti",
+        "WithdrawalAmount": "Çıxarış məbləği",
+        "withdrawalTip": "Çıxarış üçün mövcud balans: {{amount}}",
+        "noBalance": "Balans yoxdur",
+        "title": "Çıxar",
+        "desc": "Gas hesabınızdakı balansı DeBank L2 pul kisənizə çıxara bilərsiniz. Lazım olduqda vəsaiti dəstəklənən blokçeynə köçürmək üçün DeBank L2 pul kisənizə daxil olun.",
+        "amount": "Məbləğ",
+        "to": "Hədəf",
+        "selectChain": "Zəncir seç",
+        "selectAddr": "Ünvan seç",
+        "recipientAddress": "Alıcı ünvanı",
+        "destinationChain": "Təyinat zənciri",
+        "deductGasFees": "Alınacaq məbləğdən Gas haqları çıxılacaq",
+        "noEligibleAddr": "Çıxarış üçün uyğun ünvan yoxdur",
+        "noEligibleChain": "Çıxarış üçün uyğun zəncir yoxdur",
+        "amountTooLowCoverFee": "Məbləğ Gas haqlarını ödəmək üçün çox azdır"
+      },
+      "withdrawConfirmModal": {
+        "title": "DeBank L2 pul kisənizə köçürüldü",
+        "button": "DeBank-da bax"
+      },
+      "GasAccountDepositTipPopup": {
+        "title": "Gas hesabı aç və vəsait yatır",
+        "gotIt": "Anladım"
+      },
+      "switchLoginAddressBeforeDeposit": {
+        "title": "Yatırmadan əvvəl ünvanı dəyiş",
+        "desc": "Giriş ünvanınıza keçin."
+      },
+      "loginSuccess": "Giriş uğurludur",
+      "loginFailed": "Giriş alınmadı"
+    },
+    "safeMessageQueue": {
+      "loading": "Mesajlar yüklənir",
+      "noData": "Mesaj yoxdur"
+    },
+    "newUserImport": {
+      "guide": {
+        "title": "Rabby pul kisəsinə xoş gəlmisiniz",
+        "desc": "Ethereum və EVM üçün seçdiyiniz pul kisəsi",
+        "createNewAddress": "Yeni ünvan yarat",
+        "importAddress": "Artıq ünvanım var"
+      },
+      "createNewAddress": {
+        "title": "Başlamazdan əvvəl",
+        "desc": "Aşağıdakı təhlükəsizlik tövsiyələrini oxuyun və yadda saxlayın",
+        "tip1": "Bərpa ifadəmi itirsəm və ya paylaşsam, aktivlərimə çıxışı həmişəlik itirəcəyəm",
+        "tip2": "Bərpa ifadəm yalnız cihazımda saxlanılır. Rabby ona çıxış əldə edə bilmir",
+        "tip3": "Bərpa ifadəmin ehtiyat nüsxəsini yaratmadan Rabby-ni silsəm, Rabby onu bərpa edə bilməz",
+        "showSeedPhrase": "Bərpa ifadəsini göstər"
+      },
+      "importList": {
+        "title": "İdxal üsulunu seç "
+      },
+      "importPrivateKey": {
+        "title": "Şəxsi açarı idxal et",
+        "pasteCleared": "Yapışdırıldı və mübadilə buferi təmizləndi",
+        "noWallet": "Hələ bərpa ifadəniz və ya şəxsi açarınız yoxdur?",
+        "createWallet": "Pul kisəsi yarat",
+        "placeholder": "Şəxsi açarı daxil et",
+        "required": "Şəxsi açarı daxil edin"
+      },
+      "PasswordCard": {
+        "title": "Parol təyin et",
+        "form": {
+          "password": {
+            "label": "Parol",
+            "placeholder": "Parol (ən azı 8 simvol)",
+            "required": "Parolu daxil edin",
+            "min": "Parol ən azı 8 simvoldan ibarət olmalıdır"
+          },
+          "confirmPassword": {
+            "label": "Parolu təsdiqlə",
+            "placeholder": "Parolu təsdiqlə",
+            "required": "Parolu təsdiqləyin",
+            "notMatch": "Parollar uyğun gəlmir"
+          }
+        },
+        "agree": "<1/> <2>İstifadə şərtləri</2> və <4>Məxfilik siyasəti</4> ilə razıyam",
+        "desc": "Pul kisəsini kiliddən çıxarmaq və məlumatları şifrələmək üçün istifadə olunacaq"
+      },
+      "successful": {
+        "create": "Uğurla yaradıldı",
+        "import": "Uğurla idxal edildi",
+        "start": "Başla",
+        "addMoreAddr": "Bu bərpa ifadəsindən daha çox ünvan əlavə et",
+        "addMoreFrom": "{{name}} mənbəyindən daha çox ünvan əlavə et",
+        "desc": "Rabby pul kisəsi istifadəyə hazırdır!",
+        "openWallet": "Pul kisəsini aç",
+        "backupSeedPhraseNow": "Bərpa ifadəsinin ehtiyat nüsxəsini indi yarat",
+        "backupSeedPhrase": "Bərpa ifadəsinin ehtiyat nüsxəsini yarat"
+      },
+      "readyToUse": {
+        "title": "Rabby pul kisəniz hazırdır!",
+        "desc": "Rabby pul kisəsini tapın və bərkidin",
+        "pin": "Rabby pul kisəsini bərkit",
+        "extensionTip": "<1/>, sonra <3/> üzərinə klikləyin",
+        "guides": {
+          "step1": "Brauzerin genişlənmə nişanına klikləyin",
+          "step2": "Rabby pul kisəsini bərkit"
+        }
+      },
+      "importSeedPhrase": {
+        "title": "Bərpa ifadəsini idxal et",
+        "noWallet": "Hələ bərpa ifadəniz və ya şəxsi açarınız yoxdur?",
+        "createWallet": "Pul kisəsi yarat"
+      },
+      "importOneKey": {
+        "qrcode": {
+          "desc": "OneKey aparat pul kisəsindəki QR kodunu skan edin"
+        },
+        "title": "OneKey aparat pul kisənizi USB vasitəsilə qoşun",
+        "tip1": "1. OneKey cihazınızı qoşun",
+        "tip2": "2. Cihazınızı kiliddən çıxarın",
+        "tip3": "3. Yalnız bir OneKey cihazının qoşulduğuna əmin olun",
+        "connect": "OneKey-yə qoşul"
+      },
+      "importTrezor": {
+        "title": "Trezor",
+        "tip1": "1. Trezor cihazınızı qoşun",
+        "tip2": "2. Cihazınızı kiliddən çıxarın",
+        "connect": "Trezor-a qoşul"
+      },
+      "ImportGridPlus": {
+        "title": "GridPlus",
+        "tip1": "1. GridPlus cihazınızı açın",
+        "tip2": "2. Lattice Connector vasitəsilə qoşulun",
+        "connect": "GridPlus-a qoşul"
+      },
+      "importLedger": {
+        "title": "Ledger",
+        "tip1": "Ledger cihazınızı qoşun.",
+        "tip2": "Kiliddən çıxarmaq üçün PIN kodunuzu daxil edin.",
+        "tip3": "Ethereum tətbiqini açın.",
+        "connect": "Ledger-ə qoşul"
+      },
+      "importBitBox02": {
+        "title": "BitBox02",
+        "tip1": "1. <1>BitBoxBridge<1/>-i quraşdırın",
+        "tip2": "2. BitBox02 cihazınızı qoşun",
+        "tip3": "3. Cihazınızı kiliddən çıxarın",
+        "connect": "BitBox02-yə qoşul"
+      },
+      "importKeystone": {
+        "qrcode": {
+          "desc": "{{brandName}} aparat pul kisəsindəki QR kodunu skan edin"
+        },
+        "usb": {
+          "desc": "Keystone 3 Pro cihazınızın əsas səhifədə olduğuna əmin olun",
+          "tip1": "Keystone cihazınızı qoşun",
+          "tip2": "Kiliddən çıxarmaq üçün parolunuzu daxil edin",
+          "tip3": "Kompüterinizə qoşulmağa icazə verin",
+          "connect": "Keystone-a qoşul"
+        }
+      },
+      "importSafe": {
+        "title": "Safe ünvanı əlavə et",
+        "error": {
+          "required": "Ünvan daxil edin",
+          "invalid": "Etibarlı ünvan deyil"
+        },
+        "placeholder": "Safe ünvanını daxil et",
+        "loading": "Bu ünvanın yerləşdirildiyi zəncir axtarılır"
+      },
+      "importHardwareList": {
+        "title": "Aparat pul kisəsi seç"
+      },
+      "importSeedOrKey": {
+        "title": "Bərpa ifadəsi və ya şəxsi açar",
+        "seedPhrase": "Bərpa ifadəsi",
+        "privateKey": "Şəxsi açar"
+      },
+      "importWalletType": {
+        "seedOrKey": "Bərpa ifadəsi və ya şəxsi açar",
+        "hardwareWallet": "Aparat pul kisəsi"
+      }
+    },
+    "metamaskModeDapps": {
+      "title": "İcazə verilmiş Dapp-ları idarə et",
+      "desc": "Aşağıdakı Dapp-lar üçün MetaMask rejimi aktivdir. MetaMask-ı seçərək Rabby-yə qoşula bilərsiniz."
+    },
+    "forgotPassword": {
+      "home": {
+        "title": "Unudulmuş parol",
+        "description": "Rabby pul kisəsi parolunuzu saxlamır və onu bərpa etməyə kömək edə bilmir. Yeni parol təyin etmək üçün pul kisənizi sıfırlayın.",
+        "button": "Sıfırlama prosesini başlat",
+        "descriptionNoData": "Rabby pul kisəsi parolunuzu saxlamır və onu bərpa etməyə kömək edə bilmir. Unutmusunuzsa, yeni parol təyin edin",
+        "buttonNoData": "Parol təyin et"
+      },
+      "reset": {
+        "title": "Rabby pul kisəsinin sıfırlanması",
+        "button": "Sıfırlamanı təsdiqlə",
+        "alert": {
+          "title": "Məlumatlar silinəcək və bərpa edilə bilməyəcək:",
+          "seed": "Bərpa ifadəsi",
+          "privateKey": "Şəxsi açar"
+        },
+        "tip": {
+          "title": "Saxlanılacaq məlumatlar:",
+          "hardware": "İdxal edilmiş aparat pul kisələri",
+          "whitelist": "Ağ siyahı parametrləri",
+          "records": "İmza qeydləri",
+          "safe": "İdxal edilmiş Safe pul kisələri",
+          "watch": "Kontaktlar və yalnız izləmə ünvanları"
+        },
+        "confirm": "Təsdiqləyib davam etmək üçün xanaya <1>RESET</1> yazın"
+      },
+      "tip": {
+        "title": "Rabby pul kisəsinin sıfırlanması tamamlandı",
+        "description": "Davam etmək üçün yeni parol yaradın",
+        "button": "Parol təyin et",
+        "descriptionNoData": "Başlamaq üçün ünvanınızı əlavə edin",
+        "buttonNoData": "Ünvan əlavə et"
+      },
+      "success": {
+        "title": "Parol uğurla təyin edildi",
+        "description": "Rabby pul kisəsindən istifadəyə hazırsınız",
+        "button": "Tamamla"
+      }
+    },
+    "eip7702": {
+      "alert": "EIP-7702 hələ dəstəklənmir"
+    },
+    "metamaskModeDappsGuide": {
+      "title": "Rabby-ni MetaMask kimi göstərərək qoş",
+      "alert": "Dapp Rabby pul kisəsini seçim kimi göstərmədiyi üçün qoşula bilmirsiniz?",
+      "step1": "Addım 1",
+      "step1Desc": "Cari Dapp-da Rabby-nin MetaMask kimi görünməsinə icazə verin",
+      "step2": "Addım 2",
+      "step2Desc": "Yeniləyin və MetaMask vasitəsilə qoşulun",
+      "manage": "İcazə verilmiş Dapp-ları idarə et",
+      "noDappFound": "Dapp tapılmadı",
+      "toast": {
+        "enabled": "MetaMask kimi görünmə aktivləşdirildi. Yenidən qoşulmaq üçün Dapp-ı yeniləyin.",
+        "disabled": "MetaMask kimi görünmə söndürüldü. Dapp-ı yeniləyin."
+      }
+    },
+    "syncToMobile": {
+      "title": "Ünvanın Rabby genişlənməsindən mobil tətbiqə sinxronlaşdırılması",
+      "description": "Ünvan məlumatlarınız tam oflayn və şifrələnmiş qalır, QR kodu ilə təhlükəsiz ötürülür.",
+      "steps1": "1. Rabby Mobile-ı yükləyin",
+      "steps2": "2. Rabby Mobile ilə skan edin",
+      "steps2Description": " *QR kodunuz həssas məlumatlar ehtiva edir. Onu gizli saxlayın və heç kimlə paylaşmayın.",
+      "downloadGooglePlay": "Google Play",
+      "downloadAppleStore": "App Store",
+      "clickToShowQr": "Ünvan seçmək və QR kodunu göstərmək üçün klikləyin",
+      "selectAddress": {
+        "title": "Sinxronlaşdırılacaq ünvanların seçimi"
+      },
+      "disableSelectAddress": "{{type}} ünvanı üçün sinxronlaşdırma dəstəklənmir",
+      "disableSelectAddressWithSlip39": "slip39 ilə {{type}} ünvanı üçün sinxronlaşdırma dəstəklənmir",
+      "disableSelectAddressWithPassphrase": "Əlavə parollu {{type}} ünvanı üçün sinxronlaşdırma dəstəklənmir",
+      "selectedLenAddressesForSync_one": "Sinxronlaşdırma üçün {{len}} ünvan seçildi",
+      "selectedLenAddressesForSync_other": "Sinxronlaşdırma üçün {{len}} ünvan seçildi",
+      "verifyPassword": "Parolun yoxlanması"
+    },
+    "search": {
+      "sectionHeader": {
+        "token": "Tokenlər",
+        "NFT": "NFT",
+        "AllChains": "Bütün zəncirlər"
+      },
+      "header": {
+        "placeHolder": "Axtar",
+        "searchPlaceHolder": "Token adı / ünvanı üzrə axtar"
+      },
+      "tokenItem": {
+        "gasToken": "Gas tokeni",
+        "FDV": "Tam durulaşdırılmış dəyər",
+        "listBy": "{{name}} üzrə sırala",
+        "Issuedby": "Buraxan",
+        "verifyDangerTips": "Bu, dələduzluq tokenidir",
+        "scamWarningTips": "Bu token aşağı keyfiyyətlidir və dələduzluq məqsədli ola bilər"
+      },
+      "searchWeb": {
+        "noResult": "Nəticə tapılmadı",
+        "noResults": "Nəticə yoxdur",
+        "title": "Bütün nəticələr",
+        "searching": "Nəticələr",
+        "searchTips": "İnternetdə axtar"
+      }
+    },
+    "desktopProfile": {
+      "CurveModal": {
+        "appChainTips": "Hyperliquid və Polymarket hesabları daxil deyil",
+        "netWorth": "Xalis dəyər"
+      },
+      "UpdateButton": {
+        "updating": "Məlumatlar yenilənir",
+        "updatedAgo": "Məlumatlar <1/> <2>{{timeText}}</2> <3/> əvvəl yeniləndi"
+      },
+      "ReachedEnd": {
+        "content": "Sona çatdınız"
+      },
+      "portfolio": {
+        "headers": {
+          "wallet": "Pul kisəsi",
+          "allTokenMode": "Bütün tokenlər rejimi",
+          "lpToken": "LP-token",
+          "foldProtocols": "{{count}} protokolu yığ",
+          "unfoldProtocols": "{{count}} protokolu aç",
+          "foldDifis": "{{count}} DeFi-ni yığ",
+          "unfoldDifis": "{{count}} DeFi-ni aç"
+        },
+        "hidden": {
+          "tokensWithZeroBalance": "$0 balanslı tokenləri gizlət",
+          "tokensWithZeroBalanceDesc": "$0 balanslı tokenlər gizlədilib.",
+          "showAll": "Hamısını göstər",
+          "hideSmall": "Kiçik balanslı tokenləri gizlət.",
+          "hideSmallDesc": "Kiçik balanslı tokenlər göstərilmir.",
+          "hideProtocolsWithSmallDeposits": "Kiçik yatırımlı protokolları gizlət.",
+          "hideProtocolsWithSmallDepositsDesc": "Kiçik yatırımlı protokollar göstərilmir.",
+          "hideDefiWithSmallDeposits": "Kiçik yatırımlı DeFi-ləri gizlət.",
+          "hideDefiWithSmallDepositsDesc": "Kiçik yatırımlı DeFi-lər göstərilmir.",
+          "hideDeFiWithSmallDeposits": "Kiçik yatırımlı DeFi-ləri gizlət.",
+          "hideDeFiWithSmallDepositsDesc": "Kiçik yatırımlı DeFi-lər göstərilmir."
+        },
+        "table": {
+          "token": "Token",
+          "price": "Qiymət",
+          "amount": "Məbləğ",
+          "usdValue": "USD dəyəri",
+          "chain": "Zəncir",
+          "tokenAddress": "Token ünvanı"
+        },
+        "actions": {
+          "swap": "Mübadilə et",
+          "send": "Göndər"
+        }
+      },
+      "button": {
+        "swap": "Mübadilə et",
+        "send": "Göndər",
+        "bridge": "Körpü ilə köçür",
+        "queue": "Növbə",
+        "pending": "{{pendingTxCount}} gözləyən"
+      },
+      "tabs": {
+        "tokens": "Tokenlər",
+        "transactions": "Tranzaksiyalar",
+        "approvals": "İcazələr"
+      },
+      "nft": {
+        "all": "Hamısı",
+        "hideLowValue": "Aşağı dəyərli NFT-ləri gizlət",
+        "empty": "NFT yoxdur",
+        "message": {
+          "cancelSuccess": "Satış elanı uğurla ləğv edildi",
+          "cancelSuccessDesc": "{{name}} üçün satış elanını uğurla ləğv etdiniz",
+          "cancelFailed": "Alınmadı!",
+          "cancelFailedDesc": "Yenidən cəhd edin",
+          "listingSuccess": "Satışa çıxarıldı!",
+          "listingSuccessDesc": "{{name}} OpenSea-də satışa çıxarıldı",
+          "listingFailed": "Satışa çıxarma alınmadı",
+          "listingFailedDesc": "Yenidən cəhd edin.",
+          "acceptSuccess": "Uğurla satıldı",
+          "acceptSuccessDesc": "{{name}} uğurla satıldı",
+          "acceptFailed": "Satış alınmadı",
+          "acceptFailedDesc": "Yenidən cəhd edin."
+        },
+        "pending": "Gözləyən",
+        "confirmingTx": "Tranzaksiyanız təsdiqlənir",
+        "detail": {
+          "nft": "NFT",
+          "collection": "Kolleksiya",
+          "chain": "Zəncir",
+          "collectionFloor": "Kolleksiyanın minimum qiyməti",
+          "rarity": "Nadirlik",
+          "lastSale": "Son satış",
+          "topOffer": "Ən yüksək təklif",
+          "supportPlatform": "Dəstəklənən platformalar:",
+          "ending": "Bitmə vaxtı:",
+          "platform": "Platforma:",
+          "noOffer": "Hələ təklif yoxdur",
+          "accept": "Qəbul et",
+          "listing": "OpenSea-də satış elanı",
+          "edit": "Satış elanını redaktə et",
+          "cancel": "Satış elanını ləğv et",
+          "send": "Göndər",
+          "listedFor": "{{count}} ədəd, qiyməti"
+        },
+        "cancelModal": {
+          "title": "Satış elanını ləğv et",
+          "listing": "Satış elanı",
+          "listingPrice": "Satış elanı qiyməti",
+          "cancelListing": "Satış elanını ləğv et"
+        },
+        "listingModal": {
+          "editListing": "Satış elanını redaktə et",
+          "createListing": "Satış elanının yaradılması",
+          "nft": "NFT",
+          "floor": "Minimum qiymət",
+          "topOffer": "Ən yüksək təklif",
+          "cost": "Xərc",
+          "proceeds": "Gəlir",
+          "listedAs": "Satış forması",
+          "quantity": "Miqdar",
+          "total": "Ümumi satış elanı qiyməti",
+          "floorDifference": "Minimum qiymətdən fərq",
+          "platformFee": "  OpenSea platforma haqları ({{fee}}%)",
+          "creatorFee": "Yaradıcı haqları ({{fee}}%)",
+          "platformFeeTips": "Bu haqq OpenSea-nin xidmət haqqıdır",
+          "creatorFeeTips1": "Yaradıcı gəlirləri satıcı tərəfindən ödəniləcək. Yaradıcı gəlirlərinin ödənilməsi məcburidir",
+          "creatorFeeTips": "Yaradıcı gəlirləri satıcı tərəfindən ödəniləcək.",
+          "rabbyFee": "Rabby haqqı (0%)",
+          "totalEst": "Cəmi təxmini gəlir",
+          "listOn": "OpenSea-də satışa çıxar",
+          "approveAndList": "İcazə ver və satışa çıxar"
+        },
+        "acceptModal": {
+          "title": "Təklifi qəbul et",
+          "offer": "Təklif",
+          "offerPrice": "Təklif qiyməti",
+          "quantity": "Miqdar",
+          "platform": "Platforma",
+          "floorDifference": "Minimum qiymətdən fərq",
+          "platformFee": "  OpenSea platforma haqları ({{fee}}%)",
+          "creatorFee": "Yaradıcı haqları ({{fee}}%)",
+          "platformFeeTips": "Bu haqq OpenSea-nin xidmət haqqıdır",
+          "creatorFeeTips1": "Yaradıcı gəlirləri satıcı tərəfindən ödəniləcək. Yaradıcı gəlirlərinin ödənilməsi məcburidir",
+          "creatorFeeTips": "Yaradıcı gəlirləri satıcı tərəfindən ödəniləcək.",
+          "rabbyFee": "Rabby haqqı (0%)",
+          "totalEst": "Cəmi təxmini gəlir",
+          "acceptOffer": "Təklifi qəbul et"
+        }
+      }
+    },
+    "selectToAddress": {
+      "title": "Ünvan",
+      "enterAddress": "Ünvan daxil et",
+      "enterAddressOrENS": "Ünvan daxil edin və ya axtarın",
+      "selectExchangeSource": "Birja mənbəyini seç",
+      "emptyWhitelist": {
+        "title": "Ünvanı ağ siyahıya əlavə et",
+        "desc": "Sürətli köçürmələr üçün etibarlı ünvanları ağ siyahıya əlavə edin, növbəti dəfə təsdiq tələb olunmayacaq",
+        "addNow": "İndi əlavə et"
+      },
+      "whitelist": {
+        "title": "Ağ siyahı",
+        "addWhitelistDesc": "Sürətli köçürmələr üçün etibarlı ünvanları ağ siyahıya əlavə edin, növbəti dəfə təsdiq tələb olunmayacaq",
+        "addWhitelist": "Ünvanı ağ siyahıya əlavə et",
+        "removeFromWhitelist": "Ağ siyahıdan çıxar",
+        "notWhitelist": "Ünvan ağ siyahıda deyil",
+        "PwdForNonWhitelistedTx": {
+          "enabledHint": "Ağ siyahıdan kənar köçürmələr üçün parol"
+        }
+      },
+      "sendToImportedAddress": "İdxal edilmiş ünvana göndər",
+      "selectImportedAddress": "İdxal edilmiş ünvanı seç",
+      "addWhitelist": {
+        "title": "Ünvanı ağ siyahıya əlavə et",
+        "desc": "Sürətli köçürmələr üçün etibarlı ünvanları ağ siyahıya əlavə edin, növbəti dəfə təsdiq tələb olunmayacaq"
+      },
+      "riskAlert": {
+        "title": "Bu ünvana göndər",
+        "understandRisks": "Riskləri anlayıram və davam etmək istəyirəm",
+        "cexDepositAddress": "{{cexName}} yatırma ünvanı",
+        "cexAddress": "{{cexName}} ünvanı",
+        "passwordPlaceholder": "Davam etmək üçün parolu daxil edin",
+        "TransferBefore": "Əvvəllər köçürmə edilib",
+        "TransferBeforeValue": "Bəli",
+        "AddToWhitelist": "Ağ siyahıya əlavə et",
+        "riskType": {
+          "risks": {
+            "dexNoDeposite": "Yatırma üçün nəzərdə tutulmayan birja ünvanına göndərirsiniz",
+            "contractAddress": "Kontrakta göndərirsiniz, vəsait itirilə bilər",
+            "scamAddress": "Dələduz ünvanına göndərirsiniz",
+            "noSend": "180 gündür bu ünvana göndərməmisiniz"
+          }
+        }
+      },
+      "tabs": {
+        "whitelist": "Ağ siyahıda",
+        "imported": "İdxal edilmiş"
+      },
+      "positiveTips": {
+        "whitelistAddress": "Ağ siyahıdakı ünvan",
+        "sentBefore": "Bu yaxınlarda göndərilib",
+        "yourOwnAddress": "Öz ünvanınız"
+      },
+      "typedTitle": {
+        "send": "Alıcı"
+      }
+    },
+    "dappIfame": {
+      "serviceUnavailable": "Xidmət əlçatan deyil",
+      "predictionNotSupported": "Proqnoz funksiyası cari regionunuzda dəstəklənmir.",
+      "serviceNotSupported": "Xidmət cari regionunuzda dəstəklənmir.",
+      "opening": "{{name}} açılır...",
+      "openPolymarket": "Polymarket açılır...",
+      "networkErrorTitle": "Bu sayta giriş mümkün deyil",
+      "networkErrorDescription": "{{site}} gözlənilmədən əlaqəni kəsdi. Şəbəkənizi yoxlayın.",
+      "networkErrorDescriptionFallback": "Sayt gözlənilmədən əlaqəni kəsdi. Şəbəkənizi yoxlayın.",
+      "reload": "Yenidən yüklə"
+    },
+    "manageBatchApprovals": {
+      "title": "Toplu geri al",
+      "cols": {
+        "asset": "Aktiv",
+        "revokeFrom": "İcazənin geri alınacağı tərəf",
+        "gasFee": "Gas haqqı"
+      },
+      "stopTheRevokeProcess": "Geri alma prosesi dayandırılsın?",
+      "leavingThisPageWillStopTheRevokeProcess": "Bu səhifədən çıxmaq geri alma prosesini dayandıracaq.",
+      "startRevoke": "Geri almağa başla",
+      "continueRevoke": "Davam et",
+      "pauseRevoke": "Fasilə ver",
+      "revokeCompleted": "Tamamla",
+      "canStillRevoke": "Yenə də geri al"
+    },
+    "manageApprovals": {
+      "title": "İcazələr",
+      "tabs": {
+        "contracts": "Kontraktlar üzrə",
+        "assets": "Aktivlər üzrə"
+      },
+      "revoke": "Geri al",
+      "approvals": "icazələr",
+      "ApprovalCardContractPopup": {
+        "allApprovals": "Bütün icazələr",
+        "contractAddress": "Kontrakt ünvanı"
+      },
+      "ApprovalContractPopup": {
+        "approvedAssetsAmountAndBalance": "İcazə verilmiş aktivlərin məbləği və balansı"
+      },
+      "unselectAll": "Bütün seçimləri ləğv et",
+      "selectAll": "Hamısını seç",
+      "ApprovalCardAssetPopup": {
+        "allApprovals": "Bütün icazələr",
+        "myBalance": "Balansım"
+      },
+      "ApprovalAssetPopup": {
+        "approvedContractsAndAmount": "İcazə verilmiş kontraktlar və məbləğ"
+      },
+      "EIP7702Panel": {
+        "unsupportedAddressType": "Dəstəklənməyən ünvan növü",
+        "unsupportedAddressTypeDesc": "EIP-7702 səlahiyyət ötürmələrinin geri alınması yalnız şəxsi açar və ya bərpa ifadəsi ünvanları üçün dəstəklənir",
+        "supportedChains": "Dəstəklənən zəncirlər",
+        "delegatedAddressDesc": "Səlahiyyət verilmiş ünvan",
+        "notMatched": "Uyğunluq yoxdur",
+        "noApprovals": "İcazə yoxdur"
+      },
+      "ListByAssets": {
+        "noApprovals": "İcazə yoxdur",
+        "notMatched": "Uyğunluq yoxdur"
+      },
+      "ListByContracts": {
+        "noApprovals": "İcazə yoxdur",
+        "notMatched": "Uyğunluq yoxdur"
+      },
+      "approvalsCount": "{{count}} icazə",
+      "approvalsCount_one": "{{count}} icazə"
+    }
+  },
+  "component": {
+    "externalSwapBrideDappPopup": {
+      "noQuotesForChain": "Bu zəncir üçün hələ qiymət təklifi yoxdur",
+      "thirdPartyDappToProceed": "Davam etmək üçün üçüncü tərəf Dapp-dan istifadə edin",
+      "viewDappOptions": "Dapp seçimlərinə bax",
+      "selectADapp": "Dapp seçimi",
+      "noDapp": "Mövcud Dapp yoxdur",
+      "help": "Dəstək üçün bu zəncirin rəsmi komandası ilə əlaqə saxlayın",
+      "chainNotSupported": "Bu zəncirdə dəstəklənmir",
+      "noDapps": "Bu zəncirdə mövcud Dapp yoxdur",
+      "swapOnDapp": "Dapp-da mübadilə et",
+      "bridgeOnDapp": "Dapp-da körpü ilə köçür"
+    },
+    "TokenChart": {
+      "price": "Qiymət",
+      "holding": "Saxlanılan aktivlərin dəyəri"
+    },
+    "AccountSearchInput": {
+      "noMatchAddress": "Uyğun ünvan yoxdur",
+      "AddressItem": {
+        "whitelistedAddressTip": "Ağ siyahıdakı ünvan"
+      }
+    },
+    "AccountSelectDrawer": {
+      "btn": {
+        "cancel": "Ləğv et",
+        "proceed": "Davam et"
+      }
+    },
+    "AddressList": {
+      "AddressItem": {
+        "addressTypeTip": "{{type}} ilə idxal edilib"
+      }
+    },
+    "AuthenticationModal": {
+      "passwordError": "yanlış parol",
+      "passwordRequired": "Parolu daxil edin",
+      "passwordPlaceholder": "Təsdiqləmək üçün parolu daxil edin"
+    },
+    "ConnectStatus": {
+      "connecting": "Qoşulur...",
+      "connect": "Qoşul",
+      "gridPlusConnected": "GridPlus qoşulub",
+      "gridPlusNotConnected": "GridPlus qoşulmayıb",
+      "ledgerNotConnected": "Ledger qoşulmayıb",
+      "ledgerConnected": "Ledger qoşulub",
+      "keystoneConnected": "Keystone qoşulub",
+      "keystoneNotConnected": "Keystone qoşulmayıb",
+      "imKeyrNotConnected": "imKey qoşulmayıb",
+      "imKeyConnected": "imKey qoşulub"
+    },
+    "Contact": {
+      "AddressItem": {
+        "notWhitelisted": "Bu ünvan ağ siyahıda deyil",
+        "whitelistedTip": "Ağ siyahıdakı ünvan"
+      },
+      "EditModal": {
+        "title": "Ünvan qeydini redaktə et"
+      },
+      "EditWhitelist": {
+        "backModalTitle": "Dəyişikliklərdən imtina",
+        "backModalContent": "Etdiyiniz dəyişikliklər yadda saxlanılmayacaq",
+        "title": "Ağ siyahını redaktə et",
+        "tip": "Ağ siyahıya əlavə etmək istədiyiniz ünvanı seçin və yadda saxlayın.",
+        "save": "Ağ siyahıda yadda saxla ({{count}})"
+      },
+      "ListModal": {
+        "title": "Ünvan seç",
+        "whitelistEnabled": "Ağ siyahı aktivdir. Aktivləri yalnız ağ siyahıdakı ünvana göndərə bilərsiniz və ya onu \"Parametrlər\"də söndürə bilərsiniz",
+        "whitelistDisabled": "Ağ siyahı söndürülüb. Aktivləri istənilən ünvana göndərə bilərsiniz",
+        "editWhitelist": "Ağ siyahını redaktə et",
+        "whitelistUpdated": "Ağ siyahı yeniləndi",
+        "authModal": {
+          "title": "Ağ siyahıda yadda saxlama"
+        }
+      }
+    },
+    "LoadingOverlay": {
+      "loadingData": "Məlumatlar yüklənir..."
+    },
+    "MultiSelectAddressList": {
+      "imported": "İdxal edilmiş"
+    },
+    "NFTNumberInput": {
+      "erc1155Tips": "Balansınız: {{amount}}",
+      "erc721Tips": "Bir dəfəyə yalnız bir ERC 721 NFT-si göndərilə bilər"
+    },
+    "TiledSelect": {
+      "errMsg": "Bərpa ifadəsində söz sırası yanlışdır, yoxlayın"
+    },
+    "Uploader": {
+      "placeholder": "JSON faylı seçin"
+    },
+    "WalletConnectBridgeModal": {
+      "title": "Körpü serverinin URL-i",
+      "requiredMsg": "Körpü serverinin ünvanını daxil edin",
+      "invalidMsg": "Server ünvanını yoxlayın",
+      "restore": "İlkin parametri bərpa et"
+    },
+    "PillsSwitch": {
+      "NetSwitchTabs": {
+        "mainnet": "İnteqrasiya edilmiş şəbəkə",
+        "testnet": "Fərdi şəbəkə"
+      }
+    },
+    "ChainSelectorModal": {
+      "searchPlaceholder": "Zəncir axtar",
+      "noChains": "Zəncir yoxdur",
+      "addTestnet": "Xüsusi şəbəkə əlavə et"
+    },
+    "TokenSelector": {
+      "listTableHead": {
+        "assetAmount": {
+          "title": "Aktiv / məbləğ"
+        },
+        "price": {
+          "title": "Qiymət"
+        },
+        "usdValue": {
+          "title": "USD dəyəri"
+        }
+      },
+      "bridge": {
+        "token": "Token",
+        "value": "Dəyər",
+        "liquidity": "Likvidlik",
+        "liquidityTips": "Keçmiş ticarət həcmi nə qədər yüksəkdirsə, körpü ilə köçürmənin uğur ehtimalı da bir o qədər çoxdur.",
+        "low": "Aşağı likvidlik",
+        "high": "Yüksək likvidlik"
+      },
+      "searchInput": {
+        "placeholder": "Ad / ünvan üzrə axtar",
+        "placeholder1": "Token adı / ünvanı üzrə axtar"
+      },
+      "header": {
+        "title": "Token seç"
+      },
+      "noTokens": "Token yoxdur",
+      "noLpTokens": "Likvidlik təminatçısı (LP) tokeni yoxdur",
+      "noMatch": "Uyğunluq yoxdur",
+      "noMatchSuggestion": "{{ chainName }} zəncirində kontrakt ünvanını axtarmağa çalışın",
+      "hot": "Populyar",
+      "common": "Ümumi",
+      "recent": "Son",
+      "chainNotSupport": "Bu zəncir dəstəklənmir",
+      "chainFilterLine": {
+        "filterAll": "Bütün zəncirlər"
+      }
+    },
+    "ModalPreviewNFTItem": {
+      "FieldLabel": {
+        "Collection": "Kolleksiya",
+        "Chain": "Zəncir",
+        "PurschaseDate": "Alış tarixi",
+        "LastPrice": "Son qiymət"
+      }
+    },
+    "signPermissionCheckModal": {
+      "title": "Bu Dapp-a yalnız Testnet şəbəkələrində imzalamağa icazə verirsiniz",
+      "reconnect": "Dapp-a yenidən qoşul"
+    },
+    "testnetCheckModal": {
+      "title": "Testnet şəbəkələrində imzalamazdan əvvəl \"Daha çox\" bölməsində \"Testnet şəbəkələrini aktivləşdir\" seçimini açın"
+    },
+    "EcologyNavBar": {
+      "providedBy": "{{chainName}} tərəfindən təqdim olunur"
+    },
+    "EcologyNoticeModal": {
+      "title": "Bildiriş",
+      "desc": "Aşağıdakı xidmətlər birbaşa üçüncü tərəf ekosistem tərəfdaşı tərəfindən təqdim ediləcək. Rabby pul kisəsi bu xidmətlərin təhlükəsizliyinə görə məsuliyyət daşımır.",
+      "notRemind": "Bir daha xatırlatma"
+    },
+    "ReserveGasPopup": {
+      "title": "Gas ayır",
+      "instant": "Sürətli",
+      "fast": "Normal",
+      "normal": "Yavaş",
+      "doNotReserve": "Gas ayırma"
+    },
+    "OpenExternalWebsiteModal": {
+      "title": "Rabby pul kisəsini tərk edirsiniz",
+      "content": "Xarici veb-sayta keçmək üzrəsiniz. Rabby pul kisəsi bu saytın məzmununa və ya təhlükəsizliyinə görə məsuliyyət daşımır.",
+      "button": "Davam et"
+    },
+    "AccountSelectorModal": {
+      "title": "Ünvan seç",
+      "searchPlaceholder": "Ünvan axtar"
+    },
+    "PageHeader": {
+      "selectAccount": "Ünvan seç"
+    },
+    "ChainItem": {
+      "appChain": "{{chain}} hesabında",
+      "hyperliquidCode": "Rabby-nin dəvət kodu ilə Hyperliquid haqlarına qənaət edin."
+    },
+    "RiskTip": {
+      "title": "Risk aşkarlandı"
+    },
+    "DappActions": {
+      "queueDescription": "Cari çıxarış gözləmə növbəsinə daxil olacaq. İşləndikdən sonra vəsaiti pul kisənizə çıxara bilərsiniz.",
+      "manage": "İdarə et"
+    },
+    "DesktopChainSelector": {
+      "allChains": "Bütün zəncirlər"
+    },
+    "DesktopNav": {
+      "portfolio": "Portfel",
+      "perps": "Perps",
+      "comingSoon": "Tezliklə"
+    },
+    "DesktopSelectAccountList": {
+      "addAddresses": "Ünvan əlavə et",
+      "smallSwapDisabledTips": "Bu ünvan növü dəstəklənmir"
+    },
+    "LpTokenTag": {
+      "title": "Bu, likvidlik təminatçısı (LP) tokenidir",
+      "descriptionFor": "Bu, {{ protocolName }} üçün likvidlik təminatçısı (LP) tokenidir",
+      "description": "LP tokenləri aktivlərinizi yatırdığınız DeFi protokolları tərəfindən buraxılır. Onlar həmin aktivlərin sübutudur, lakin dəyərləri ümumi balansınıza daxil edilmir"
+    },
+    "SeedPhraseBackupAlert": {
+      "message": "Pul kisəsinin ehtiyat nüsxəsi yoxdur. Ehtiyat nüsxələməyə başlayın."
+    },
+    "DesktopAccountSelector": {
+      "selectAddress": "Ünvan seç"
+    },
+    "UnknownTag": {
+      "label": "Naməlum",
+      "tooltip": "Naməlum token, özünüz araşdırın."
+    },
+    "screenshotModal": {
+      "title": "Rəy üçün ekran görüntüsü",
+      "placeholder": "Problemi təsvir edin",
+      "placeholderRequired": "Problemi təsvir edin (məcburi)"
+    },
+    "feedbackPopup": {
+      "title": "Rabby dəstəyindən cavab",
+      "issueReported": "Bildirdiyiniz problem:",
+      "issueReplied": "Rabby dəstəyi cavab verdi:"
+    }
+  },
+  "global": {
+    "appName": "Rabby pul kisəsi",
+    "appDescription": "Ethereum və EVM üçün seçdiyiniz pul kisəsi",
+    "copied": "Kopyalandı",
+    "confirm": "Təsdiqlə",
+    "next": "Davam et",
+    "back": "Geri qayıt",
+    "ok": "Oldu",
+    "refresh": "Yenilə",
+    "failed": "Alınmadı",
+    "scamTx": "Dələduzluq tranzaksiyası",
+    "gas": "Gas",
+    "unknownNFT": "Naməlum NFT",
+    "copyAddress": "Ünvanı kopyala",
+    "watchModeAddress": "İzləmə ünvanı",
+    "assets": "aktivlər",
+    "Confirm": "Təsdiqlə",
+    "Cancel": "Ləğv et",
+    "Clear": "Təmizlə",
+    "Save": "Yadda saxla",
+    "confirmButton": "Təsdiqlə",
+    "cancelButton": "Ləğv et",
+    "backButton": "Geri qayıt",
+    "proceedButton": "Davam et",
+    "editButton": "Redaktə et",
+    "addButton": "Əlavə et",
+    "closeButton": "Bağla",
+    "Deleted": "Silindi",
+    "Loading": "Yüklənir",
+    "nonce": "Nonce",
+    "Balance": "Balans",
+    "Done": "Tamamla",
+    "Nonce": "Nonce",
+    "tryAgain": "Yenidən cəhd et",
+    "notSupportTesntnet": "Xüsusi şəbəkə üçün dəstəklənmir",
+    "collapse": "Yığ",
+    "Yes": "Bəli",
+    "Submit": "Göndər"
+  },
+  "background": {
+    "error": {
+      "noCurrentAccount": "Cari hesab yoxdur",
+      "invalidChainId": "Yanlış zəncir ID-si",
+      "notFindChain": "{{chain}} zənciri tapılmadı",
+      "unknownAbi": "kontraktın binar interfeysi naməlumdur",
+      "invalidAddress": "Etibarlı ünvan deyil",
+      "notFoundGnosisKeyring": "Gnosis açar dəsti tapılmadı",
+      "notFoundTxGnosisKeyring": "Gnosis açar dəstində tranzaksiya tapılmadı",
+      "addKeyring404": "açar dəsti əlavə edilə bilmədi, açar dəsti təyin edilməyib",
+      "emptyAccount": "cari hesab boşdur",
+      "generateCacheAliasNames": "[Keş ləqəblərinin yaradılması]: ən azı bir ünvan lazımdır",
+      "invalidPrivateKey": "Şəxsi açar etibarsızdır",
+      "invalidJson": "giriş faylı etibarsızdır",
+      "invalidMnemonic": "Bərpa ifadəsi etibarsızdır, yoxlayın!",
+      "notFoundKeyringByAddress": "Ünvana görə açar dəsti tapılmadı",
+      "txPushFailed": "Tranzaksiyanı göndərmək alınmadı",
+      "unlock": "əvvəlcə pul kisəsini kiliddən çıxarmalısınız",
+      "duplicateAccount": "İdxal etmək istədiyiniz hesab artıq mövcuddur",
+      "canNotUnlock": "Əvvəlki anbar olmadan kiliddən çıxarmaq mümkün deyil"
+    },
+    "transactionWatcher": {
+      "submitted": "Tranzaksiya göndərildi",
+      "more": "ətraflı məlumat üçün klikləyin",
+      "txCompleteMoreContent": "{{chain}} #{{nonce}} tamamlandı. Ətraflı baxmaq üçün klikləyin.",
+      "txFailedMoreContent": "{{chain}} #{{nonce}} alınmadı. Ətraflı baxmaq üçün klikləyin.",
+      "completed": "Tranzaksiya tamamlandı",
+      "failed": "Tranzaksiya alınmadı"
+    },
+    "feedback": {
+      "screenshotContextMenuTitle": "Rəy üçün ekran görüntüsü"
+    },
+    "alias": {
+      "HdKeyring": "Bərpa ifadəsi",
+      "simpleKeyring": "Şəxsi açar",
+      "watchAddressKeyring": "Yalnız izləmə"
+    },
+    "keyring": {
+      "onekey": {
+        "notFoundDevice": "Cihaz tapılmadı",
+        "deviceInitializeFailed": "Cihaz xətası, yenidən başladın və yenidən cəhd edin",
+        "needUpgradeFirmware": "Cihazdan istifadə etmək üçün daxili proqram təminatı yenilənməlidir",
+        "thisMethodNeedUpgradeFirmware": "Bu funksiya daxili proqram təminatının yenilənməsini tələb edir, OneKey tətbiqində yeniləyin",
+        "notAllowInBootloaderMode": "Normal rejimdə istifadə edin",
+        "deviceCheckPassphraseStateError": "Hesab cihazın hazırda açıq olan ünvanına uyğun gəlmir. Cihazdakı ünvanla hesab ünvanının eyni olduğunu yoxlayın və yenidən cəhd edin",
+        "actionCancel": "Əməliyyat ləğv edildi",
+        "deviceNeedsWebHIDPermission": "Cihaz tapılmadı və ya WebHID icazəsi tələb olunur"
+      }
+    }
+  },
+  "constant": {
+    "KEYRING_TYPE_TEXT": {
+      "HdKeyring": "Bərpa ifadəsi ilə yaradılıb",
+      "SimpleKeyring": "Şəxsi açarla idxal edilib",
+      "WatchAddressKeyring": "Yalnız izləmə"
+    },
+    "IMPORTED_HD_KEYRING": "Bərpa ifadəsi ilə idxal edilib",
+    "SIGN_PERMISSION_OPTIONS": {
+      "MAINNET_AND_TESTNET": "Mainnet & Testnet",
+      "TESTNET": "Yalnız Testnet şəbəkələri"
+    },
+    "IMPORTED_HD_KEYRING_NEED_PASSPHRASE": "Bərpa ifadəsi ilə idxal edilib (əlavə parol)"
+  }
+}

--- a/_raw/locales/az/messages.json
+++ b/_raw/locales/az/messages.json
@@ -1413,7 +1413,6 @@
           "tpSl": "TP/SL",
           "positions": "Mövqelər",
           "openOrders": "Açıq sifarişlər",
-          "twap": "TWAP",
           "tradeHistory": "Ticarət tarixçəsi",
           "fundingHistory": "Maliyyələşdirmə tarixçəsi",
           "orderHistory": "Sifariş tarixçəsi",

--- a/_raw/locales/index.json
+++ b/_raw/locales/index.json
@@ -13,5 +13,6 @@
   { "code": "pt", "name": "Português" },
   { "code": "vi", "name": "Tiếng Việt" },
   { "code": "id", "name": "Bahasa Indonesia" },
-  { "code": "ko", "name": "한국어" }
+  { "code": "ko", "name": "한국어" },
+  { "code": "az", "name": "Azərbaycan dili" }
 ]


### PR DESCRIPTION
This PR adds an Azerbaijani (az) translation.

New file _raw/locales/az/messages.json: 3686 strings, all filled in.
_raw/locales/index.json: added az with the name Azərbaycan dili.

The key set and key order follow _raw/locales/en/messages.json. The keys covered by the `__skip_translation` markers are left out, so the file has the same 3686 keys as _raw/locales/id/messages.json. Placeholders, react-i18next tags and HTML tags are unchanged and their count matches English in every string. Industry labels such as NFT, DeFi, APY, APR, TVL, TP, SL, TWAP, PnL, Gas, Nonce, Perps, Long and Short are kept in English, as the other locales keep them.
